### PR TITLE
feat: RedisStackContainer废弃、使用RedisContainer代替

### DIFF
--- a/spring-boot-example/spring-redis/redis-caffeine/src/test/java/com/livk/caffeine/controller/CacheControllerTest.java
+++ b/spring-boot-example/spring-redis/redis-caffeine/src/test/java/com/livk/caffeine/controller/CacheControllerTest.java
@@ -55,7 +55,7 @@ class CacheControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = RedisContainer.redis();
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/test/java/com/livk/redisson/lock/ShopControllerTest.java
+++ b/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/test/java/com/livk/redisson/lock/ShopControllerTest.java
@@ -52,7 +52,7 @@ class ShopControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = RedisContainer.redis().withPassword("123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/src/test/java/com/livk/redisson/limit/controller/RateLimiterControllerTest.java
+++ b/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/src/test/java/com/livk/redisson/limit/controller/RateLimiterControllerTest.java
@@ -43,7 +43,7 @@ class RateLimiterControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = RedisContainer.redis().withPassword("123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/redis-spring-boot-test/redisearch-spring-boot-test/redisearch-spring-boot-test-webflux/src/test/java/com/livk/redisearch/webflux/controller/StudentControllerTest.java
+++ b/spring-boot-extension-tests/redis-spring-boot-test/redisearch-spring-boot-test/redisearch-spring-boot-test-webflux/src/test/java/com/livk/redisearch/webflux/controller/StudentControllerTest.java
@@ -17,7 +17,7 @@
 package com.livk.redisearch.webflux.controller;
 
 import com.livk.redisearch.webflux.entity.Student;
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.containers.RedisContainer;
 import org.hamcrest.core.IsIterableContaining;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,12 +41,12 @@ class StudentControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redis = new RedisStackContainer();
+	static RedisContainer redisStack = RedisContainer.redisStack();
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redisearch.host", redis::getHost);
-		registry.add("spring.redisearch.port", () -> redis.getMappedPort(6379));
+		registry.add("spring.redisearch.host", redisStack::getHost);
+		registry.add("spring.redisearch.port", () -> redisStack.getMappedPort(6379));
 	}
 
 	@Autowired

--- a/spring-boot-extension-tests/redis-spring-boot-test/redisearch-spring-boot-test/redisearch-spring-boot-test-webmvc/src/test/java/com/livk/redisearch/mvc/controller/StudentControllerTest.java
+++ b/spring-boot-extension-tests/redis-spring-boot-test/redisearch-spring-boot-test/redisearch-spring-boot-test-webmvc/src/test/java/com/livk/redisearch/mvc/controller/StudentControllerTest.java
@@ -16,7 +16,7 @@
 
 package com.livk.redisearch.mvc.controller;
 
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.containers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,12 +47,12 @@ class StudentControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redis = new RedisStackContainer();
+	static RedisContainer redisStack = RedisContainer.redisStack();
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redisearch.host", redis::getHost);
-		registry.add("spring.redisearch.port", () -> redis.getMappedPort(6379));
+		registry.add("spring.redisearch.host", redisStack::getHost);
+		registry.add("spring.redisearch.port", () -> redisStack.getMappedPort(6379));
 	}
 
 	@Autowired

--- a/spring-boot-extension-tests/redis-spring-boot-test/redisson-spring-boot-test/src/test/java/com/livk/redisson/schedule/ScheduleControllerTest.java
+++ b/spring-boot-extension-tests/redis-spring-boot-test/redisson-spring-boot-test/src/test/java/com/livk/redisson/schedule/ScheduleControllerTest.java
@@ -44,7 +44,7 @@ class ScheduleControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = RedisContainer.redis().withPassword("123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-extension-context/src/test/java/com/livk/context/lock/support/RedissonLockTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/lock/support/RedissonLockTest.java
@@ -15,7 +15,7 @@ package com.livk.context.lock.support;
 
 import com.livk.context.lock.DistributedLock;
 import com.livk.context.lock.LockType;
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.containers.RedisContainer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
@@ -43,11 +43,12 @@ class RedissonLockTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redis = new RedisStackContainer();
+	static RedisContainer redisStack = RedisContainer.redisStack();
 
 	@DynamicPropertySource
 	static void properties(DynamicPropertyRegistry registry) {
-		registry.add("redisson.address", () -> "redis://" + redis.getHost() + ":" + redis.getMappedPort(6379));
+		registry.add("redisson.address",
+				() -> "redis://" + redisStack.getHost() + ":" + redisStack.getMappedPort(6379));
 	}
 
 	static ExecutorService service = Executors.newVirtualThreadPerTaskExecutor();

--- a/spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTest.java
@@ -45,7 +45,7 @@ class ReactiveRedisOpsTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = RedisContainer.redis().withPassword("123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTest.java
@@ -43,7 +43,7 @@ class RedisOpsTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = RedisContainer.redis().withPassword("123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTest.java
@@ -15,7 +15,7 @@ package com.livk.context.redisearch;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.livk.context.redisearch.codec.RedisCodecs;
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.containers.RedisContainer;
 import io.lettuce.core.codec.RedisCodec;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,12 +37,12 @@ class RediSearchTemplateTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redis = new RedisStackContainer();
+	static RedisContainer redisStack = RedisContainer.redisStack();
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("redisearch.host", redis::getHost);
-		registry.add("redisearch.port", () -> redis.getMappedPort(6379));
+		registry.add("redisearch.host", redisStack::getHost);
+		registry.add("redisearch.port", () -> redisStack.getMappedPort(6379));
 	}
 
 	@Autowired

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTest.java
@@ -13,7 +13,7 @@
 
 package com.livk.context.redisearch;
 
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.containers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -34,12 +34,12 @@ class StringRediSearchTemplateTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redis = new RedisStackContainer();
+	static RedisContainer redisStack = RedisContainer.redisStack();
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("redisearch.host", redis::getHost);
-		registry.add("redisearch.port", () -> redis.getMappedPort(6379));
+		registry.add("redisearch.host", redisStack::getHost);
+		registry.add("redisearch.port", () -> redisStack.getMappedPort(6379));
 	}
 
 	@Autowired

--- a/spring-extension-testcontainers/src/main/java/com/livk/testcontainers/containers/RedisContainer.java
+++ b/spring-extension-testcontainers/src/main/java/com/livk/testcontainers/containers/RedisContainer.java
@@ -16,6 +16,7 @@ package com.livk.testcontainers.containers;
 import com.livk.testcontainers.DockerImageNames;
 import lombok.Getter;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.Optional;
 
@@ -27,9 +28,17 @@ public class RedisContainer extends GenericContainer<RedisContainer> {
 
 	private String password;
 
-	public RedisContainer() {
-		super(DockerImageNames.redis());
+	public RedisContainer(DockerImageName dockerImageName) {
+		super(dockerImageName);
 		addExposedPorts(6379);
+	}
+
+	public static RedisContainer redis() {
+		return new RedisContainer(DockerImageNames.redis());
+	}
+
+	public static RedisContainer redisStack() {
+		return new RedisContainer(DockerImageNames.redisStack());
 	}
 
 	@Override

--- a/spring-extension-testcontainers/src/main/java/com/livk/testcontainers/containers/RedisStackContainer.java
+++ b/spring-extension-testcontainers/src/main/java/com/livk/testcontainers/containers/RedisStackContainer.java
@@ -18,7 +18,9 @@ import org.testcontainers.containers.GenericContainer;
 
 /**
  * @author livk
+ * @see RedisContainer
  */
+@Deprecated(since = "1.3.3", forRemoval = true)
 public class RedisStackContainer extends GenericContainer<RedisStackContainer> {
 
 	public static final int PORT = 6379;

--- a/spring-extension-testcontainers/src/main/java/com/livk/testcontainers/spring/RedisStackContainerConnectionDetailsFactory.java
+++ b/spring-extension-testcontainers/src/main/java/com/livk/testcontainers/spring/RedisStackContainerConnectionDetailsFactory.java
@@ -15,33 +15,34 @@ package com.livk.testcontainers.spring;
 
 import com.livk.auto.service.annotation.SpringFactories;
 import com.livk.testcontainers.DockerImageNames;
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.containers.RedisContainer;
 import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory;
 import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
 import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
 
 /**
+ * <a href="https://github.com/spring-projects/spring-boot/pull/41327">redis-stack支持</a>
+ *
  * @author livk
  */
 @SpringFactories(ConnectionDetailsFactory.class)
 class RedisStackContainerConnectionDetailsFactory
-		extends ContainerConnectionDetailsFactory<RedisStackContainer, RedisConnectionDetails> {
+		extends ContainerConnectionDetailsFactory<RedisContainer, RedisConnectionDetails> {
 
 	RedisStackContainerConnectionDetailsFactory() {
 		super(DockerImageNames.REDIS_STACK_IMAGE);
 	}
 
 	@Override
-	protected RedisConnectionDetails getContainerConnectionDetails(
-			ContainerConnectionSource<RedisStackContainer> source) {
+	protected RedisConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<RedisContainer> source) {
 		return new RedisStackContainerConnectionDetails(source);
 	}
 
-	private static final class RedisStackContainerConnectionDetails
-			extends ContainerConnectionDetails<RedisStackContainer> implements RedisConnectionDetails {
+	private static final class RedisStackContainerConnectionDetails extends ContainerConnectionDetails<RedisContainer>
+			implements RedisConnectionDetails {
 
-		private RedisStackContainerConnectionDetails(ContainerConnectionSource<RedisStackContainer> source) {
+		private RedisStackContainerConnectionDetails(ContainerConnectionSource<RedisContainer> source) {
 			super(source);
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了新的 `RedisContainer` 类，增强了对 Docker 镜像的灵活性，提供了静态工厂方法以简化实例化过程。
- **重大更改**
	- 更新了测试类中的 Redis 容器实例化方式，采用统一的 `RedisContainer` 方法，提升了可读性和可维护性。
- **弃用**
	- `RedisStackContainer` 类已标记为弃用，建议开发者转向使用 `RedisContainer`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->