### PR TITLE
Feat kotlin2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,21 @@ jobs:
       - checkout
       - run: ./gradlew build
 
+  jdk23-ci:
+    docker:
+      - image: cimg/openjdk:23.0.1
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+      - run: ./gradlew build
+
 workflows:
   gradle-build:
     jobs:
       - jdk21-ci
       - jdk22-ci
+      - jdk23-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java: [ 21, 22 ]
+        java: [ 21, 22 ,23 ]
 
     name: JDK ${{ matrix.java }} CI with Gradle
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 spring-boot = "3.4.0"
-kotlin = "2.1.0-RC2"
+kotlin = "2.1.0"
 pagehelper-starter = "2.1.0"
 mybatis = "3.5.16"
 mybatis-spring = "3.0.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 spring-boot = "3.4.0"
-kotlin = "2.0.21"
+kotlin = "2.1.0-RC2"
 pagehelper-starter = "2.1.0"
 mybatis = "3.5.16"
 mybatis-spring = "3.0.4"


### PR DESCRIPTION
## Summary by Sourcery

在CI工作流程中添加对JDK 23的支持，并将Kotlin升级到版本2.1.0-RC2。

新功能：
- 在CI工作流程中添加对JDK 23的支持。

增强：
- 将项目依赖中的Kotlin版本升级到2.1.0-RC2。

CI：
- 更新CircleCI配置以包含JDK 23的新作业。
- 修改GitHub Actions工作流程以针对JDK 23进行测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for JDK 23 in CI workflows and upgrade Kotlin to version 2.1.0-RC2.

New Features:
- Add support for JDK 23 in CI workflows.

Enhancements:
- Upgrade Kotlin version to 2.1.0-RC2 in the project dependencies.

CI:
- Update CircleCI configuration to include a new job for JDK 23.
- Modify GitHub Actions workflow to test against JDK 23.

</details>