### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,36 @@
 version: 2.1
 
 executors:
-  jdk21:
-    docker:
-      - image: cimg/openjdk:21.0.5
+  ubuntu:
     environment:
       JVM_OPTS: -Xmx3200m
       TERM: dumb
-  jdk22:
-    docker:
-      - image: cimg/openjdk:22.0.2
-    environment:
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
-  jdk23:
+    machine:
+      image: ubuntu-2204:2024.11.1
+      docker_layer_caching: true
+    resource_class: arm.large
+
+jobs:
+  jdk21-ci:
+    executor: ubuntu
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt install openjdk-21-jdk
+      - checkout
+      - run: ./gradlew build
+  jdk22-ci:
+    executor: ubuntu
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt install openjdk-22-jdk
+      - checkout
+      - run: ./gradlew build
+  jdk23-ci:
     docker:
       - image: cimg/openjdk:23.0.1
     environment:
       JVM_OPTS: -Xmx3200m
       TERM: dumb
-
-jobs:
-  jdk21-ci:
-    executor: jdk21
-    steps:
-      - checkout
-      - run: ./gradlew build
-  jdk22-ci:
-    executor: jdk22
-    steps:
-      - checkout
-      - run: ./gradlew build
-  jdk23-ci:
-    executor: jdk23
     steps:
       - checkout
       - run: ./gradlew build


### PR DESCRIPTION
## Summary by Sourcery

更新 CircleCI 配置，通过为 JDK 21 和 22 任务使用单个基于 Ubuntu 的执行器来简化执行器，同时为 JDK 23 保留基于 Docker 的执行器。

CI:
- 更新 CircleCI 配置，为 JDK 21 和 22 任务使用单个 Ubuntu 执行器，在任务执行期间安装必要的 JDK 版本。
- 保留 JDK 23 任务的基于 Docker 的执行器，维护该版本的现有设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the CircleCI configuration to streamline the executors by using a single Ubuntu-based executor for JDK 21 and 22 jobs, while keeping the Docker-based executor for JDK 23.

CI:
- Update CircleCI configuration to use a single Ubuntu executor for JDK 21 and 22 jobs, installing the necessary JDK versions during the job execution.
- Retain the Docker-based executor for the JDK 23 job, maintaining the existing setup for this version.

</details>