### PR TITLE
feat: 升级circleci machine为ubuntu-2404:2024.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       JVM_OPTS: -Xmx3200m
       TERM: dumb
     machine:
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2404:2024.11.1
       docker_layer_caching: true
     resource_class: arm.large
 
@@ -26,12 +26,10 @@ jobs:
       - checkout
       - run: ./gradlew build
   jdk23-ci:
-    docker:
-      - image: cimg/openjdk:23.0.1
-    environment:
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
+    executor: ubuntu
     steps:
+      - run: sudo apt-get update
+      - run: sudo apt install openjdk-23-jdk
       - checkout
       - run: ./gradlew build
 


### PR DESCRIPTION
## Summary by Sourcery

升级 CircleCI 配置以使用更新的 Ubuntu 机器镜像，并修改 jdk23-ci 任务以使用机器执行器而不是 Docker 镜像。

CI:
- 将 CircleCI 机器执行器镜像从 ubuntu-2204:2024.11.1 升级到 ubuntu-2404:2024.11.1。
- 将 jdk23-ci 任务从使用 Docker 镜像切换为使用带有手动 JDK 安装的 Ubuntu 机器执行器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the CircleCI configuration to use a newer Ubuntu machine image and modify the jdk23-ci job to use the machine executor instead of a Docker image.

CI:
- Upgrade CircleCI machine executor image from ubuntu-2204:2024.11.1 to ubuntu-2404:2024.11.1.
- Switch jdk23-ci job from using a Docker image to using the ubuntu machine executor with manual JDK installation.

</details>