### PR TITLE
refactor: 设置部分分支运行 circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,21 @@ jobs:
 workflows:
   gradle-build:
     jobs:
-      - jdk21-ci
-      - jdk22-ci
-      - jdk23-ci
+      - jdk21-ci:
+          filters:
+            branches:
+              only:
+                - main
+                - dev-snapshot
+      - jdk22-ci:
+          filters:
+            branches:
+              only:
+                - main
+                - dev-snapshot
+      - jdk23-ci:
+          filters:
+            branches:
+              only:
+                - main
+                - dev-snapshot


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 限制 CI 工作流仅在 'main' 和 'dev-snapshot' 分支上运行，用于 jdk21-ci、jdk22-ci 和 jdk23-ci 任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Restrict CI workflows to run only on 'main' and 'dev-snapshot' branches for jdk21-ci, jdk22-ci, and jdk23-ci jobs.

</details>