### PR TITLE
ci: 移除jdk22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,6 @@ jobs:
       - run: sudo apt install openjdk-21-jdk
       - checkout
       - run: ./gradlew build
-  jdk22:
-    executor: ubuntu
-    steps:
-      - run: sudo apt-get update
-      - run: sudo apt install openjdk-22-jdk
-      - checkout
-      - run: ./gradlew build
   jdk23:
     executor: ubuntu
     steps:
@@ -37,5 +30,4 @@ workflows:
   gradle-build:
     jobs:
       - jdk21
-      - jdk22
       - jdk23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java: [ 21, 22 ,23 ]
+        java: [ 21 ,23 ]
 
     name: JDK ${{ matrix.java }}
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 从 CircleCI 和 GitHub Actions 配置中移除 JDK 22。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove JDK 22 from CircleCI and GitHub Actions configurations.

</details>