### PR TITLE
refactor: 使用GitHub Action具体版本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v4.2.2
 
       - name: Gradle Run Build
         run: ./gradlew build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,12 +48,12 @@ jobs:
           cache: gradle
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v3.28.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v3.28.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v3.28.0


### PR DESCRIPTION
## Summary by Sourcery

更新 GitHub Actions 以使用特定版本。

CI：
- 将 GitHub CodeQL Action 固定到 v3.28.0。
- 将 Gradle Setup Action 固定到 v4.2.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions to use specific versions.

CI:
- Pin GitHub CodeQL Action to v3.28.0.
- Pin Gradle Setup Action to v4.2.2.

</details>