### PR TITLE
增加Github Bug提交模板

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug报告
+description: 帮助我们改进
+title: "[Bug报告]: 描述"
+labels: ["bug"]
+assignees: 'livk-cloud'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请确认以下信息：
+        1. 请按此模板提交issues, 不按模板提交的问题将直接关闭
+        2. 如果你使用的版本号不是最新版, 那么你的 issue 大概率将会被直接关闭
+        3. 如果你的问题与该仓库无关或者可以直接在以往 issue 中找到, 那么你的 issue 大概率将会被直接关闭
+        4. 提交问题务必描述清楚、附上日志, 描述不清导致无法理解和分析的问题 大概率会被直接关闭
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: 确认
+      description: 在提交 issue 之前, 请确认你已经阅读并确认以下内容, 如果 不全部勾选 或 勾选与事实不符 那么你的 issue 大概率将会被直接关闭
+      options:
+        - label: 我使用的版本是[最新版](https://github.com/livk-cloud/spring-boot-extension), 并且使用插件确认过项目里无依赖版本冲突
+          required: true
+        - label: 我已经在 [issue](https://github.com/livk-cloud/spring-boot-extension/issues) 中搜索过, 确认问题没有被提出过
+          required: true
+        - label: 我已经修改标题, 将标题中的 描述 替换为遇到的问题
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: 当前程序版本
+      description: 遇到问题时程序所在的版本号
+    validations:
+      required: true
+  - type: input
+    id: jdk-version
+    attributes:
+      label: 当前JDK版本
+      description: 遇到问题时程序所在的JDK版本
+    validations:
+      required: true
+  - type: input
+    id: spring-boot-version
+    attributes:
+      label: 当前SpringBoot版本
+      description: 遇到问题时程序所在的SpringBoot版本
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: BUG描述
+      description: 请描述你碰到的问题
+      placeholder: "BUG描述"
+    validations:
+      required: true
+  - type: textarea
+    id: bug-reproduction-steps
+    attributes:
+      label: BUG复现步骤
+      description: 请详细描述BUG复现步骤
+      placeholder: "BUG复现步骤"
+    validations:
+      required: true
+  - type: textarea
+    id: desired-result
+    attributes:
+      label: 预期效果
+      description: 请描述预期效果
+      placeholder: "预期效果"
+    validations:
+      required: true
+  - type: textarea
+    id: stack-log
+    attributes:
+      label: 详细堆栈日志
+      description: 问题出现时，程序错误堆栈日志
+      render: bash


### PR DESCRIPTION
增加Github Bug提交模板

## Summary by Sourcery

文档：
- 在 GitHub 上添加了一个 bug 报告模板，要求用户提供版本信息、重现步骤和预期结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a template for bug reports on GitHub, requiring users to provide version information, reproduction steps, and the expected result.

</details>