### PR TITLE
refactor: 镜像源调整

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,8 +54,8 @@ configure(module) {
 
 allprojects {
 	repositories {
-		maven("https://mirrors.tencent.com/nexus/repository/maven-public/")
-		maven("https://repo.spring.io/release")
 		mavenCentral()
+//		国内镜像源，海外CI拉取容易失败，在国内构建项目使用即可
+//		maven("https://mirrors.tencent.com/nexus/repository/maven-public/")
 	}
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
 }
 
 repositories {
-	maven("https://repo.spring.io/release")
-	maven("https://mirrors.tencent.com/nexus/repository/maven-public/")
+	mavenCentral()
+	gradlePluginPortal()
+//	国内镜像源，海外CI拉取容易失败，在国内构建项目使用即可
+//	maven("https://mirrors.tencent.com/nexus/repository/maven-public/")
 }
 
 dependencies {


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Maven 仓库配置，默认使用 Maven Central 和 Gradle Plugin Portal，并移除腾讯镜像，以避免海外 CI 构建出现问题。腾讯镜像作为注释选项保留，供中国本地构建使用。

杂项：
- 从默认 Maven 仓库中移除腾讯镜像仓库。
- 使用 Maven Central 和 Gradle Plugin Portal 作为默认仓库。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Maven repository configuration to use Maven Central and Gradle Plugin Portal by default, and remove the Tencent mirror to avoid issues with overseas CI builds. The Tencent mirror is kept as a commented-out option for local builds in China.

Chores:
- Remove the Tencent mirror repository from the default Maven repositories.
- Use Maven Central and Gradle Plugin Portal as the default repositories.

</details>