### PR TITLE
feat: 废弃collectionType，添加ListType和setType

### DIFF
--- a/spring-boot-example/spring-admin/spring-admin-server/src/main/java/com/livk/admin/server/config/AdminRedisConfig.java
+++ b/spring-boot-example/spring-admin/spring-admin-server/src/main/java/com/livk/admin/server/config/AdminRedisConfig.java
@@ -50,7 +50,7 @@ public class AdminRedisConfig {
 			.build();
 		Jackson2JsonRedisSerializer<InstanceId> hashKeySerializer = new Jackson2JsonRedisSerializer<>(mapper,
 				InstanceId.class);
-		CollectionType collectionType = TypeFactoryUtils.collectionType(InstanceEvent.class);
+		CollectionType collectionType = TypeFactoryUtils.listType(InstanceEvent.class);
 		Jackson2JsonRedisSerializer<List<InstanceEvent>> hashValueSerializer = new Jackson2JsonRedisSerializer<>(mapper,
 				collectionType);
 		RedisSerializationContext<String, Object> serializationContext = RedisSerializationContext

--- a/spring-extension-bom/spring-extension-bom.gradle.kts
+++ b/spring-extension-bom/spring-extension-bom.gradle.kts
@@ -10,8 +10,10 @@ dependencies {
 		api(project(":spring-extension-commons"))
 		api(project(":spring-extension-context"))
 		api(project(":spring-boot-extension-autoconfigure"))
-		project.project(project(":spring-boot-extension-starters").path).subprojects {
-			api(this)
+		project(":spring-boot-extension-starters") {
+			subprojects{
+				api(this)
+			}
 		}
 	}
 }

--- a/spring-extension-commons/src/main/java/com/livk/commons/jackson/util/JsonMapperUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/jackson/util/JsonMapperUtils.java
@@ -101,7 +101,7 @@ public class JsonMapperUtils {
 	 * @return the list
 	 */
 	public static <T> List<T> readValueList(Object obj, Class<T> type) {
-		CollectionType collectionType = TypeFactoryUtils.collectionType(type);
+		CollectionType collectionType = TypeFactoryUtils.listType(type);
 		return JSON.readValue(obj, collectionType);
 	}
 
@@ -173,7 +173,7 @@ public class JsonMapperUtils {
 	 * @return List
 	 */
 	public static <T> List<T> convertValueList(Object fromValue, Class<T> type) {
-		CollectionType collectionType = TypeFactoryUtils.collectionType(type);
+		CollectionType collectionType = TypeFactoryUtils.listType(type);
 		return JSON.convertValue(fromValue, collectionType);
 	}
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/jackson/util/TypeFactoryUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/jackson/util/TypeFactoryUtils.java
@@ -27,7 +27,9 @@ import org.springframework.core.ResolvableType;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * TypeFactory工具类
@@ -105,7 +107,9 @@ public class TypeFactoryUtils {
 	 * @param <T> the type parameter
 	 * @param type the target class
 	 * @return CollectionType
+	 * @deprecated use {@link #listType(JavaType)} or {@link #setType(JavaType)}
 	 */
+	@Deprecated(since = "1.4.3")
 	public static <T> CollectionType collectionType(Class<T> type) {
 		return instance().constructCollectionType(Collection.class, type);
 	}
@@ -114,9 +118,49 @@ public class TypeFactoryUtils {
 	 * 构建一个CollectionType
 	 * @param javaType the java type
 	 * @return CollectionType
+	 * @deprecated use {@link #listType(JavaType)} or {@link #setType(JavaType)}
 	 */
+	@Deprecated(since = "1.4.3")
 	public static CollectionType collectionType(JavaType javaType) {
 		return instance().constructCollectionType(Collection.class, javaType);
+	}
+
+	/**
+	 * 构建一个SetType
+	 * @param javaType the java type
+	 * @return SetType
+	 */
+	public static CollectionType setType(JavaType javaType) {
+		return instance().constructCollectionType(Set.class, javaType);
+	}
+
+	/**
+	 * 构建一个SetType
+	 * @param <T> the type parameter
+	 * @param type the target class
+	 * @return SetType
+	 */
+	public static <T> CollectionType setType(Class<T> type) {
+		return instance().constructCollectionType(Set.class, type);
+	}
+
+	/**
+	 * 构建一个ListType
+	 * @param <T> the type parameter
+	 * @param type the target class
+	 * @return ListType
+	 */
+	public static <T> CollectionType listType(Class<T> type) {
+		return instance().constructCollectionType(List.class, type);
+	}
+
+	/**
+	 * 构建一个ListType
+	 * @param javaType the java type
+	 * @return ListType
+	 */
+	public static CollectionType listType(JavaType javaType) {
+		return instance().constructCollectionType(List.class, javaType);
 	}
 
 	/**

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/core/JacksonSupportTest.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/core/JacksonSupportTest.java
@@ -97,12 +97,10 @@ class JacksonSupportTest {
 		assertEquals(String.class, type.getBindings().getBoundType(0).getRawClass());
 		assertEquals(Integer.class, type.getBindings().getBoundType(1).getRawClass());
 
-		assertEquals(String.class,
-				TypeFactoryUtils.collectionType(String.class).getBindings().getBoundType(0).getRawClass());
+		assertEquals(String.class, TypeFactoryUtils.listType(String.class).getBindings().getBoundType(0).getRawClass());
 		assertEquals(Integer.class,
-				TypeFactoryUtils.collectionType(Integer.class).getBindings().getBoundType(0).getRawClass());
-		assertEquals(Long.class,
-				TypeFactoryUtils.collectionType(Long.class).getBindings().getBoundType(0).getRawClass());
+				TypeFactoryUtils.listType(Integer.class).getBindings().getBoundType(0).getRawClass());
+		assertEquals(Long.class, TypeFactoryUtils.setType(Long.class).getBindings().getBoundType(0).getRawClass());
 
 		assertEquals(List.of(TypeFactoryUtils.javaType(String.class), TypeFactoryUtils.javaType(String.class)),
 				TypeFactoryUtils.mapType(String.class, String.class).getBindings().getTypeParameters());
@@ -294,7 +292,7 @@ class JacksonSupportTest {
 		assertEquals(jsonDependency, JSON.convertValue(jsonNodeList.get(1), mapType));
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
-		CollectionType collectionType = TypeFactoryUtils.collectionType(mapType);
+		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
 		assertEquals(dependencyList, JSON.convertValue(dependencyArray, collectionType));
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);
@@ -327,7 +325,7 @@ class JacksonSupportTest {
 		assertEquals(jsonDependency, YAML.convertValue(jsonNodeList.get(1), mapType));
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
-		CollectionType collectionType = TypeFactoryUtils.collectionType(mapType);
+		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
 		assertEquals(dependencyList, YAML.convertValue(dependencyArray, collectionType));
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);
@@ -364,7 +362,7 @@ class JacksonSupportTest {
 		assertEquals(jsonDependency, XML.convertValue(jsonNodeList.get(1), mapType));
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
-		CollectionType collectionType = TypeFactoryUtils.collectionType(mapType);
+		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
 		assertEquals(dependencyList, XML.convertValue(dependencyArray, collectionType));
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/util/JsonMapperUtilsTest.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/util/JsonMapperUtilsTest.java
@@ -435,7 +435,7 @@ class JsonMapperUtilsTest {
 		assertEquals(jsonDependency, JsonMapperUtils.convertValue(jsonNodeList.get(1), mapType));
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
-		CollectionType collectionType = TypeFactoryUtils.collectionType(mapType);
+		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
 		assertEquals(dependencyList, JsonMapperUtils.convertValue(dependencyArray, collectionType));
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/util/TypeFactoryUtilsTest.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/util/TypeFactoryUtilsTest.java
@@ -24,11 +24,13 @@ import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import com.fasterxml.jackson.databind.type.TypeBindings;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
-import org.springframework.core.ResolvableType;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -83,13 +85,23 @@ class TypeFactoryUtilsTest {
 	}
 
 	@Test
-	void collectionType() {
+	void listType() {
 		SimpleType strType = SimpleType.constructUnsafe(String.class);
-		TypeBindings bindings = TypeBindings.createIfNeeded(Collection.class, strType);
-		CollectionType collectionType = CollectionType.construct(Collection.class, bindings,
+		TypeBindings bindings = TypeBindings.createIfNeeded(List.class, strType);
+		CollectionType listType = CollectionType.construct(List.class, bindings,
 				SimpleType.constructUnsafe(Iterable.class), null, strType);
-		assertEquals(collectionType, TypeFactoryUtils.collectionType(String.class));
-		assertEquals(collectionType, TypeFactoryUtils.collectionType(strType));
+		assertEquals(listType, TypeFactoryUtils.listType(String.class));
+		assertEquals(listType, TypeFactoryUtils.listType(strType));
+	}
+
+	@Test
+	void seyType() {
+		SimpleType strType = SimpleType.constructUnsafe(String.class);
+		TypeBindings bindings = TypeBindings.createIfNeeded(Set.class, strType);
+		CollectionType setType = CollectionType.construct(Set.class, bindings,
+				SimpleType.constructUnsafe(Iterable.class), null, strType);
+		assertEquals(setType, TypeFactoryUtils.setType(String.class));
+		assertEquals(setType, TypeFactoryUtils.setType(strType));
 	}
 
 	@Test


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 `TypeFactoryUtils` 中引入 `listType` 和 `setType` 方法，以便为列表和集合提供更具体的集合类型构造，并弃用通用的 `collectionType` 方法。

增强功能：
- 弃用 `collectionType` 方法，推荐使用更具体的 `listType` 和 `setType` 方法。
- 在 `TypeFactoryUtils` 中添加 `listType` 和 `setType` 方法，分别用于构造 `List` 和 `Set` 类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduces `listType` and `setType` methods in `TypeFactoryUtils` to provide more specific collection type construction for lists and sets, and deprecates the general `collectionType` method.

Enhancements:
- Deprecates the `collectionType` method in favor of the more specific `listType` and `setType` methods.
- Adds `listType` and `setType` methods to `TypeFactoryUtils` for constructing `List` and `Set` types respectively.

</details>