### PR TITLE
feat: springboot 3.4.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-spring-boot = "3.4.3"
+spring-boot = "3.4.4"
 kotlin = "2.1.20"
 pagehelper-starter = "2.1.0"
 mybatis = "3.5.19"

--- a/spring-boot-example/spring-rabbit/rabbit-provider/src/main/java/com/livk/provider/controller/RabbitController.java
+++ b/spring-boot-example/spring-rabbit/rabbit-provider/src/main/java/com/livk/provider/controller/RabbitController.java
@@ -42,22 +42,22 @@ public class RabbitController {
 	private final RabbitSend send;
 
 	@PostMapping("sendMsgDirect")
-	public void sendMsgDirect(@RequestBody Message<String> message) {
+	public <T> void sendMsgDirect(@RequestBody Message<T> message) {
 		send.sendMsgDirect(message);
 	}
 
 	@PostMapping("sendMsgFanout")
-	public void sendMsgFanout(@RequestBody Message<String> message) {
+	public <T> void sendMsgFanout(@RequestBody Message<T> message) {
 		send.sendMsgFanout(message);
 	}
 
 	@PostMapping("/sendMsgTopic/{key}")
-	public void sendMsgTopic(@RequestBody Message<String> message, @PathVariable String key) {
+	public <T> void sendMsgTopic(@RequestBody Message<T> message, @PathVariable String key) {
 		send.sendMsgTopic(message, key);
 	}
 
 	@PostMapping("sendMsgHeaders")
-	public void sendMsgHeaders(@RequestBody Message<String> message, @RequestParam String json) {
+	public <T> void sendMsgHeaders(@RequestBody Message<T> message, @RequestParam String json) {
 		send.sendMsgHeaders(message, JsonMapperUtils.readValueMap(json, String.class, Object.class));
 	}
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 Spring Boot 更新至 3.4.4 版本，并修改 RabbitController 以接受泛型消息类型。

增强功能：
- 将 Spring Boot 更新至 3.4.4 版本。
- 修改 RabbitController 以接受泛型消息类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates Spring Boot to version 3.4.4 and modifies the RabbitController to accept generic message types.

Enhancements:
- Updates Spring Boot to version 3.4.4.
- Modify the RabbitController to accept generic message types.

</details>