### PR TITLE
refactor: testcontainers-redis替换自定义RedisContainer

### DIFF
--- a/spring-boot-example/spring-redis/redis-caffeine/build.gradle.kts
+++ b/spring-boot-example/spring-redis/redis-caffeine/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 	implementation("com.github.ben-manes.caffeine:caffeine")
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-example/spring-redis/redis-caffeine/src/test/java/com/livk/caffeine/controller/CacheControllerTest.java
+++ b/spring-boot-example/spring-redis/redis-caffeine/src/test/java/com/livk/caffeine/controller/CacheControllerTest.java
@@ -17,7 +17,8 @@
 package com.livk.caffeine.controller;
 
 import com.livk.context.redis.RedisOps;
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,13 +56,12 @@ class CacheControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
 		registry.add("spring.data.redis.host", redis::getHost);
 		registry.add("spring.data.redis.port", redis::getFirstMappedPort);
-		registry.add("spring.data.redis.password", redis::getPassword);
 	}
 
 	@Autowired

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-autoconfigure.gradle.kts
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-autoconfigure.gradle.kts
@@ -38,4 +38,5 @@ dependencies {
 
 	testImplementation(project(":spring-testcontainers-support"))
 	testImplementation("com.zaxxer:HikariCP")
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/limit/LimitAutoConfigurationTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/limit/LimitAutoConfigurationTest.java
@@ -15,7 +15,8 @@ package com.livk.autoconfigure.limit;
 
 import com.livk.context.limit.executor.RedissonLimitExecutor;
 import com.livk.context.limit.interceptor.LimitInterceptor;
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -52,7 +53,7 @@ class LimitAutoConfigurationTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/lock/LockAutoConfigurationTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/lock/LockAutoConfigurationTest.java
@@ -18,8 +18,9 @@ import com.livk.commons.util.GenericsByteBuddy;
 import com.livk.context.lock.intercept.DistributedLockInterceptor;
 import com.livk.context.lock.support.CuratorLock;
 import com.livk.context.lock.support.RedissonLock;
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
 import com.livk.testcontainers.containers.ZookeeperContainer;
+import com.redis.testcontainers.RedisContainer;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import org.apache.curator.RetryPolicy;
@@ -72,7 +73,7 @@ class LockAutoConfigurationTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@Container
 	@ServiceConnection

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonAutoConfigurationTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonAutoConfigurationTest.java
@@ -13,7 +13,8 @@
 
 package com.livk.autoconfigure.redisson;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.redisson.spring.data.connection.RedissonConnectionFactory;
@@ -52,7 +53,7 @@ class RedissonAutoConfigurationTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonClientFactoryTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonClientFactoryTest.java
@@ -13,7 +13,8 @@
 
 package com.livk.autoconfigure.redisson;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.PropertyEditorRegistry;
@@ -51,7 +52,7 @@ class RedissonClientFactoryTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/build.gradle.kts
+++ b/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/test/java/com/livk/redisson/lock/ShopControllerTest.java
+++ b/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/test/java/com/livk/redisson/lock/ShopControllerTest.java
@@ -16,7 +16,8 @@
 
 package com.livk.redisson.lock;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ class ShopControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis()).withCommand("--requirepass", "123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/build.gradle.kts
+++ b/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
 	implementation(project(":spring-boot-extension-starters:limit-spring-boot-starter"))
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/src/test/java/com/livk/redisson/limit/controller/RateLimiterControllerTest.java
+++ b/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/src/test/java/com/livk/redisson/limit/controller/RateLimiterControllerTest.java
@@ -16,7 +16,8 @@
 
 package com.livk.redisson.limit.controller;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -43,7 +44,7 @@ class RateLimiterControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis()).withCommand("--requirepass", "123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webflux/build.gradle.kts
+++ b/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webflux/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     implementation(project(":spring-boot-extension-starters:redisearch-spring-boot-starter"))
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webflux/src/test/java/com/livk/redisearch/webflux/controller/StudentControllerTest.java
+++ b/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webflux/src/test/java/com/livk/redisearch/webflux/controller/StudentControllerTest.java
@@ -17,7 +17,8 @@
 package com.livk.redisearch.webflux.controller;
 
 import com.livk.redisearch.webflux.entity.Student;
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisStackContainer;
 import org.hamcrest.core.IsIterableContaining;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +42,7 @@ class StudentControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redisStack = new RedisStackContainer();
+	static RedisStackContainer redisStack = new RedisStackContainer(DockerImageNames.redisStack());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webmvc/build.gradle.kts
+++ b/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webmvc/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     implementation(project(":spring-boot-extension-starters:redisearch-spring-boot-starter"))
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webmvc/src/test/java/com/livk/redisearch/mvc/controller/StudentControllerTest.java
+++ b/spring-boot-extension-tests/redisearch-spring-boot-test/redisearch-spring-boot-test-webmvc/src/test/java/com/livk/redisearch/mvc/controller/StudentControllerTest.java
@@ -16,7 +16,8 @@
 
 package com.livk.redisearch.mvc.controller;
 
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisStackContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,7 +48,7 @@ class StudentControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redisStack = new RedisStackContainer();
+	static RedisStackContainer redisStack = new RedisStackContainer(DockerImageNames.redisStack());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-boot-extension-tests/redisson-spring-boot-test/build.gradle.kts
+++ b/spring-boot-extension-tests/redisson-spring-boot-test/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     implementation(project(":spring-boot-extension-starters:redisson-spring-boot-starter"))
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("com.redis:testcontainers-redis")
 }

--- a/spring-boot-extension-tests/redisson-spring-boot-test/src/test/java/com/livk/redisson/schedule/ScheduleControllerTest.java
+++ b/spring-boot-extension-tests/redisson-spring-boot-test/src/test/java/com/livk/redisson/schedule/ScheduleControllerTest.java
@@ -13,7 +13,8 @@
 
 package com.livk.redisson.schedule;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -44,7 +45,7 @@ class ScheduleControllerTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis()).withCommand("--requirepass", "123456");
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-extension-context/spring-extension-context.gradle.kts
+++ b/spring-extension-context/spring-extension-context.gradle.kts
@@ -42,5 +42,6 @@ dependencies {
 	testImplementation("net.bytebuddy:byte-buddy")
 	testImplementation("org.testcontainers:postgresql")
 	testImplementation("org.testcontainers:mysql")
+	testImplementation("com.redis:testcontainers-redis")
 	testImplementation(project(":spring-testcontainers-support"))
 }

--- a/spring-extension-context/src/test/java/com/livk/context/lock/support/RedissonLockTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/lock/support/RedissonLockTest.java
@@ -15,7 +15,8 @@ package com.livk.context.lock.support;
 
 import com.livk.context.lock.DistributedLock;
 import com.livk.context.lock.LockType;
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.redisson.Redisson;
@@ -51,7 +52,7 @@ class RedissonLockTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer();
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void properties(DynamicPropertyRegistry registry) {

--- a/spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTest.java
@@ -16,7 +16,8 @@
 
 package com.livk.context.redis;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -45,13 +46,12 @@ class ReactiveRedisOpsTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
 		registry.add("redis.host", redis::getHost);
 		registry.add("redis.port", redis::getFirstMappedPort);
-		registry.add("redis.password", redis::getPassword);
 	}
 
 	@Autowired

--- a/spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTest.java
@@ -16,7 +16,8 @@
 
 package com.livk.context.redis;
 
-import com.livk.testcontainers.containers.RedisContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -43,13 +44,12 @@ class RedisOpsTest {
 
 	@Container
 	@ServiceConnection
-	static RedisContainer redis = new RedisContainer().withPassword("123456");
+	static RedisContainer redis = new RedisContainer(DockerImageNames.redis());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
 		registry.add("redis.host", redis::getHost);
 		registry.add("redis.port", redis::getFirstMappedPort);
-		registry.add("redis.password", redis::getPassword);
 	}
 
 	@Autowired

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/FactoryProxySupportTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/FactoryProxySupportTest.java
@@ -13,9 +13,10 @@
 
 package com.livk.context.redisearch;
 
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.DockerImageNames;
 import com.redis.lettucemod.RedisModulesClient;
 import com.redis.lettucemod.api.StatefulRedisModulesConnection;
+import com.redis.testcontainers.RedisStackContainer;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.resource.ClientResources;
 import org.junit.jupiter.api.AfterAll;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class FactoryProxySupportTest {
 
 	@Container
-	static RedisStackContainer redisStack = new RedisStackContainer();
+	static RedisStackContainer redisStack = new RedisStackContainer(DockerImageNames.redisStack());
 
 	static RediSearchConnectionFactory factory;
 

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTest.java
@@ -15,7 +15,8 @@ package com.livk.context.redisearch;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.livk.context.redisearch.codec.RedisCodecs;
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisStackContainer;
 import io.lettuce.core.codec.RedisCodec;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,7 @@ class RediSearchTemplateTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redisStack = new RedisStackContainer();
+	static RedisStackContainer redisStack = new RedisStackContainer(DockerImageNames.redisStack());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTest.java
@@ -13,7 +13,8 @@
 
 package com.livk.context.redisearch;
 
-import com.livk.testcontainers.containers.RedisStackContainer;
+import com.livk.testcontainers.DockerImageNames;
+import com.redis.testcontainers.RedisStackContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -34,7 +35,7 @@ class StringRediSearchTemplateTest {
 
 	@Container
 	@ServiceConnection
-	static RedisStackContainer redisStack = new RedisStackContainer();
+	static RedisStackContainer redisStack = new RedisStackContainer(DockerImageNames.redisStack());
 
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/containers/AbstractRedisContainer.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/containers/AbstractRedisContainer.java
@@ -24,6 +24,7 @@ import java.util.Optional;
  * @author livk
  */
 @Getter
+@Deprecated(since = "1.4.5")
 abstract class AbstractRedisContainer<C extends AbstractRedisContainer<C>> extends GenericContainer<C> {
 
 	private String password;

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/containers/RedisContainer.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/containers/RedisContainer.java
@@ -19,6 +19,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * @author livk
  */
+@Deprecated(since = "1.4.5")
 public class RedisContainer extends AbstractRedisContainer<RedisContainer> {
 
 	public RedisContainer() {

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/containers/RedisStackContainer.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/containers/RedisStackContainer.java
@@ -19,6 +19,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * @author livk
  */
+@Deprecated(since = "1.4.5")
 public class RedisStackContainer extends AbstractRedisContainer<RedisStackContainer> {
 
 	public RedisStackContainer() {


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构项目，使用官方的 `testcontainers-redis` 库，而不是自定义的 `RedisContainer` 和 `RedisStackContainer` 实现。 现在自定义实现已被弃用。

测试：
- 在测试中，用官方的 `testcontainers-redis` 库替换自定义的 `RedisContainer` 和 `RedisStackContainer` 实现。
- 将 `testcontainers-redis` 依赖项添加到构建文件中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactors the project to use the official testcontainers-redis library instead of the custom RedisContainer and RedisStackContainer implementations. The custom implementations are now deprecated.

Tests:
- Replaces custom RedisContainer and RedisStackContainer implementations with the official testcontainers-redis library in tests.
- Adds testcontainers-redis dependency to build files.

</details>