### PR TITLE
feat: 优化commons和spring-testcontainers

### DIFF
--- a/spring-boot-extension-tests/oss-spring-boot-test/minio-spring-boot-test/src/test/java/com/livk/oss/minio/controller/OssControllerTest.java
+++ b/spring-boot-extension-tests/oss-spring-boot-test/minio-spring-boot-test/src/test/java/com/livk/oss/minio/controller/OssControllerTest.java
@@ -57,7 +57,7 @@ class OssControllerTest {
 	static void properties(DynamicPropertyRegistry registry) {
 		registry.add("spring.oss.access-key", minio::getUserName);
 		registry.add("spring.oss.secret-key", minio::getPassword);
-		registry.add("spring.oss.url", () -> "minio:http://" + minio.getHost() + ":" + minio.getFirstMappedPort());
+		registry.add("spring.oss.url", () -> "minio:" + minio.getS3URL());
 	}
 
 	@Autowired

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/BeanLambdaDescriptor.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/BeanLambdaDescriptor.java
@@ -15,6 +15,9 @@ package com.livk.commons.util;
 
 import lombok.Getter;
 import lombok.SneakyThrows;
+import org.springframework.beans.BeanUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 
 import java.beans.PropertyDescriptor;
 import java.lang.invoke.SerializedLambda;
@@ -33,16 +36,19 @@ final class BeanLambdaDescriptor {
 
 	private static final Map<Method, BeanLambdaDescriptor> cache = new ConcurrentHashMap<>(128);
 
-	private final Class<?> type;
-
 	private final Method method;
 
-	private final PropertyDescriptor propertyDescriptor;
-
-	private BeanLambdaDescriptor(Class<?> type, Method method) {
-		this.type = type;
+	private BeanLambdaDescriptor(Method method) {
 		this.method = method;
-		this.propertyDescriptor = BeanUtils.findPropertyForMethod(method, type);
+	}
+
+	private PropertyDescriptor getPropertyDescriptor() {
+		Class<?> type = method.getDeclaringClass();
+		PropertyDescriptor propertyDescriptor = BeanUtils.findPropertyForMethod(method, type);
+		if (propertyDescriptor == null) {
+			throw new IllegalStateException("propertyDescriptor must not be null");
+		}
+		return propertyDescriptor;
 	}
 
 	/**
@@ -59,22 +65,22 @@ final class BeanLambdaDescriptor {
 		writeReplace.setAccessible(true);
 		SerializedLambda serializedLambda = (SerializedLambda) writeReplace.invoke(function);
 		String className = ClassUtils.convertResourcePathToClassName(serializedLambda.getImplClass());
-		Class<?> type = ClassUtils.resolveClassName(className);
+		Class<?> type = ClassUtils.resolveClassName(className, ClassUtils.getDefaultClassLoader());
 		Method method = ReflectionUtils.findMethod(type, serializedLambda.getImplMethodName());
-		return cache.computeIfAbsent(method, other -> new BeanLambdaDescriptor(type, other));
+		Assert.notNull(method, "method must not be null");
+		return cache.computeIfAbsent(method, BeanLambdaDescriptor::new);
 	}
 
 	public String getFieldName() {
-		return propertyDescriptor != null ? propertyDescriptor.getName() : null;
+		return getPropertyDescriptor().getName();
 	}
 
 	public Field getField() {
-		if (propertyDescriptor != null) {
-			String fieldName = propertyDescriptor.getName();
-			Class<?> fieldType = propertyDescriptor.getPropertyType();
-			return ReflectionUtils.findField(type, fieldName, fieldType);
-		}
-		return null;
+		PropertyDescriptor propertyDescriptor = getPropertyDescriptor();
+		String fieldName = propertyDescriptor.getName();
+		Class<?> fieldType = propertyDescriptor.getPropertyType();
+		Class<?> type = method.getDeclaringClass();
+		return ReflectionUtils.findField(type, fieldName, fieldType);
 	}
 
 	public String getMethodName() {

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/MinIOConnectionDetails.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/MinIOConnectionDetails.java
@@ -1,0 +1,22 @@
+package com.livk.testcontainers.spring;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author livk
+ */
+public interface MinIOConnectionDetails extends ConnectionDetails {
+
+	default String getEndpoint() {
+		return null;
+	}
+
+	default String getUserName() {
+		return null;
+	}
+
+	default String getPassword() {
+		return null;
+	}
+
+}

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/MinIOContainerConnectionDetailsFactory.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/MinIOContainerConnectionDetailsFactory.java
@@ -15,7 +15,6 @@ package com.livk.testcontainers.spring;
 
 import com.livk.auto.service.annotation.SpringFactories;
 import com.livk.testcontainers.DockerImageNames;
-import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory;
 import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
 import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
@@ -26,21 +25,37 @@ import org.testcontainers.containers.MinIOContainer;
  */
 @SpringFactories(ConnectionDetailsFactory.class)
 class MinIOContainerConnectionDetailsFactory
-		extends ContainerConnectionDetailsFactory<MinIOContainer, ConnectionDetails> {
+		extends ContainerConnectionDetailsFactory<MinIOContainer, MinIOConnectionDetails> {
 
 	MinIOContainerConnectionDetailsFactory() {
 		super(DockerImageNames.MINIO_IMAGE);
 	}
 
 	@Override
-	protected ConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<MinIOContainer> source) {
+	protected MinIOConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<MinIOContainer> source) {
 		return new MinIOContainerConnectionDetails(source);
 	}
 
-	private static final class MinIOContainerConnectionDetails extends ContainerConnectionDetails<MinIOContainer> {
+	private static final class MinIOContainerConnectionDetails extends ContainerConnectionDetails<MinIOContainer>
+			implements MinIOConnectionDetails {
 
 		private MinIOContainerConnectionDetails(ContainerConnectionSource<MinIOContainer> source) {
 			super(source);
+		}
+
+		@Override
+		public String getEndpoint() {
+			return getContainer().getS3URL();
+		}
+
+		@Override
+		public String getUserName() {
+			return getContainer().getUserName();
+		}
+
+		@Override
+		public String getPassword() {
+			return getContainer().getPassword();
 		}
 
 	}

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/ZookeeperConnectionDetails.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/ZookeeperConnectionDetails.java
@@ -1,0 +1,14 @@
+package com.livk.testcontainers.spring;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author livk
+ */
+public interface ZookeeperConnectionDetails extends ConnectionDetails {
+
+	default String getConnectString() {
+		return null;
+	}
+
+}

--- a/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/ZookeeperContainerConnectionDetailsFactory.java
+++ b/spring-testcontainers-support/src/main/java/com/livk/testcontainers/spring/ZookeeperContainerConnectionDetailsFactory.java
@@ -31,22 +31,28 @@ import org.springframework.boot.testcontainers.service.connection.ContainerConne
  */
 @SpringFactories(ConnectionDetailsFactory.class)
 class ZookeeperContainerConnectionDetailsFactory
-		extends ContainerConnectionDetailsFactory<ZookeeperContainer, ConnectionDetails> {
+		extends ContainerConnectionDetailsFactory<ZookeeperContainer, ZookeeperConnectionDetails> {
 
 	ZookeeperContainerConnectionDetailsFactory() {
 		super(DockerImageNames.ZOOKEEPER_IMAGE);
 	}
 
 	@Override
-	protected ConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<ZookeeperContainer> source) {
+	protected ZookeeperConnectionDetails getContainerConnectionDetails(
+			ContainerConnectionSource<ZookeeperContainer> source) {
 		return new ZookeeperContainerConnectionDetails(source);
 	}
 
 	private static final class ZookeeperContainerConnectionDetails
-			extends ContainerConnectionDetails<ZookeeperContainer> {
+			extends ContainerConnectionDetails<ZookeeperContainer> implements ZookeeperConnectionDetails {
 
 		private ZookeeperContainerConnectionDetails(ContainerConnectionSource<ZookeeperContainer> source) {
 			super(source);
+		}
+
+		@Override
+		public String getConnectString() {
+			return String.format("%s:%s", getContainer().getHost(), getContainer().getMappedPort(2181));
 		}
 
 	}


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化 `commons` 和 `spring-testcontainers` 模块，改进连接详情和 Bean Lambda 描述符的实现。

**新特性:**

- 引入 `MinIOConnectionDetails` 和 `ZookeeperConnectionDetails` 接口，以提供更明确的连接信息。

**增强:**

- 重构 `BeanLambdaDescriptor` 以改进方法缓存和属性描述符处理。
- 使用更具体的连接接口来增强容器连接详情工厂。

**杂务:**

- 简化 `BeanLambdaDescriptor` 中的方法实现。
- 更新测试配置以使用更具体的连接方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize commons and spring-testcontainers modules by improving connection details and bean lambda descriptor implementations

New Features:
- Introduce MinIOConnectionDetails and ZookeeperConnectionDetails interfaces for more explicit connection information

Enhancements:
- Refactor BeanLambdaDescriptor to improve method caching and property descriptor handling
- Enhance container connection details factories with more specific connection interfaces

Chores:
- Simplify method implementations in BeanLambdaDescriptor
- Update test configurations to use more specific connection methods

</details>