### PR TITLE
feat: OSSRH迁移至Portal

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,10 +11,11 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-gradle-plugin:${libs.versions.spring.boot.get()}")
-	implementation("io.spring.javaformat:spring-javaformat-gradle-plugin:${libs.versions.spring.javaformat.get()}")
-	implementation("com.google.protobuf:protobuf-gradle-plugin:${libs.versions.google.protobuf.plugins.get()}")
-	implementation("com.google.gradle:osdetector-gradle-plugin:${libs.versions.google.osdetector.plugins.get()}")
+	implementation(libs.spring.boot.plugin)
+	implementation(libs.spring.javaformat.plugin)
+	implementation(libs.google.protobuf.plugin)
+	implementation(libs.osdetector.gradle.plugin)
+	implementation(libs.maven.publish.plugin)
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/com/livk/boot/maven/DeployedPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/livk/boot/maven/DeployedPlugin.kt
@@ -33,74 +33,10 @@ import org.gradle.plugins.signing.SigningPlugin
  * @author livk
  */
 abstract class DeployedPlugin : Plugin<Project> {
-	companion object {
-		const val NAME = "maven"
-	}
 
 	override fun apply(project: Project) {
 		project.pluginManager.apply(SigningPlugin::class.java)
-		val publication = publication(project)
-		val signing = project.extensions.getByType(SigningExtension::class.java)
-		signing.isRequired = false
-		signing.sign(publication)
-		project.afterEvaluate {
-			project.plugins.withType(JavaPlugin::class.java) {
-				if ((project.tasks.named(JavaPlugin.JAR_TASK_NAME).get() as Jar).isEnabled) {
-					val javaPluginExtension = project.extensions.getByType(JavaPluginExtension::class.java)
-					javaPluginExtension.withSourcesJar()
-					javaPluginExtension.withJavadocJar()
-					project.components
-						.matching { softwareComponent -> softwareComponent.name == "java" }
-						.all(publication::from)
-					mavenInfo(publication, project)
-				}
-			}
-		}
-		project.plugins.withType(JavaPlatformPlugin::class.java) {
-			project.components
-				.matching { softwareComponent -> softwareComponent.name == "javaPlatform" }
-				.all(publication::from)
-			mavenInfo(publication, project)
-		}
-	}
-
-	private fun publication(project: Project): MavenPublication {
-		project.pluginManager.apply(MavenPublishPlugin::class.java)
 		project.pluginManager.apply(MavenRepositoryPlugin::class.java)
-		return project.extensions
-			.getByType(PublishingExtension::class.java)
-			.publications
-			.create(NAME, MavenPublication::class.java, MavenPublication::suppressAllPomMetadataWarnings)
-
+		project.pluginManager.apply(MavenPortalPublishPlugin::class.java)
 	}
-
-	private fun mavenInfo(publication: MavenPublication, project: Project) {
-		publication.versionMapping { versionMappingStrategy ->
-			versionMappingStrategy.allVariants(VariantVersionMappingStrategy::fromResolutionResult)
-		}
-		publication.pom { pom ->
-			project.afterEvaluate {
-				pom.name.set(project.name)
-				pom.description.set(project.description)
-			}
-			pom.url.set("https://github.com/livk-cloud/" + project.rootProject.name)
-			pom.licenses { licenses ->
-				licenses.license { license ->
-					license.name.set("The Apache License, Version 2.0")
-					license.url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-				}
-			}
-			pom.developers { developers ->
-				developers.developer { developer ->
-					developer.name.set("livk")
-					developer.email.set("livk.cloud@gmail.com")
-				}
-			}
-			pom.scm { scm ->
-				scm.connection.set("git@github.com:livk-cloud/${project.rootProject.name}.git")
-				scm.url.set("https://github.com/livk-cloud/${project.rootProject.name}/")
-			}
-		}
-	}
-
 }

--- a/buildSrc/src/main/kotlin/com/livk/boot/maven/MavenPortalPublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/livk/boot/maven/MavenPortalPublishPlugin.kt
@@ -1,0 +1,57 @@
+package com.livk.boot.maven
+
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.MavenPublishPlugin
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * <p>
+ * MavenPortalPublishPlugin
+ * </p>
+ *
+ * @author livk
+ * @date 2025/4/28
+ */
+abstract class MavenPortalPublishPlugin : Plugin<Project> {
+
+	override fun apply(project: Project) {
+		project.pluginManager.apply(MavenPublishPlugin::class.java)
+
+		val group = project.group.toString()
+
+		project.extensions.getByType(MavenPublishBaseExtension::class.java).apply {
+
+			publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+			signAllPublications()
+
+			coordinates(group, project.name, project.version.toString())
+
+			pom { pom ->
+				project.afterEvaluate {
+					pom.name.set(project.name)
+					pom.description.set(project.description)
+				}
+				pom.url.set("https://github.com/livk-cloud/" + project.rootProject.name)
+				pom.licenses { licenses ->
+					licenses.license { license ->
+						license.name.set("The Apache License, Version 2.0")
+						license.url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+					}
+				}
+				pom.developers { developers ->
+					developers.developer { developer ->
+						developer.name.set("livk")
+						developer.email.set("livk.cloud@gmail.com")
+					}
+				}
+				pom.scm { scm ->
+					scm.connection.set("git@github.com:livk-cloud/${project.rootProject.name}.git")
+					scm.url.set("https://github.com/livk-cloud/${project.rootProject.name}/")
+				}
+			}
+		}
+	}
+}

--- a/buildSrc/src/main/kotlin/com/livk/boot/maven/MavenRepositoryPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/livk/boot/maven/MavenRepositoryPlugin.kt
@@ -34,6 +34,7 @@ abstract class MavenRepositoryPlugin : Plugin<Project> {
 			val snapshotsRepoUrl = project.property("mvn.releasesRepoUrl").toString()
 			publishing.repositories.maven { maven ->
 				//使用不安全的http请求、也就是缺失SSL
+				maven.name = "CustomizeMaven"
 				maven.isAllowInsecureProtocol = true
 				val url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
 				maven.setUrl(url)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ spring-javaformat = "0.0.43"
 compile-testing = "0.21.0"
 okhttp = "4.12.0"
 spotbugs-annotations = "4.9.3"
+maven-publish-plugins = "0.31.0"
 
 [libraries]
 spring-boot-admin-dependencies = { group = "de.codecentric", name = "spring-boot-admin-dependencies", version.ref = "spring-admin" }
@@ -90,14 +91,18 @@ spring-asciidoctor = { group = "io.spring.asciidoctor.backends", name = "spring-
 compile-testing = { group = "com.google.testing.compile", name = "compile-testing", version.ref = "compile-testing" }
 spotbugs-annotations = { group = "com.github.spotbugs", name = "spotbugs-annotations", version.ref = "spotbugs-annotations" }
 
+#plugin
+spring-boot-plugin = { group = "org.springframework.boot", name = "spring-boot-gradle-plugin", version.ref = "spring-boot" }
+spring-javaformat-plugin = { group = "io.spring.javaformat", name = "spring-javaformat-gradle-plugin", version.ref = "spring-javaformat" }
+google-protobuf-plugin = { group = "com.google.protobuf", name = "protobuf-gradle-plugin", version.ref = "google-protobuf-plugins" }
+osdetector-gradle-plugin = { group = "com.google.gradle", name = "osdetector-gradle-plugin", version.ref = "google-osdetector-plugins" }
+maven-publish-plugin = { group = "com.vanniktech.maven.publish", name = "com.vanniktech.maven.publish.gradle.plugin", version.ref = "maven-publish-plugins" }
+
 [bundles]
 mybatis-all = ["mybatis", "mybatis-spring", "mybatis-autoconfigure", "mybatis-starter"]
 redisson-all = ["redisson", "redisson-starter", "redisson-spring-data"]
 mapstruct-all = ["mapstruct", "mapstruct-processor", "lombok-mapstruct"]
 
 [plugins]
-spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 asciidoctor-jvm = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor-jvm" }
-google-protobuf = { id = "com.google.protobuf", version.ref = "google-protobuf-plugins" }
-spring-javaformat = { id = "io.spring.javaformat", version.ref = "spring-javaformat" }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将构件发布从 OSSRH 迁移到 Maven Central Portal。

构建：
- 引入并配置 Gradle 插件 (`MavenPortalPublishPlugin`)，用于通过 Maven Central Portal 发布构件。
- 更新 `libs.versions.toml` 和 `buildSrc` 中的 Gradle 插件依赖项和声明。
- 集成 `com.vanniktech.maven.publish` 插件，用于处理 Maven 发布任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate artifact publishing from OSSRH to the Maven Central Portal.

Build:
- Introduce and configure a Gradle plugin (`MavenPortalPublishPlugin`) for publishing artifacts via the Maven Central Portal.
- Update Gradle plugin dependencies and declarations in `libs.versions.toml` and `buildSrc`.
- Integrate the `com.vanniktech.maven.publish` plugin for handling Maven publishing tasks.

</details>