### PR TITLE
feat: polish

### DIFF
--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/curator/CuratorAutoConfiguration.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/curator/CuratorAutoConfiguration.java
@@ -21,7 +21,9 @@ import com.livk.context.curator.CuratorTemplate;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.drivers.TracerDriver;
 import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.DefaultTracerDriver;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -62,6 +64,18 @@ public class CuratorAutoConfiguration {
 			throws InterruptedException {
 		return CuratorFactory.create(properties, retryPolicy, curatorFrameworkBuilderCustomizers::orderedStream,
 				ensembleProviders::getIfAvailable, tracerDrivers::getIfAvailable);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public TracerDriver tracerDriver() {
+		return new DefaultTracerDriver();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public EnsembleProvider fixedEnsembleProvider(CuratorProperties properties) {
+		return new FixedEnsembleProvider(properties.getConnectString());
 	}
 
 	/**

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrar.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrar.java
@@ -13,7 +13,6 @@
 
 package com.livk.autoconfigure.redisson;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -99,7 +98,6 @@ final class RedissonPropertyEditorRegistrar implements PropertyEditorRegistrar {
 			FilterProvider filterProvider = new SimpleFilterProvider().addFilter("classFilter",
 					SimpleBeanPropertyFilter.filterOutAllExcept());
 			mapper.setFilterProvider(filterProvider);
-			mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 			mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 			support = new JacksonSupport(mapper);
 		}

--- a/spring-extension-commons/src/main/java/com/livk/commons/expression/CacheExpressionResolver.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/expression/CacheExpressionResolver.java
@@ -57,11 +57,7 @@ public abstract class CacheExpressionResolver<CONTEXT, EXPRESSION> extends Abstr
 			if (environment != null) {
 				value = environment.resolvePlaceholders(value);
 			}
-			EXPRESSION expression = this.expressionCache.get(value);
-			if (expression == null) {
-				expression = compile(value);
-				this.expressionCache.put(value, expression);
-			}
+			EXPRESSION expression = this.expressionCache.computeIfAbsent(value, this::compile);
 			CONTEXT frameworkContext = transform(context);
 			Assert.notNull(frameworkContext, "frameworkContext not be null");
 			return calculate(expression, frameworkContext, returnType);
@@ -84,9 +80,8 @@ public abstract class CacheExpressionResolver<CONTEXT, EXPRESSION> extends Abstr
 	 * 对表达式进行处理生成EXPRESSION
 	 * @param value 表达式
 	 * @return EXPRESSION expression
-	 * @throws Throwable the throwable
 	 */
-	protected abstract EXPRESSION compile(String value) throws Throwable;
+	protected abstract EXPRESSION compile(String value);
 
 	/**
 	 * 从Context装换成框架的上下文

--- a/spring-extension-commons/src/main/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolver.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolver.java
@@ -22,6 +22,7 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -49,8 +50,9 @@ public class FreeMarkerExpressionResolver extends CacheExpressionResolver<Map<St
 		this(DEFAULT_CONFIG);
 	}
 
+	@SneakyThrows
 	@Override
-	protected Template compile(String value) throws IOException {
+	protected Template compile(String value) {
 		return new Template(TEMPLATE_NAME, value, configuration);
 	}
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/expression/mvel2/MvelExpressionResolver.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/expression/mvel2/MvelExpressionResolver.java
@@ -23,7 +23,9 @@ import org.mvel2.DataConversion;
 import org.mvel2.MVELInterpretedRuntime;
 import org.mvel2.ParserContext;
 import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.CachedMapVariableResolverFactory;
 import org.mvel2.integration.impl.CachingMapVariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
 
 /**
  * 使用<a href="https://github.com/mvel/mvel">Mvel 2</a>实现的表达式解析器
@@ -51,7 +53,9 @@ public class MvelExpressionResolver extends CacheExpressionResolver<VariableReso
 
 	@Override
 	protected VariableResolverFactory transform(Context context) {
-		return new CachingMapVariableResolverFactory(context.asMap());
+		VariableResolverFactory resolverFactory = new CachingMapVariableResolverFactory(context.asMap());
+		VariableResolverFactory nextFactory = new CachedMapVariableResolverFactory(context.asMap(), resolverFactory);
+		return new MapVariableResolverFactory(context.asMap(), nextFactory);
 	}
 
 	@Override

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/Pair.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/Pair.java
@@ -109,7 +109,9 @@ public final class Pair<K, V> implements Serializable, Cloneable {
 	 * 转成Map
 	 * @return the map
 	 * @see Map#of(Object, Object)
+	 * @deprecated use {@link Map#of()}
 	 */
+	@Deprecated(since = "1.5.0")
 	public Map<K, V> toMap() {
 		return Map.of(key, value);
 	}
@@ -117,7 +119,9 @@ public final class Pair<K, V> implements Serializable, Cloneable {
 	/**
 	 * 转成Map.Entry
 	 * @return entry
+	 * @deprecated use {@link Map#entry(Object, Object)}
 	 */
+	@Deprecated(since = "1.5.0")
 	public Map.Entry<K, V> toEntry() {
 		return Map.entry(key, value);
 	}
@@ -129,7 +133,9 @@ public final class Pair<K, V> implements Serializable, Cloneable {
 	 * @param keyFunction key function
 	 * @param valueFunction value function
 	 * @return pair
+	 * @deprecated 暂无使用场景
 	 */
+	@Deprecated(since = "1.5.0")
 	public <S, U> Pair<S, U> map(Function<K, S> keyFunction, Function<V, U> valueFunction) {
 		return of(keyFunction.apply(key), valueFunction.apply(value));
 	}
@@ -139,7 +145,9 @@ public final class Pair<K, V> implements Serializable, Cloneable {
 	 * @param <S> key转换后type
 	 * @param keyFunction key function
 	 * @return pair
+	 * @deprecated 暂无使用场景
 	 */
+	@Deprecated(since = "1.5.0")
 	public <S> Pair<S, V> keyMap(Function<K, S> keyFunction) {
 		return map(keyFunction, Function.identity());
 	}
@@ -149,7 +157,9 @@ public final class Pair<K, V> implements Serializable, Cloneable {
 	 * @param <U> value转换后type
 	 * @param valueFunction value function
 	 * @return pair
+	 * @deprecated 暂无使用场景
 	 */
+	@Deprecated(since = "1.5.0")
 	public <U> Pair<K, U> valueMap(Function<V, U> valueFunction) {
 		return map(Function.identity(), valueFunction);
 	}
@@ -160,7 +170,9 @@ public final class Pair<K, V> implements Serializable, Cloneable {
 	 * @param <U> value转换后type
 	 * @param biFunction bi function
 	 * @return pair
+	 * @deprecated 暂无使用场景
 	 */
+	@Deprecated(since = "1.5.0")
 	public <S, U> Pair<S, U> flatMap(BiFunction<K, V, Pair<S, U>> biFunction) {
 		return biFunction.apply(key, value);
 	}

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/WebUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/WebUtils.java
@@ -29,6 +29,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.MultiValueMapAdapter;
 import org.springframework.web.ErrorResponseException;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.RequestAttributes;
@@ -119,7 +121,9 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
 	 * @return MultiValueMap
 	 */
 	public HttpParameters params(HttpServletRequest request) {
-		return new HttpParameters(Maps.transformValues(request.getParameterMap(), Lists::newArrayList));
+		Map<String, List<String>> map = Maps.transformValues(request.getParameterMap(), Lists::newArrayList);
+		MultiValueMap<String, String> adapter = new MultiValueMapAdapter<>(map);
+		return new HttpParameters(adapter);
 	}
 
 	/**

--- a/spring-extension-commons/src/main/java/com/livk/commons/web/HttpParameters.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/web/HttpParameters.java
@@ -15,7 +15,7 @@
 
 package com.livk.commons.web;
 
-import org.springframework.lang.NonNull;
+import lombok.experimental.Delegate;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -24,11 +24,9 @@ import org.springframework.util.MultiValueMap;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -48,6 +46,7 @@ public final class HttpParameters implements MultiValueMap<String, String>, Seri
 	@Serial
 	private static final long serialVersionUID = -578554704772377436L;
 
+	@Delegate
 	final MultiValueMap<String, String> parameters;
 
 	public HttpParameters() {
@@ -59,6 +58,13 @@ public final class HttpParameters implements MultiValueMap<String, String>, Seri
 		this.parameters = parameters;
 	}
 
+	/**
+	 * @see #HttpParameters(MultiValueMap)
+	 * @see CollectionUtils#toMultiValueMap
+	 * @see MultiValueMap#fromMultiValue(Map)
+	 * @deprecated since 1.5.0 use {@link #HttpParameters(MultiValueMap)}
+	 */
+	@Deprecated(since = "1.5.0")
 	public HttpParameters(Map<String, List<String>> map) {
 		this(CollectionUtils.toMultiValueMap(map));
 	}
@@ -66,105 +72,6 @@ public final class HttpParameters implements MultiValueMap<String, String>, Seri
 	public List<String> getOrEmpty(Object parameterName) {
 		List<String> values = get(parameterName);
 		return (values != null ? values : Collections.emptyList());
-	}
-
-	@Override
-	@Nullable public String getFirst(@NonNull String parameterName) {
-		return this.parameters.getFirst(parameterName);
-	}
-
-	@Override
-	public void add(@NonNull String parameterName, @Nullable String parameterValue) {
-		this.parameters.add(parameterName, parameterValue);
-	}
-
-	@Override
-	public void addAll(@NonNull String key, @NonNull List<? extends String> values) {
-		this.parameters.addAll(key, values);
-	}
-
-	@Override
-	public void addAll(@NonNull MultiValueMap<String, String> values) {
-		this.parameters.addAll(values);
-	}
-
-	@Override
-	public void set(@NonNull String parameterName, @Nullable String parameterValue) {
-		this.parameters.set(parameterName, parameterValue);
-	}
-
-	@Override
-	public void setAll(@NonNull Map<String, String> values) {
-		this.parameters.setAll(values);
-	}
-
-	@NonNull
-	@Override
-	public Map<String, String> toSingleValueMap() {
-		return this.parameters.toSingleValueMap();
-	}
-
-	@Override
-	public int size() {
-		return this.parameters.size();
-	}
-
-	@Override
-	public boolean isEmpty() {
-		return this.parameters.isEmpty();
-	}
-
-	@Override
-	public boolean containsKey(Object key) {
-		return this.parameters.containsKey(key);
-	}
-
-	@Override
-	public boolean containsValue(Object value) {
-		return this.parameters.containsValue(value);
-	}
-
-	@Override
-	@Nullable public List<String> get(Object key) {
-		return this.parameters.get(key);
-	}
-
-	@Override
-	public List<String> put(String key, List<String> value) {
-		return this.parameters.put(key, value);
-	}
-
-	@Override
-	public List<String> remove(Object key) {
-		return this.parameters.remove(key);
-	}
-
-	@Override
-	public void putAll(@NonNull Map<? extends String, ? extends List<String>> map) {
-		this.parameters.putAll(map);
-	}
-
-	@Override
-	public void clear() {
-		this.parameters.clear();
-	}
-
-	@NonNull
-	@Override
-	public Set<String> keySet() {
-		return this.parameters.keySet();
-	}
-
-	@NonNull
-	@Override
-	public Collection<List<String>> values() {
-		return this.parameters.values();
-	}
-
-	@NonNull
-	@Override
-	public Set<Entry<String, List<String>>> entrySet() {
-		return this.parameters.entrySet();
 	}
 
 	@Override

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/util/JsonMapperUtilsTest.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/util/JsonMapperUtilsTest.java
@@ -402,7 +402,7 @@ class JsonMapperUtilsTest {
 	void convertValueMap() {
 		Pair<String, String> pair = Pair.of("username", "password");
 		Map<String, String> map = JsonMapperUtils.convertValueMap(pair, String.class, String.class);
-		assertEquals(pair.toMap(), map);
+		assertEquals(Map.of(pair.key(), pair.value()), map);
 	}
 
 	@Test

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTest.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTest.java
@@ -22,8 +22,10 @@ import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 /**
  * <p>
@@ -57,6 +59,31 @@ class BeanUtilsTest {
 		List<TargetBean> result = BeanUtils.copyList(beanList, TargetBean.class);
 		List<TargetBean> targetBeans = List.of(new TargetBean("source", 10), new TargetBean("target", 9));
 		assertEquals(result, targetBeans);
+	}
+
+	@Test
+	void convert() {
+		{
+			TargetBean source = new TargetBean("source", 10);
+			Map<String, Object> convert = BeanUtils.convert(source);
+			assertEquals("source", convert.get("beanName"));
+			assertEquals(10, convert.get("beanNo"));
+			assertEquals(TargetBean.class, convert.get("class"));
+
+			TargetBean target = BeanUtils.convert(convert);
+			assertEquals(source, target);
+		}
+
+		{
+			SourceBean source = new SourceBean("source", 10);
+			Map<String, Object> convert = BeanUtils.convert(source);
+			assertEquals("source", convert.get("beanName"));
+			assertEquals(10, convert.get("beanNo"));
+			assertEquals(SourceBean.class, convert.get("class"));
+
+			assertThrowsExactly(IllegalArgumentException.class, () -> BeanUtils.convert(convert),
+					"Missing no-argument constructor");
+		}
 	}
 
 	record SourceBean(String beanName, Integer beanNo) {

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/PairTest.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/PairTest.java
@@ -39,31 +39,6 @@ class PairTest {
 	static Pair<String, Integer> pair = Pair.of("livk", 123456);
 
 	@Test
-	void toMap() {
-		assertEquals(pair.toMap(), Map.of("livk", 123456));
-		assertEquals(Map.entry("livk", 123456), pair.toEntry());
-	}
-
-	@Test
-	void map() {
-		Pair<String, String> map = pair.map(String::toUpperCase, String::valueOf);
-		assertEquals("LIVK", map.key());
-		assertEquals("123456", map.value());
-
-		Pair<String, Integer> keyMap = pair.keyMap(String::toUpperCase);
-		assertEquals("LIVK", keyMap.key());
-		assertEquals(123456, keyMap.value());
-
-		Pair<String, String> valueMap = pair.valueMap(String::valueOf);
-		assertEquals("livk", valueMap.key());
-		assertEquals("123456", valueMap.value());
-
-		Pair<String, String> flatMap = pair.flatMap((key, value) -> Pair.of(key.toUpperCase(), String.valueOf(value)));
-		assertEquals("LIVK", flatMap.key());
-		assertEquals("123456", flatMap.value());
-	}
-
-	@Test
 	void pairJsonSerializerTest() {
 		String json = "{\"livk\":123456}";
 		String result = JsonMapperUtils.writeValueAsString(pair);


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化和清理常用工具类，新增 map 到 bean 的转换支持，简化表达式解析器，并通过默认 bean 扩展 Curator 自动配置

**新特性:**

- 增加泛型方法 `BeanUtils.convert(Map<String,Object>)` 用于 map 到 bean 的转换
- 在 `CuratorAutoConfiguration` 中提供默认的 `TracerDriver` 和固定的 `EnsembleProvider` bean

**Bug 修复:**

- 从 `RedissonPropertyEditorRegistrar` 中的 `ObjectMapper` 移除 `NON_NULL` 包含，以避免空 bean 失败

**增强:**

- 使用 Lombok 的 `@Delegate` 替换 `HttpParameters` 样板代码，并弃用基于 Map 的构造函数
- 简化 `CacheExpressionResolver` 以使用 `computeIfAbsent`，并从编译中删除检查型异常
- 在 `MvelExpressionResolver` 中链接解析器工厂，并使用 `@SneakyThrows` 注解 `FreeMarkerExpressionResolver.compile`
- 调整 `WebUtils.params` 以使用 `MultiValueMapAdapter`
- 内联 `BeanUtils.convert(Object)` 中的属性描述符检索

**测试:**

- 增加 `BeanUtilsTest.convert` 测试用例，用于往返转换和缺失构造函数错误的测试
- 更新 `JsonMapperUtilsTest` 以断言 `Map.of` 而不是已弃用的 `Pair.toMap`
- 删除过时的 `PairTest` 方法以反映实用程序映射的弃用

**杂项:**

- 弃用 `Pair` 方法 (`toMap`, `toEntry`, `map`, `keyMap`, `valueMap`, `flatMap`) 和 `HttpParameters(Map)` 构造函数，从 1.5.0 版本开始

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize and clean up common utilities, add map-to-bean conversion support, simplify expression resolvers, and extend Curator auto-configuration with default beans

New Features:
- Add generic BeanUtils.convert(Map<String,Object>) method for map-to-bean conversion
- Provide default TracerDriver and fixed EnsembleProvider beans in CuratorAutoConfiguration

Bug Fixes:
- Remove NON_NULL inclusion from ObjectMapper in RedissonPropertyEditorRegistrar to avoid empty-bean failures

Enhancements:
- Replace HttpParameters boilerplate with Lombok @Delegate and deprecate Map-based constructor
- Simplify CacheExpressionResolver to use computeIfAbsent and remove checked exception from compile
- Chain resolver factories in MvelExpressionResolver and annotate FreeMarkerExpressionResolver.compile with @SneakyThrows
- Adapt WebUtils.params to use MultiValueMapAdapter
- Inline property descriptor retrieval in BeanUtils.convert(Object)

Tests:
- Add BeanUtilsTest.convert test cases for roundtrip conversion and missing constructor error
- Update JsonMapperUtilsTest to assert against Map.of instead of deprecated Pair.toMap
- Remove outdated PairTest methods to reflect deprecation of utility mappings

Chores:
- Deprecate Pair methods (toMap, toEntry, map, keyMap, valueMap, flatMap) and HttpParameters(Map) constructor since 1.5.0

</details>