### PR TITLE
Refactor redisson

### DIFF
--- a/spring-boot-example/spring-redis/redis-repeated-submit/src/main/resources/application.yml
+++ b/spring-boot-example/spring-redis/redis-repeated-submit/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
         connectTimeout: 10000
         timeout: 3000
         retryAttempts: 3
-        retryInterval: 1500
         subscriptionsPerConnection: 5
         subscriptionConnectionMinimumIdleSize: 1
         subscriptionConnectionPoolSize: 50

--- a/spring-boot-example/spring-redis/redisson-order-expired/src/main/resources/application.yml
+++ b/spring-boot-example/spring-redis/redisson-order-expired/src/main/resources/application.yml
@@ -14,7 +14,6 @@ spring:
         connectTimeout: 10000
         timeout: 3000
         retryAttempts: 3
-        retryInterval: 1500
         subscriptionsPerConnection: 5
         subscriptionConnectionMinimumIdleSize: 1
         subscriptionConnectionPoolSize: 50

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/ConfigProperties.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/ConfigProperties.java
@@ -54,6 +54,7 @@ import org.redisson.connection.balancer.LoadBalancer;
 import org.redisson.connection.balancer.RoundRobinLoadBalancer;
 import org.springframework.beans.PropertyEditorRegistry;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
@@ -72,7 +73,6 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -133,23 +133,21 @@ public class ConfigProperties {
 				@DefaultValue("!<org.redisson.connection.SequentialDnsAddressResolverFactory> {}") AddressResolverGroupFactory addressResolverGroupFactory,
 				Boolean lazyInitialization, @DefaultValue("RESP2") Protocol protocol,
 				Set<ValkeyCapability> valkeyCapabilities) {
-			Optional.ofNullable(sentinelServersConfig).map(Base::convert).ifPresent(super::setSentinelServersConfig);
-			Optional.ofNullable(masterSlaveServersConfig)
-				.map(Base::convert)
-				.ifPresent(super::setMasterSlaveServersConfig);
-			Optional.ofNullable(singleServerConfig).map(Base::convert).ifPresent(super::setSingleServerConfig);
-			Optional.ofNullable(clusterServersConfig).map(Base::convert).ifPresent(super::setClusterServersConfig);
-			Optional.ofNullable(replicatedServersConfig)
-				.map(Base::convert)
-				.ifPresent(super::setReplicatedServersConfig);
+			PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
+
+			mapper.from(sentinelServersConfig).as(Base::convert).to(this::setSentinelServersConfig);
+			mapper.from(masterSlaveServersConfig).as(Base::convert).to(this::setMasterSlaveServersConfig);
+			mapper.from(singleServerConfig).as(Base::convert).to(this::setSingleServerConfig);
+			mapper.from(clusterServersConfig).as(Base::convert).to(this::setClusterServersConfig);
+			mapper.from(replicatedServersConfig).as(Base::convert).to(this::setReplicatedServersConfig);
 			setThreads(threads);
 			setNettyThreads(nettyThreads);
-			Optional.ofNullable(nettyExecutor).ifPresent(super::setNettyExecutor);
-			Optional.ofNullable(codec).ifPresent(super::setCodec);
-			Optional.ofNullable(executor).ifPresent(super::setExecutor);
+			mapper.from(nettyExecutor).to(this::setNettyExecutor);
+			mapper.from(codec).to(this::setCodec);
+			mapper.from(executor).to(this::setExecutor);
 			setReferenceEnabled(referenceEnabled);
 			setTransportMode(transportMode);
-			Optional.ofNullable(eventLoopGroup).ifPresent(super::setEventLoopGroup);
+			mapper.from(eventLoopGroup).to(this::setEventLoopGroup);
 			setLockWatchdogTimeout(lockWatchdogTimeout);
 			setLockWatchdogBatchSize(lockWatchdogBatchSize);
 			setFairLockWaitTimeout(fairLockWaitTimeout);
@@ -162,12 +160,12 @@ public class ConfigProperties {
 			setMaxCleanUpDelay(maxCleanUpDelay);
 			setCleanUpKeysAmount(cleanUpKeysAmount);
 			setNettyHook(nettyHook);
-			Optional.ofNullable(connectionListener).ifPresent(super::setConnectionListener);
+			mapper.from(connectionListener).to(this::setConnectionListener);
 			setUseThreadClassLoader(useThreadClassLoader);
 			setAddressResolverGroupFactory(addressResolverGroupFactory);
-			Optional.ofNullable(lazyInitialization).ifPresent(super::setLazyInitialization);
+			mapper.from(lazyInitialization).to(this::setLazyInitialization);
 			setProtocol(protocol);
-			Optional.ofNullable(valkeyCapabilities).ifPresent(super::setValkeyCapabilities);
+			mapper.from(valkeyCapabilities).to(this::setValkeyCapabilities);
 		}
 
 	}

--- a/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/main/resources/application.yml
+++ b/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/main/resources/application.yml
@@ -9,7 +9,6 @@ spring:
         connectTimeout: 10000
         timeout: 3000
         retryAttempts: 3
-        retryInterval: 1500
         subscriptionTimeout: 15000
         subscriptionsPerConnection: 10
         subscriptionConnectionMinimumIdleSize: 1

--- a/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/src/main/resources/application.yml
+++ b/spring-boot-extension-tests/limit-spring-boot-test/redisson-limit-spring-boot-test/src/main/resources/application.yml
@@ -9,7 +9,6 @@ spring:
         connectTimeout: 10000
         timeout: 3000
         retryAttempts: 3
-        retryInterval: 1500
         subscriptionsPerConnection: 5
         subscriptionConnectionMinimumIdleSize: 1
         subscriptionConnectionPoolSize: 50

--- a/spring-boot-extension-tests/redisson-spring-boot-test/src/main/resources/application.yml
+++ b/spring-boot-extension-tests/redisson-spring-boot-test/src/main/resources/application.yml
@@ -9,7 +9,6 @@ spring:
         connectTimeout: 10000
         timeout: 3000
         retryAttempts: 3
-        retryInterval: 1500
         subscriptionTimeout: 15000
         subscriptionsPerConnection: 10
         subscriptionConnectionMinimumIdleSize: 1


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Redisson 自动配置，使用 PropertyMapper 设置配置属性，并通过删除已弃用的 retryInterval 条目来清理示例和测试 application.yml 文件。

增强功能：
- 通过用 PropertyMapper 映射替换基于 Optional 的 setter，从而简化 Redisson ConfigProperties。

杂项：
- 从示例和测试 application.yml 配置中删除 retryInterval 属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Redisson autoconfiguration to use PropertyMapper for setting configuration properties and clean up example and test application.yml files by removing deprecated retryInterval entries.

Enhancements:
- Streamline Redisson ConfigProperties by replacing Optional-based setters with PropertyMapper mappings.

Chores:
- Remove retryInterval property from example and test application.yml configurations.

</details>