### PR TITLE
Refactor disruptor bean factory

### DIFF
--- a/buildSrc/src/main/kotlin/com/livk/boot/ModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/livk/boot/ModulePlugin.kt
@@ -43,7 +43,7 @@ class ModulePlugin : Plugin<Project> {
 		project.tasks.withType(Jar::class.java) { jar ->
 			jar.dependsOn(extractResourcesProvider)
 			jar.metaInf { metaInf ->
-				metaInf.from(extractResourcesProvider.get())
+				metaInf.from(extractResourcesProvider)
 			}
 		}
 	}

--- a/buildSrc/src/main/kotlin/com/livk/boot/ModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/livk/boot/ModulePlugin.kt
@@ -41,10 +41,9 @@ class ModulePlugin : Plugin<Project> {
 			}
 
 		project.tasks.withType(Jar::class.java) { jar ->
-			project.afterEvaluate {
-				jar.metaInf { metaInf ->
-					metaInf.from(extractResourcesProvider.get())
-				}
+			jar.dependsOn(extractResourcesProvider)
+			jar.metaInf { metaInf ->
+				metaInf.from(extractResourcesProvider.get())
 			}
 		}
 	}

--- a/spring-extension-context/src/main/java/com/livk/context/disruptor/ClassPathDisruptorScanner.java
+++ b/spring-extension-context/src/main/java/com/livk/context/disruptor/ClassPathDisruptorScanner.java
@@ -23,7 +23,6 @@ import com.livk.context.disruptor.annotation.DisruptorEvent;
 import com.livk.context.disruptor.factory.DisruptorFactoryBean;
 import com.livk.context.disruptor.support.SpringDisruptor;
 import com.lmax.disruptor.WaitStrategy;
-import com.lmax.disruptor.dsl.ProducerType;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -69,13 +68,14 @@ class ClassPathDisruptorScanner extends AnnotationBeanDefinitionScanner<Disrupto
 		Class<?> type = ClassUtils.resolveClassName(beanClassName, super.getResourceLoader().getClassLoader());
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(DisruptorFactoryBean.class)
 			.addConstructorArgValue(type)
-			.addPropertyValue("bufferSize", bufferSize(attributes))
-			.addPropertyValue("producerType", type(attributes))
-			.addPropertyValue("threadFactory", threadFactory(attributes))
-			.addPropertyValue("threadFactoryBeanName", threadFactoryBeanName(attributes))
-			.addPropertyValue("useVirtualThreads", useVirtualThreads(attributes))
-			.addPropertyValue("waitStrategy", strategy(attributes))
-			.addPropertyValue("strategyBeanName", strategyBeanName(attributes))
+			.addPropertyValue("bufferSize", attributes.getNumber("bufferSize").intValue())
+			.addPropertyValue("producerType", attributes.getEnum("type"))
+			.addPropertyValue("threadFactory",
+					BeanUtils.instantiateClass(attributes.<ThreadFactory>getClass("threadFactory")))
+			.addPropertyValue("threadFactoryBeanName", attributes.getString("threadFactoryBeanName"))
+			.addPropertyValue("useVirtualThreads", attributes.getBoolean("useVirtualThreads"))
+			.addPropertyValue("waitStrategy", BeanUtils.instantiateClass(attributes.<WaitStrategy>getClass("strategy")))
+			.addPropertyValue("strategyBeanName", attributes.getString("strategyBeanName"))
 			.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 
 		AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
@@ -89,34 +89,6 @@ class ClassPathDisruptorScanner extends AnnotationBeanDefinitionScanner<Disrupto
 			return new BeanDefinitionHolder(beanDefinition, beanName);
 		}
 		return null;
-	}
-
-	private int bufferSize(AnnotationAttributes attributes) {
-		return attributes.getNumber("bufferSize").intValue();
-	}
-
-	private ProducerType type(AnnotationAttributes attributes) {
-		return attributes.getEnum("type");
-	}
-
-	private ThreadFactory threadFactory(AnnotationAttributes attributes) {
-		return BeanUtils.instantiateClass(attributes.<ThreadFactory>getClass("threadFactory"));
-	}
-
-	private String threadFactoryBeanName(AnnotationAttributes attributes) {
-		return attributes.getString("threadFactoryBeanName");
-	}
-
-	private boolean useVirtualThreads(AnnotationAttributes attributes) {
-		return attributes.getBoolean("useVirtualThreads");
-	}
-
-	private WaitStrategy strategy(AnnotationAttributes attributes) {
-		return BeanUtils.instantiateClass(attributes.<WaitStrategy>getClass("strategy"));
-	}
-
-	private String strategyBeanName(AnnotationAttributes attributes) {
-		return attributes.getString("strategyBeanName");
 	}
 
 }

--- a/spring-extension-context/src/main/java/com/livk/context/disruptor/factory/DisruptorFactoryBean.java
+++ b/spring-extension-context/src/main/java/com/livk/context/disruptor/factory/DisruptorFactoryBean.java
@@ -95,6 +95,7 @@ public class DisruptorFactoryBean<T>
 		Assert.notNull(factory, "threadFactory must not be null");
 		WaitStrategy strategy = getWaitStrategy();
 		Assert.notNull(strategy, "waitStrategy must not be null");
+		Assert.notNull(producerType, "producerType must not be null");
 		disruptor = new SpringDisruptor<>(eventFactory, bufferSize, factory, producerType, strategy);
 		disruptor.handleEventsWith(createEventHandler(beanFactory, type));
 		disruptor.start();

--- a/spring-extension-context/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTest.java
@@ -13,15 +13,13 @@
 
 package com.livk.context.disruptor.factory;
 
-import com.livk.commons.util.AnnotationUtils;
 import com.livk.context.disruptor.DisruptorConfig;
 import com.livk.context.disruptor.Entity;
 import com.livk.context.disruptor.annotation.DisruptorEvent;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.annotation.AnnotationAttributes;
-import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,12 +35,17 @@ class DisruptorFactoryBeanTest {
 
 	@Test
 	void test() {
-		DisruptorFactoryBean<Entity> factoryBean = new DisruptorFactoryBean<>();
-		AnnotationMetadata metadata = AnnotationMetadata.introspect(Entity.class);
-		AnnotationAttributes attributes = AnnotationUtils.attributesFor(metadata, DisruptorEvent.class);
-		factoryBean.setType(Entity.class);
-		factoryBean.setAttributes(attributes);
+		DisruptorFactoryBean<Entity> factoryBean = new DisruptorFactoryBean<>(Entity.class);
+		DisruptorEvent event = Entity.class.getAnnotation(DisruptorEvent.class);
 		factoryBean.setBeanFactory(beanFactory);
+		assertNotNull(event);
+		factoryBean.setBufferSize(event.bufferSize());
+		factoryBean.setProducerType(event.type());
+		factoryBean.setThreadFactory(BeanUtils.instantiateClass(event.threadFactory()));
+		factoryBean.setThreadFactoryBeanName(event.threadFactoryBeanName());
+		factoryBean.setUseVirtualThreads(event.useVirtualThreads());
+		factoryBean.setWaitStrategy(BeanUtils.instantiateClass(event.strategy()));
+		factoryBean.setStrategyBeanName(event.strategyBeanName());
 		factoryBean.afterPropertiesSet();
 		assertNotNull(factoryBean.getObject());
 	}


### PR DESCRIPTION
好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

重构 disruptor bean 工厂设置，分离职责，用显式配置替换注解属性处理，更新扫描器和测试以匹配新的 API，并简化构建插件中的 jar 打包依赖。

增强功能：
- 重构 `DisruptorFactoryBean` 以接受构造函数注入的类型，并通过显式属性配置缓冲区大小、生产者类型、等待策略、线程工厂和虚拟线程使用
- 修订 `ClassPathDisruptorScanner` 以使用构造函数参数和单独的属性映射注册 `DisruptorFactoryBean` 定义，而不是原始注解属性

构建：
- 使 jar 任务依赖于资源提取任务，并配置 meta-inf 资源而不使用 `afterEvaluate`

测试：
- 调整 `DisruptorFactoryBeanTest` 以通过新的构造函数和 setter 实例化 `DisruptorFactoryBean` 以进行配置

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

通过使用显式的构造函数参数和属性设置器替换基于注解的配置，分离 disruptor bean 的创建职责；相应地更新扫描器、测试和构建插件。

增强功能：
- 重构 DisruptorFactoryBean 以通过构造函数接受类型，并通过显式属性配置缓冲区大小、生产者类型、等待策略、线程工厂和虚拟线程使用
- 修改 ClassPathDisruptorScanner 以使用构造函数参数和属性映射而不是注解属性来注册 DisruptorFactoryBean 定义

构建：
- 使 Jar 任务依赖于资源提取，并直接配置 meta-inf 资源，而无需使用 afterEvaluate

测试：
- 调整 DisruptorFactoryBeanTest 以通过新的构造函数和 setter 实例化和配置 factory bean

<details>
<summary>Original summary in English</summary>

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

通过使用显式的 bean 配置替换注解属性处理来分离 disruptor bean 创建中的职责，更新扫描器以使用新的 API，相应地调整测试，并简化构建插件的 Jar 设置。

增强功能：
- 重构 DisruptorFactoryBean，使用构造函数注入事件类型，并为缓冲区大小、生产者类型、等待策略、线程工厂和虚拟线程使用显式属性
- 更新 ClassPathDisruptorScanner，通过构造函数参数和映射属性注册 DisruptorFactoryBean 定义，而不是解析注解属性

构建：
- 使 Jar 任务依赖于资源提取，并在 ModulePlugin 中直接配置 META-INF 资源，而无需使用 afterEvaluate

测试：
- 调整 DisruptorFactoryBeanTest 以使用新的构造函数和配置的 setter 来实例化 factory bean

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将注解驱动的 Disruptor bean 创建替换为显式的构造函数和基于属性的配置，更新扫描器和测试以匹配新的 API，并简化 Jar 构建插件配置

增强功能：
- 重构 DisruptorFactoryBean 以通过构造函数接受事件类型，并使用显式 setter 来设置缓冲区大小、生产者类型、等待策略、线程工厂和虚拟线程使用
- 更新 ClassPathDisruptorScanner 以使用构造函数参数和显式属性值注册 DisruptorFactoryBean 定义，而不是注解属性解析

构建：
- 使 Jar 任务依赖于资源提取，并直接配置 META-INF 资源，而无需使用 afterEvaluate

测试：
- 调整 DisruptorFactoryBeanTest 以使用新的构造函数和基于 setter 的 API 来实例化和配置工厂 bean

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace annotation-driven disruptor bean creation with explicit constructor and property-based configuration, update scanner and tests to match the new API, and simplify the Jar build plugin configuration

Enhancements:
- Refactor DisruptorFactoryBean to accept event type via constructor and use explicit setters for buffer size, producer type, wait strategy, thread factory, and virtual thread usage
- Update ClassPathDisruptorScanner to register DisruptorFactoryBean definitions with constructor arguments and explicit property values instead of annotation attribute parsing

Build:
- Make Jar tasks depend on resource extraction and configure META-INF resources directly without using afterEvaluate

Tests:
- Adjust DisruptorFactoryBeanTest to instantiate and configure the factory bean using the new constructor and setter-based API

</details>

</details>

</details>

</details>