### PR TITLE
Refactor Redisson config and add fallback

### DIFF
--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonClientFactory.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonClientFactory.java
@@ -21,11 +21,11 @@ import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.util.Assert;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * The type Redisson client factory.
@@ -38,16 +38,17 @@ abstract class RedissonClientFactory {
 
 	private static final String REDISS_PROTOCOL_PREFIX = "rediss://";
 
-	/**
-	 * Create redisson client.
-	 * @param properties the properties
-	 * @param redisProperties the redis properties
-	 * @param configCustomizers the config customizers
-	 * @return the redisson client
-	 */
-	public static RedissonClient create(ConfigProperties properties, RedisProperties redisProperties,
+	public static RedissonClient create(RedissonProperties properties,
 			ObjectProvider<ConfigCustomizer> configCustomizers) {
-		Config config = Optional.<Config>ofNullable(properties.getConfig()).orElse(createConfig(redisProperties));
+		Config config = properties.getConfig();
+		Assert.notNull(config, "Redisson config must not be null");
+		configCustomizers.orderedStream().forEach(customizer -> customizer.customize(config));
+		return Redisson.create(config);
+	}
+
+	public static RedissonClient create(RedisProperties redisProperties,
+			ObjectProvider<ConfigCustomizer> configCustomizers) {
+		Config config = createConfig(redisProperties);
 		configCustomizers.orderedStream().forEach(customizer -> customizer.customize(config));
 		return Redisson.create(config);
 	}

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonCondition.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonCondition.java
@@ -1,0 +1,33 @@
+package com.livk.autoconfigure.redisson;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * RedissonCondition
+ * </p>
+ *
+ * @author livk
+ */
+class RedissonCondition extends SpringBootCondition {
+
+	private static final String PREFIX = RedissonProperties.PREFIX + ".config";
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		Environment environment = context.getEnvironment();
+		BindResult<Map<String, Object>> result = Binder.get(environment)
+			.bind(PREFIX, Bindable.mapOf(String.class, Object.class));
+		return new ConditionOutcome(result.isBound(), "Redisson Config is loaded");
+	}
+
+}

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
@@ -344,7 +344,7 @@ public class RedissonProperties {
 	 */
 	@EqualsAndHashCode(callSuper = true)
 	@Data
-	public static abstract class BaseMasterSlaveServers<T extends BaseMasterSlaveServersConfig<T>> extends Base<T> {
+	public abstract static class BaseMasterSlaveServers<T extends BaseMasterSlaveServersConfig<T>> extends Base<T> {
 
 		private LoadBalancer loadBalancer = new RoundRobinLoadBalancer();
 
@@ -404,7 +404,7 @@ public class RedissonProperties {
 	 * @param <T> the type parameter
 	 */
 	@Data
-	public static abstract class Base<T extends BaseConfig<T>> {
+	public abstract static class Base<T extends BaseConfig<T>> {
 
 		/**
 		 * If pooled connection not used for a <code>timeout</code> time and current

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
@@ -84,8 +84,8 @@ import java.util.function.Consumer;
  * @author livk
  */
 @Data
-@ConfigurationProperties(ConfigProperties.PREFIX)
-public class ConfigProperties {
+@ConfigurationProperties(RedissonProperties.PREFIX)
+public class RedissonProperties {
 
 	/**
 	 * The constant PREFIX.
@@ -94,14 +94,14 @@ public class ConfigProperties {
 
 	private RedissonConfig config;
 
-	public static ConfigProperties load(ConfigurableEnvironment environment) {
+	public static RedissonProperties load(ConfigurableEnvironment environment) {
 		Iterable<ConfigurationPropertySource> sources = ConfigurationPropertySources.get(environment);
 		ConfigurableConversionService conversionService = environment.getConversionService();
 		PlaceholdersResolver resolver = new PropertySourcesPlaceholdersResolver(environment);
 		Consumer<PropertyEditorRegistry> consumer = registry -> new RedissonPropertyEditorRegistrar()
 			.registerCustomEditors(registry);
 		Binder binder = new Binder(sources, resolver, conversionService, consumer);
-		return binder.bind(ConfigProperties.PREFIX, ConfigProperties.class).orElse(new ConfigProperties());
+		return binder.bind(RedissonProperties.PREFIX, RedissonProperties.class).orElse(new RedissonProperties());
 	}
 
 	/**

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonAutoConfigurationTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonAutoConfigurationTest.java
@@ -70,11 +70,11 @@ class RedissonAutoConfigurationTest {
 
 	@Test
 	void fallbackRedissonClient() {
-		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		new ApplicationContextRunner()
 			.withPropertyValues("spring.data.redis.host=" + redis.getHost(),
 					"spring.data.redis.port=" + redis.getFirstMappedPort())
-			.withConfiguration(AutoConfigurations.of(RedissonAutoConfiguration.class));
-		contextRunner.run((context) -> assertThat(context).hasSingleBean(RedissonClient.class));
+			.withConfiguration(AutoConfigurations.of(RedissonAutoConfiguration.class))
+			.run((context) -> assertThat(context).hasSingleBean(RedissonClient.class));
 	}
 
 	@Test

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonClientFactoryTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonClientFactoryTest.java
@@ -62,21 +62,20 @@ class RedissonClientFactoryTest {
 	@Autowired
 	ObjectProvider<ConfigCustomizer> configCustomizers;
 
-	ConfigProperties configProperties;
+	RedissonProperties redissonProperties;
 
 	RedisProperties redisProperties;
 
 	@BeforeEach
 	void before() {
-		this.configProperties = ConfigProperties.load(environment);
+		this.redissonProperties = RedissonProperties.load(environment);
 
 		this.redisProperties = Binder.get(environment).bind("spring.data.redis", RedisProperties.class).get();
 	}
 
 	@Test
 	void createTest() {
-		RedissonClient redissonClient = RedissonClientFactory.create(configProperties, new RedisProperties(),
-				configCustomizers);
+		RedissonClient redissonClient = RedissonClientFactory.create(redissonProperties, configCustomizers);
 
 		assertNotNull(redissonClient);
 		redissonClient.shutdown();
@@ -84,8 +83,7 @@ class RedissonClientFactoryTest {
 
 	@Test
 	void createByRedisPropertiesTest() {
-		RedissonClient redissonClient = RedissonClientFactory.create(new ConfigProperties(), redisProperties,
-				configCustomizers);
+		RedissonClient redissonClient = RedissonClientFactory.create(redisProperties, configCustomizers);
 
 		assertNotNull(redissonClient);
 		redissonClient.shutdown();

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertiesTest.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertiesTest.java
@@ -31,14 +31,14 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 @SpringJUnitConfig
 @TestPropertySource(properties = { "spring.redisson.config.single-server-config.address=redis://livk.com:6379",
 		"spring.redisson.config.codec=!<org.redisson.codec.JsonJacksonCodec> {}" })
-class ConfigPropertiesTest {
+class RedissonPropertiesTest {
 
 	@Autowired
 	ConfigurableEnvironment environment;
 
 	@Test
 	void test() {
-		ConfigProperties properties = ConfigProperties.load(environment);
+		RedissonProperties properties = RedissonProperties.load(environment);
 		assertEquals("redis://livk.com:6379", properties.getConfig().useSingleServer().getAddress());
 		assertInstanceOf(JsonJacksonCodec.class, properties.getConfig().getCodec());
 		assertInstanceOf(DefaultNettyHook.class, properties.getConfig().getNettyHook());


### PR DESCRIPTION
好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

重构 Redisson 自动配置，利用新的 RedissonProperties 以及条件 primary 和 fallback bean，并更新了相应的工厂和测试

**新特性:**

- 引入 RedissonCondition，以便在存在 RedissonProperties.config 的情况下有条件地注册 RedissonClient bean
- 添加 fallback RedissonClient bean，在未提供自定义 RedissonProperties.config 时使用 RedisProperties

**增强:**

- 将 ConfigProperties 重命名为 RedissonProperties 并更新配置前缀
- 将 RedissonClientFactory.create 拆分为 RedissonProperties 和 RedisProperties 的单独重载

**测试:**

- 更新测试以使用 RedissonProperties 而不是 ConfigProperties
- 添加 fallbackRedissonClient 测试以验证回退行为

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Redisson auto-configuration to leverage new RedissonProperties with conditional primary and fallback beans, plus corresponding factory and test updates

New Features:
- Introduce RedissonCondition to conditionally register a RedissonClient bean based on presence of RedissonProperties.config
- Add fallback RedissonClient bean that uses RedisProperties when no custom RedissonProperties.config is provided

Enhancements:
- Rename ConfigProperties to RedissonProperties and update the configuration prefix
- Split RedissonClientFactory.create into separate overloads for RedissonProperties and RedisProperties

Tests:
- Update tests to use RedissonProperties instead of ConfigProperties
- Add a fallbackRedissonClient test to verify fallback behavior

</details>