### PR TITLE
Refactor MapStruct integration and add tests

### DIFF
--- a/spring-extension-context/src/main/java/com/livk/context/mapstruct/AbstractMapstructService.java
+++ b/spring-extension-context/src/main/java/com/livk/context/mapstruct/AbstractMapstructService.java
@@ -57,15 +57,19 @@ public abstract class AbstractMapstructService implements MapstructService, Maps
 		throw new ConverterNotFoundException(source + " to class " + targetType + " not found converter");
 	}
 
-	private <S, T> Converter<S, T> getConverter(Class<S> sourceType, Class<T> targetType) {
+	protected <S, T> Converter<S, T> getConverter(Class<S> sourceType, Class<T> targetType) {
 		ConverterPair converterPair = ConverterPair.of(sourceType, targetType);
-		return mapstructLocator.get(converterPair);
+		Converter<S, T> converter = mapstructLocator.get(converterPair);
+		if (converter != null) {
+			return this.addConverter(converter);
+		}
+		return null;
 	}
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		ObjectProvider<MapstructLocator> mapstructLocators = applicationContext.getBeanProvider(MapstructLocator.class);
-		this.mapstructLocator = new PrioritizedMapstructLocator(this, mapstructLocators);
+		this.mapstructLocator = new PrioritizedMapstructLocator(mapstructLocators.orderedStream().toList());
 	}
 
 }

--- a/spring-extension-context/src/main/java/com/livk/context/mapstruct/GenericMapstructService.java
+++ b/spring-extension-context/src/main/java/com/livk/context/mapstruct/GenericMapstructService.java
@@ -39,4 +39,16 @@ public class GenericMapstructService extends AbstractMapstructService implements
 		return converterRepository.computeIfAbsent(converterPair, converter);
 	}
 
+	@Override
+	protected <S, T> Converter<S, T> getConverter(Class<S> sourceType, Class<T> targetType) {
+		Converter<S, T> converter = super.getConverter(sourceType, targetType);
+		if (converter == null) {
+			converter = converterRepository.get(ConverterPair.of(sourceType, targetType));
+		}
+		if (converter != null) {
+			this.addConverter(converter);
+		}
+		return converter;
+	}
+
 }

--- a/spring-extension-context/src/main/java/com/livk/context/mapstruct/PrioritizedMapstructLocator.java
+++ b/spring-extension-context/src/main/java/com/livk/context/mapstruct/PrioritizedMapstructLocator.java
@@ -18,50 +18,28 @@ package com.livk.context.mapstruct;
 
 import com.livk.context.mapstruct.converter.Converter;
 import com.livk.context.mapstruct.converter.ConverterPair;
-import com.livk.context.mapstruct.converter.MapstructRegistry;
-import com.livk.context.mapstruct.repository.ConverterRepository;
 import com.livk.context.mapstruct.repository.MapstructLocator;
-import org.springframework.beans.factory.ObjectProvider;
+import lombok.RequiredArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * @author livk
  */
+@RequiredArgsConstructor
 class PrioritizedMapstructLocator implements MapstructLocator {
 
-	private final MapstructRegistry mapstructRegistry;
-
-	private final List<MapstructLocator> mapstructLocators = new ArrayList<>();
-
-	private ConverterRepository converterRepository;
-
-	public PrioritizedMapstructLocator(MapstructRegistry mapstructRegistry,
-			ObjectProvider<MapstructLocator> mapstructLocatorObjectProvider) {
-		this.mapstructRegistry = mapstructRegistry;
-		for (MapstructLocator mapstructLocator : mapstructLocatorObjectProvider.orderedStream().toList()) {
-			if (mapstructLocator instanceof ConverterRepository repository) {
-				this.converterRepository = repository;
-			}
-			else {
-				mapstructLocators.add(mapstructLocator);
-			}
-		}
-	}
+	private final List<MapstructLocator> mapstructLocators;
 
 	@Override
 	public <S, T> Converter<S, T> get(ConverterPair converterPair) {
-		Converter<S, T> converter = converterRepository.get(converterPair);
-		if (converter == null) {
-			for (MapstructLocator mapstructLocator : mapstructLocators) {
-				converter = mapstructLocator.get(converterPair);
-				if (converter != null) {
-					return mapstructRegistry.addConverter(converterPair, converter);
-				}
+		for (MapstructLocator mapstructLocator : mapstructLocators) {
+			Converter<S, T> converter = mapstructLocator.get(converterPair);
+			if (converter != null) {
+				return converter;
 			}
 		}
-		return converter;
+		return null;
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/GenericMapstructServiceTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/GenericMapstructServiceTest.java
@@ -1,0 +1,77 @@
+package com.livk.context.mapstruct;
+
+import com.livk.context.mapstruct.converter.Converter;
+import com.livk.context.mapstruct.repository.InMemoryConverterRepository;
+import com.livk.context.mapstruct.repository.SpringMapstructLocator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author livk
+ */
+@SpringJUnitConfig(classes = GenericMapstructServiceTest.Config.class)
+class GenericMapstructServiceTest {
+
+	@Autowired
+	private GenericMapstructService service;
+
+	@Test
+	void test() {
+		DoubleConverter converter = new DoubleConverter();
+
+		assertEquals(converter, service.addConverter(converter));
+
+		assertEquals(123, service.convert("123", Integer.class));
+		assertEquals(123L, service.convert("123", Long.class));
+		assertEquals(123.1, service.convert("123.1", Double.class));
+
+		assertEquals("123", service.convert(123, String.class));
+		assertEquals("123", service.convert(123L, String.class));
+		assertEquals("123.1", service.convert(123.1, String.class));
+	}
+
+	@TestConfiguration
+	static class Config {
+
+		@Bean
+		public IntConverter intConverter() {
+			return new IntConverter();
+		}
+
+		@Bean
+		public LongConverter longConverter() {
+			return new LongConverter();
+		}
+
+		@Bean
+		public SpringMapstructLocator springMapstructLocator() {
+			return new SpringMapstructLocator();
+		}
+
+		@Bean
+		public GenericMapstructService mapstructService() {
+			return new GenericMapstructService(new InMemoryConverterRepository());
+		}
+
+	}
+
+	static class DoubleConverter implements Converter<Double, String> {
+
+		@Override
+		public Double getSource(String s) {
+			return Double.parseDouble(s);
+		}
+
+		@Override
+		public String getTarget(Double d) {
+			return d.toString();
+		}
+
+	}
+
+}

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/IntConverter.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/IntConverter.java
@@ -1,0 +1,20 @@
+package com.livk.context.mapstruct;
+
+import com.livk.context.mapstruct.converter.Converter;
+
+/**
+ * @author livk
+ */
+public class IntConverter implements Converter<Integer, String> {
+
+	@Override
+	public Integer getSource(String s) {
+		return Integer.parseInt(s);
+	}
+
+	@Override
+	public String getTarget(Integer i) {
+		return i.toString();
+	}
+
+}

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/LongConverter.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/LongConverter.java
@@ -1,0 +1,20 @@
+package com.livk.context.mapstruct;
+
+import com.livk.context.mapstruct.converter.Converter;
+
+/**
+ * @author livk
+ */
+public class LongConverter implements Converter<Long, String> {
+
+	@Override
+	public Long getSource(String s) {
+		return Long.parseLong(s);
+	}
+
+	@Override
+	public String getTarget(Long l) {
+		return l.toString();
+	}
+
+}

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/converter/ConverterPairTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/converter/ConverterPairTest.java
@@ -1,0 +1,41 @@
+package com.livk.context.mapstruct.converter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author livk
+ */
+class ConverterPairTest {
+
+	@Test
+	void of() {
+		ConverterPair pair = ConverterPair.of(String.class, Object.class);
+
+		assertEquals(String.class, pair.getSourceType());
+		assertEquals(Object.class, pair.getTargetType());
+
+		ConverterPair converterPair = ConverterPair.of(new TestConverter());
+
+		assertNotNull(converterPair);
+		assertEquals(String.class, converterPair.getSourceType());
+		assertEquals(Object.class, converterPair.getTargetType());
+	}
+
+	static class TestConverter implements Converter<String, Object> {
+
+		@Override
+		public String getSource(Object o) {
+			return o.toString();
+		}
+
+		@Override
+		public Object getTarget(String s) {
+			return s;
+		}
+
+	}
+
+}

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/InMemoryConverterRepositoryTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/InMemoryConverterRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.livk.context.mapstruct.repository;
+
+import com.livk.context.mapstruct.IntConverter;
+import com.livk.context.mapstruct.LongConverter;
+import com.livk.context.mapstruct.converter.Converter;
+import com.livk.context.mapstruct.converter.ConverterPair;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author livk
+ */
+class InMemoryConverterRepositoryTest {
+
+	@Test
+	void test() {
+		InMemoryConverterRepository repository = new InMemoryConverterRepository();
+		IntConverter intConverter = new IntConverter();
+		LongConverter longConverter = new LongConverter();
+		repository.put(ConverterPair.of(Integer.class, String.class), intConverter);
+		Converter<Long, String> result = repository.computeIfAbsent(ConverterPair.of(Long.class, String.class),
+				longConverter);
+
+		assertNotNull(result);
+
+		assertTrue(repository.contains(ConverterPair.of(Integer.class, String.class)));
+		assertTrue(repository.contains(Integer.class, String.class));
+		assertFalse(repository.contains(ConverterPair.of(String.class, Integer.class)));
+		assertFalse(repository.contains(String.class, Integer.class));
+
+		assertTrue(repository.contains(ConverterPair.of(Long.class, String.class)));
+		assertTrue(repository.contains(Long.class, String.class));
+		assertFalse(repository.contains(ConverterPair.of(String.class, Long.class)));
+		assertFalse(repository.contains(String.class, Long.class));
+
+		assertEquals(intConverter, repository.<Integer, String>get(ConverterPair.of(Integer.class, String.class)));
+		assertEquals(longConverter, repository.<Long, String>get(ConverterPair.of(Long.class, String.class)));
+	}
+
+}

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/SpringMapstructLocatorTest.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/SpringMapstructLocatorTest.java
@@ -1,0 +1,49 @@
+package com.livk.context.mapstruct.repository;
+
+import com.livk.context.mapstruct.IntConverter;
+import com.livk.context.mapstruct.LongConverter;
+import com.livk.context.mapstruct.converter.ConverterPair;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author livk
+ */
+@SpringJUnitConfig(classes = SpringMapstructLocatorTest.Config.class)
+class SpringMapstructLocatorTest {
+
+	@Autowired
+	MapstructLocator mapstructLocator;
+
+	@Test
+	void test() {
+		assertNotNull(mapstructLocator.get(ConverterPair.of(Integer.class, String.class)));
+		assertNotNull(mapstructLocator.get(ConverterPair.of(Long.class, String.class)));
+	}
+
+	@TestConfiguration
+	static class Config {
+
+		@Bean
+		public IntConverter intConverter() {
+			return new IntConverter();
+		}
+
+		@Bean
+		public LongConverter longConverter() {
+			return new LongConverter();
+		}
+
+		@Bean
+		public SpringMapstructLocator springMapstructLocator() {
+			return new SpringMapstructLocator();
+		}
+
+	}
+
+}


### PR DESCRIPTION
好的，这是将给定的 Pull Request 总结翻译成中文的结果：

## Sourcery 总结

重构 MapStruct 集成，以简化定位器配置，集中转换器查找和缓存于服务内部，并用简化的基于列表的定位器方法替换基于注册表的缓存。整合 AbstractMapstructService 和 GenericMapstructService 中的 getConverter 逻辑，并为核心组件添加全面的单元测试。

增强功能：
- 简化 PrioritizedMapstructLocator，移除注册表和存储库依赖，并注入一个已排序的定位器列表。
- 通过重写 getConverter 以自动添加找到的转换器，将转换器查找和缓存集中在 GenericMapstructService 和 AbstractMapstructService 中。
- 通过从定位器列表构建 PrioritizedMapstructLocator，简化服务初始化。

测试：
- 添加 GenericMapstructServiceTest，覆盖转换器的添加和转换。
- 添加 SpringMapstructLocatorTest，以验证基于 Spring 的定位器解析。
- 添加 InMemoryConverterRepositoryTest，以验证存储库的存储、检索和包含性检查。
- 添加 ConverterPairTest，以验证 ConverterPair 的创建和类型提取。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor MapStruct integration to simplify locator configuration, centralize converter lookup and caching within the service, and replace registry-based caching with a streamlined list-based locator approach. Consolidate getConverter logic across AbstractMapstructService and GenericMapstructService, and add comprehensive unit tests for core components.

Enhancements:
- Simplify PrioritizedMapstructLocator by removing registry and repository dependencies and injecting an ordered list of locators.
- Centralize converter lookup and caching in GenericMapstructService and AbstractMapstructService by overriding getConverter to auto-add found converters.
- Streamline service initialization by constructing PrioritizedMapstructLocator from a list of locators.

Tests:
- Add GenericMapstructServiceTest covering converter addition and conversions.
- Add SpringMapstructLocatorTest to validate Spring-based locator resolution.
- Add InMemoryConverterRepositoryTest to verify repository storage, retrieval, and containment checks.
- Add ConverterPairTest to validate ConverterPair creation and type extraction.

</details>