### PR TITLE
Refactor annotation processing framework

### DIFF
--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/AbstractFactoriesProcessor.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/AbstractFactoriesProcessor.java
@@ -8,7 +8,6 @@ import com.google.common.collect.SetMultimap;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
@@ -21,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -57,35 +55,19 @@ abstract class AbstractFactoriesProcessor extends CustomizeAbstractProcessor {
 	}
 
 	@Override
-	protected void processAnnotations(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-		Set<? extends Element> elements = this.getElements(roundEnv);
-		log(annotations.toString());
-		log(elements.toString());
-		for (Element element : elements) {
-			Optional<Set<TypeElement>> value = this.getAnnotationAttributes(element);
-			for (TypeElement typeElement : value.orElseGet(() -> Set.of(fromInterface(element)))) {
-				String provider = TypeElements.getBinaryName(typeElement);
-				if (provider == null || provider.isBlank()) {
-					throw new IllegalArgumentException("current " + element + "missing @SpringFactories 'value'");
-				}
-				String serviceImpl = TypeElements.getBinaryName((TypeElement) element);
-				factoriesMap.put(provider, serviceImpl);
-			}
-		}
-	}
-
-	protected abstract Set<? extends Element> getElements(RoundEnvironment roundEnv);
-
-	protected abstract Optional<Set<TypeElement>> getAnnotationAttributes(Element element);
-
-	private TypeElement fromInterface(Element element) {
+	protected Set<TypeElement> elseElement(Element element) {
 		if (element instanceof TypeElement typeElement) {
 			List<? extends TypeMirror> interfaces = typeElement.getInterfaces();
 			if (interfaces != null && interfaces.size() == 1) {
-				return MoreTypes.asTypeElement(interfaces.getFirst());
+				return Set.of(MoreTypes.asTypeElement(interfaces.getFirst()));
 			}
 		}
-		return null;
+		return Set.of();
+	}
+
+	@Override
+	protected void storage(String provider, String serviceImpl) {
+		factoriesMap.put(provider, serviceImpl);
 	}
 
 	/**

--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/AotFactoriesProcessor.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/AotFactoriesProcessor.java
@@ -4,11 +4,7 @@ import com.google.auto.service.AutoService;
 import com.livk.auto.service.annotation.AotFactories;
 
 import javax.annotation.processing.Processor;
-import javax.annotation.processing.RoundEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import java.util.Optional;
-import java.util.Set;
+import java.lang.annotation.Annotation;
 
 /**
  * @author livk
@@ -25,18 +21,8 @@ public class AotFactoriesProcessor extends AbstractFactoriesProcessor {
 	}
 
 	@Override
-	protected Set<Class<?>> getSupportedAnnotation() {
-		return Set.of(SUPPORT_CLASS);
-	}
-
-	@Override
-	protected Set<? extends Element> getElements(RoundEnvironment roundEnv) {
-		return roundEnv.getElementsAnnotatedWith(SUPPORT_CLASS);
-	}
-
-	@Override
-	protected Optional<Set<TypeElement>> getAnnotationAttributes(Element element) {
-		return TypeElements.getAnnotationAttributes(element, SUPPORT_CLASS, VALUE);
+	protected Class<? extends Annotation> getSupportedAnnotation() {
+		return SUPPORT_CLASS;
 	}
 
 }

--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/SpringAutoServiceProcessor.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/SpringAutoServiceProcessor.java
@@ -23,7 +23,6 @@ import com.google.common.collect.SetMultimap;
 import com.livk.auto.service.annotation.SpringAutoService;
 
 import javax.annotation.processing.Processor;
-import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.FileObject;
@@ -31,10 +30,10 @@ import javax.tools.StandardLocation;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,8 +58,8 @@ public class SpringAutoServiceProcessor extends CustomizeAbstractProcessor {
 		.synchronizedSetMultimap(LinkedHashMultimap.create());
 
 	@Override
-	protected Set<Class<?>> getSupportedAnnotation() {
-		return Set.of(SUPPORT_CLASS);
+	protected Class<? extends Annotation> getSupportedAnnotation() {
+		return SUPPORT_CLASS;
 	}
 
 	@Override
@@ -88,21 +87,13 @@ public class SpringAutoServiceProcessor extends CustomizeAbstractProcessor {
 	}
 
 	@Override
-	protected void processAnnotations(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-		Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(SUPPORT_CLASS);
-		log(annotations.toString());
-		log(elements.toString());
-		for (Element element : elements) {
-			Optional<Set<TypeElement>> value = TypeElements.getAnnotationAttributes(element, SUPPORT_CLASS, VALUE);
-			for (TypeElement typeElement : value.orElse(autoConfigurationElement())) {
-				String provider = TypeElements.getBinaryName(typeElement);
-				importsMap.put(provider, TypeElements.getBinaryName((TypeElement) element));
-			}
-		}
+	protected Set<TypeElement> elseElement(Element element) {
+		return Set.of(elements.getTypeElement(AUTOCONFIGURATION));
 	}
 
-	private Set<TypeElement> autoConfigurationElement() {
-		return Set.of(elements.getTypeElement(AUTOCONFIGURATION));
+	@Override
+	protected void storage(String provider, String serviceImpl) {
+		importsMap.put(provider, serviceImpl);
 	}
 
 	/**

--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/SpringFactoriesProcessor.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/SpringFactoriesProcessor.java
@@ -20,11 +20,7 @@ import com.google.auto.service.AutoService;
 import com.livk.auto.service.annotation.SpringFactories;
 
 import javax.annotation.processing.Processor;
-import javax.annotation.processing.RoundEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import java.util.Optional;
-import java.util.Set;
+import java.lang.annotation.Annotation;
 
 /**
  * <p>
@@ -45,18 +41,8 @@ public class SpringFactoriesProcessor extends AbstractFactoriesProcessor {
 	}
 
 	@Override
-	protected Set<Class<?>> getSupportedAnnotation() {
-		return Set.of(SUPPORT_CLASS);
-	}
-
-	@Override
-	protected Set<? extends Element> getElements(RoundEnvironment roundEnv) {
-		return roundEnv.getElementsAnnotatedWith(SUPPORT_CLASS);
-	}
-
-	@Override
-	protected Optional<Set<TypeElement>> getAnnotationAttributes(Element element) {
-		return TypeElements.getAnnotationAttributes(element, SUPPORT_CLASS, VALUE);
+	protected Class<? extends Annotation> getSupportedAnnotation() {
+		return SUPPORT_CLASS;
 	}
 
 }

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTest.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTest.java
@@ -34,6 +34,7 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -59,8 +60,7 @@ class TypeElementsTest {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
 
-		JavaFileObject file = new SimpleJavaFileObject(java.net.URI.create("string:///Dummy.java"),
-				JavaFileObject.Kind.SOURCE) {
+		JavaFileObject file = new SimpleJavaFileObject(URI.create("string:///Dummy.java"), JavaFileObject.Kind.SOURCE) {
 			@Override
 			public CharSequence getCharContent(boolean ignoreEncodingErrors) {
 				return "final class Dummy {}";
@@ -74,6 +74,8 @@ class TypeElementsTest {
 		task.analyze();
 
 		elements = task.getElements();
+
+		fileManager.close();
 	}
 
 	@Test

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTest.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTest.java
@@ -58,24 +58,24 @@ class TypeElementsTest {
 	@BeforeAll
 	static void init() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-		StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+		try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
 
-		JavaFileObject file = new SimpleJavaFileObject(URI.create("string:///Dummy.java"), JavaFileObject.Kind.SOURCE) {
-			@Override
-			public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-				return "final class Dummy {}";
-			}
-		};
+			JavaFileObject file = new SimpleJavaFileObject(URI.create("string:///Dummy.java"),
+					JavaFileObject.Kind.SOURCE) {
+				@Override
+				public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+					return "final class Dummy {}";
+				}
+			};
 
-		JavacTask task = (JavacTask) compiler.getTask(null, fileManager, null, List.of("-proc:none"), null,
-				List.of(file));
+			JavacTask task = (JavacTask) compiler.getTask(null, fileManager, null, List.of("-proc:none"), null,
+					List.of(file));
 
-		task.parse();
-		task.analyze();
+			task.parse();
+			task.analyze();
 
-		elements = task.getElements();
-
-		fileManager.close();
+			elements = task.getElements();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Sourcery 总结

重构注解处理框架，以整合重复的逻辑，在 `CustomizeAbstractProcessor` 中引入通用的处理流程，并简化所有处理器子类中对支持的注解的处理。

增强功能：
- 统一注解处理，通过将核心处理循环移至 `CustomizeAbstractProcessor` 中，并使用抽象的 `storage()` 和 `elseElement()` 方法。
- 更改 `getSupportedAnnotation` 以返回单个 `Annotation` 类，并简化 `getSupportedAnnotationTypes` 以使用单例集合。
- 删除特定处理器中冗余的 `getElements()` 和 `getAnnotationAttributes()` 重写，利用通用实现。
- 更新 `AbstractFactoriesProcessor`、`SpringAutoServiceProcessor`、`AotFactoriesProcessor` 和 `SpringFactoriesProcessor` 以采用新的 `storage/elseElement` 抽象并消除自定义的 `processAnnotations` 方法。

测试：
- 简化 `TypeElementsTest` 中的 `JavaFileObject` 实例化，并确保在使用后关闭文件管理器。

<details>
<summary>Original summary in English</summary>

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

重构注解处理框架，将处理逻辑集中并简化到一个新的抽象基类中，并更新现有的处理器和测试以使用统一的方法。

增强功能：
- 使用抽象的 storage() 和 elseElement() 钩子，将核心注解处理集中在 CustomizeAbstractProcessor 中
- 通过返回单个 Annotation 类并使用单例集合来处理支持的类型，从而简化对支持的注解的处理
- 删除处理器中冗余的 getElements、getAnnotationAttributes 和 processAnnotations 重写，以利用通用实现
- 调整 AbstractFactoriesProcessor、SpringAutoServiceProcessor、AotFactoriesProcessor 和 SpringFactoriesProcessor 以实现 storage 和 elseElement，而不是自定义处理方法

测试：
- 简化 TypeElementsTest 中的 JavaFileObject 实例化，并确保在使用后关闭文件管理器

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the annotation processing framework to centralize and simplify the processing logic in a new abstract base class and update existing processors and tests to use the unified approach.

Enhancements:
- Centralize core annotation processing in CustomizeAbstractProcessor using abstract storage() and elseElement() hooks
- Simplify supported annotation handling by returning a single Annotation class and using a singleton set for supported types
- Remove redundant getElements, getAnnotationAttributes, and processAnnotations overrides in processors to leverage the common implementation
- Adapt AbstractFactoriesProcessor, SpringAutoServiceProcessor, AotFactoriesProcessor, and SpringFactoriesProcessor to implement storage and elseElement instead of custom processing methods

Tests:
- Simplify JavaFileObject instantiation in TypeElementsTest and ensure the file manager is closed after use

</details>

</details>