### PR TITLE
Migrate tests to AssertJ and improve resource handling

### DIFF
--- a/samples/spring-authorization-server/auth-server/src/test/java/com/livk/auth/server/AuthServerAppTest.java
+++ b/samples/spring-authorization-server/auth-server/src/test/java/com/livk/auth/server/AuthServerAppTest.java
@@ -28,8 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -71,8 +70,7 @@ class AuthServerAppTest {
 			.getResponse()
 			.getContentAsString();
 		String accessToken = JsonMapperUtils.readTree(json).get("access_token").asText();
-		assertNotNull(accessToken);
-		assertFalse(accessToken.isBlank());
+		assertThat(accessToken).isNotNull().isNotBlank();
 	}
 
 	@Test
@@ -97,8 +95,7 @@ class AuthServerAppTest {
 			.getResponse()
 			.getContentAsString();
 		String accessToken = JsonMapperUtils.readTree(json).get("access_token").asText();
-		assertNotNull(accessToken);
-		assertFalse(accessToken.isBlank());
+		assertThat(accessToken).isNotNull().isNotBlank();
 	}
 
 }

--- a/samples/spring-batch/src/test/java/com/livk/batch/controller/JobControllerTest.java
+++ b/samples/spring-batch/src/test/java/com/livk/batch/controller/JobControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -51,7 +51,7 @@ class JobControllerTest {
 			.stream()
 			.map(map -> map.get("user_name").toString())
 			.toList();
-		assertLinesMatch(List.of("张三", "李四", "王雪", "孙云", "赵柳", "孙雪"), names);
+		assertThat(names).containsExactly("张三", "李四", "王雪", "孙云", "赵柳", "孙雪");
 	}
 
 }

--- a/samples/spring-boot-web-scope/src/test/java/com/livk/spring/FilterControllerTest.java
+++ b/samples/spring-boot-web-scope/src/test/java/com/livk/spring/FilterControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -53,7 +53,7 @@ class FilterControllerTest {
 			.getResponse()
 			.getContentAsString();
 
-		assertNotEquals(uuid1, uuid2);
+		assertThat(uuid1).isNotEqualTo(uuid2);
 	}
 
 }

--- a/samples/spring-graphql/spring-graphql-mybatis/src/test/java/com/livk/graphql/mybatis/controller/BookControllerTest.java
+++ b/samples/spring-graphql/spring-graphql-mybatis/src/test/java/com/livk/graphql/mybatis/controller/BookControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.graphql.test.tester.HttpGraphQlTester;
 import org.springframework.graphql.test.tester.WebGraphQlTester;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -34,8 +35,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -68,7 +68,6 @@ class BookControllerTest {
 
 	@Order(3)
 	@Test
-	@SuppressWarnings("rawtypes")
 	void list() {
 		// language=GraphQL
 		String document = """
@@ -80,8 +79,13 @@ class BookControllerTest {
 				        }
 				    }
 				}""";
-		List<Map> result = tester.document(document).execute().path("bookList").entityList(Map.class).get();
-		assertNotNull(result);
+		List<Map<String, Object>> result = tester.document(document)
+			.execute()
+			.path("bookList")
+			.entityList(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(result).isNotNull().isNotEmpty();
 
 		// language=GraphQL
 		String d1 = """
@@ -95,13 +99,17 @@ class BookControllerTest {
 				    }
 				  }
 				}""";
-		List<Map> r1 = tester.document(d1).execute().path("bookList").entityList(Map.class).get();
-		assertNotNull(r1);
+		List<Map<String, Object>> r1 = tester.document(d1)
+			.execute()
+			.path("bookList")
+			.entityList(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(r1).isNotNull().isNotEmpty();
 	}
 
 	@Order(4)
 	@Test
-	@SuppressWarnings("rawtypes")
 	void bookByIsbn() {
 		// language=GraphQL
 		String document = """
@@ -115,8 +123,13 @@ class BookControllerTest {
 				        }
 				    }
 				}""";
-		Map result = tester.document(document).execute().path("bookByIsbn").entity(Map.class).get();
-		assertNotNull(result);
+		Map<String, Object> result = tester.document(document)
+			.execute()
+			.path("bookByIsbn")
+			.entity(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(result).isNotNull().isNotEmpty();
 	}
 
 	@Order(2)
@@ -155,13 +168,13 @@ class BookControllerTest {
 				}""";
 
 		Boolean r1 = tester.document(d1).execute().path("createBook").entity(Boolean.class).get();
-		assertTrue(r1);
+		assertThat(r1).isTrue();
 
 		Boolean r2 = tester.document(d2).execute().path("createBook").entity(Boolean.class).get();
-		assertTrue(r2);
+		assertThat(r2).isTrue();
 
 		Boolean r3 = tester.document(d3).execute().path("createBook").entity(Boolean.class).get();
-		assertTrue(r3);
+		assertThat(r3).isTrue();
 	}
 
 	@Order(1)
@@ -178,7 +191,7 @@ class BookControllerTest {
 				    })
 				}""";
 		Boolean result = tester.document(document).execute().path("createAuthor").entity(Boolean.class).get();
-		assertTrue(result);
+		assertThat(result).isTrue();
 		// language=GraphQL
 		String d2 = """
 				mutation{
@@ -189,7 +202,7 @@ class BookControllerTest {
 				    )
 				}""";
 		Boolean result2 = tester.document(d2).execute().path("createAuthor").entity(Boolean.class).get();
-		assertTrue(result2);
+		assertThat(result2).isTrue();
 	}
 
 }

--- a/samples/spring-graphql/spring-graphql-mybatis/src/test/java/com/livk/graphql/mybatis/controller/GreetingControllerTest.java
+++ b/samples/spring-graphql/spring-graphql-mybatis/src/test/java/com/livk/graphql/mybatis/controller/GreetingControllerTest.java
@@ -22,13 +22,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.graphql.test.tester.HttpGraphQlTester;
 import org.springframework.graphql.test.tester.WebGraphQlTester;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -53,15 +54,19 @@ class GreetingControllerTest {
 	}
 
 	@Test
-	@SuppressWarnings("rawtypes")
 	void greetings() {
 		// language=GraphQL
 		String document = """
 				subscription {
 				  greetings
 				}""";
-		Map result = tester.document(document).execute().path("upstreamPublisher").entity(Map.class).get();
-		assertNotNull(result);
+		Map<String, Object> result = tester.document(document)
+			.execute()
+			.path("upstreamPublisher")
+			.entity(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(result).isNotNull().isNotEmpty();
 	}
 
 }

--- a/samples/spring-graphql/spring-graphql-r2dbc/src/test/java/com/livk/graphql/r2dbc/controller/BookControllerTest.java
+++ b/samples/spring-graphql/spring-graphql-r2dbc/src/test/java/com/livk/graphql/r2dbc/controller/BookControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.graphql.test.tester.HttpGraphQlTester;
 import org.springframework.graphql.test.tester.WebGraphQlTester;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -42,7 +43,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -88,7 +89,6 @@ class BookControllerTest {
 
 	@Order(3)
 	@Test
-	@SuppressWarnings("rawtypes")
 	void list() {
 		// language=GraphQL
 		String document = """
@@ -100,8 +100,13 @@ class BookControllerTest {
 				        }
 				    }
 				}""";
-		List<Map> result = tester.document(document).execute().path("bookList").entityList(Map.class).get();
-		assertNotNull(result);
+		List<Map<String, Object>> result = tester.document(document)
+			.execute()
+			.path("bookList")
+			.entityList(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(result).isNotNull().isNotEmpty();
 
 		// language=GraphQL
 		String d1 = """
@@ -115,13 +120,17 @@ class BookControllerTest {
 				    }
 				  }
 				}""";
-		List<Map> r1 = tester.document(d1).execute().path("bookList").entityList(Map.class).get();
-		assertNotNull(r1);
+		List<Map<String, Object>> r1 = tester.document(d1)
+			.execute()
+			.path("bookList")
+			.entityList(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(r1).isNotNull().isNotEmpty();
 	}
 
 	@Order(4)
 	@Test
-	@SuppressWarnings("rawtypes")
 	void bookByIsbn() {
 		// language=GraphQL
 		String document = """
@@ -135,8 +144,13 @@ class BookControllerTest {
 				        }
 				    }
 				}""";
-		Map result = tester.document(document).execute().path("bookByIsbn").entity(Map.class).get();
-		assertNotNull(result);
+		Map<String, Object> result = tester.document(document)
+			.execute()
+			.path("bookByIsbn")
+			.entity(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(result).isNotNull().isNotEmpty();
 	}
 
 	@Order(2)
@@ -175,13 +189,13 @@ class BookControllerTest {
 				}""";
 
 		Book r1 = tester.document(d1).execute().path("createBook").entity(Book.class).get();
-		assertNotNull(r1);
+		assertThat(r1).isNotNull();
 
 		Book r2 = tester.document(d2).execute().path("createBook").entity(Book.class).get();
-		assertNotNull(r2);
+		assertThat(r2).isNotNull();
 
 		Book r3 = tester.document(d3).execute().path("createBook").entity(Book.class).get();
-		assertNotNull(r3);
+		assertThat(r3).isNotNull();
 	}
 
 	@Order(1)
@@ -198,7 +212,7 @@ class BookControllerTest {
 				    }){name age}
 				}""";
 		Author result = tester.document(document).execute().path("createAuthor").entity(Author.class).get();
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 		// language=GraphQL
 		String d2 = """
 				mutation{
@@ -209,7 +223,7 @@ class BookControllerTest {
 				    }){name age}
 				}""";
 		Author result2 = tester.document(d2).execute().path("createAuthor").entity(Author.class).get();
-		assertNotNull(result2);
+		assertThat(result2).isNotNull();
 	}
 
 }

--- a/samples/spring-graphql/spring-graphql-r2dbc/src/test/java/com/livk/graphql/r2dbc/controller/GreetingControllerTest.java
+++ b/samples/spring-graphql/spring-graphql-r2dbc/src/test/java/com/livk/graphql/r2dbc/controller/GreetingControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.graphql.test.tester.HttpGraphQlTester;
 import org.springframework.graphql.test.tester.WebGraphQlTester;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -34,7 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -72,15 +73,19 @@ class GreetingControllerTest {
 	}
 
 	@Test
-	@SuppressWarnings("rawtypes")
 	void greetings() {
 		// language=GraphQL
 		String document = """
 				subscription {
 				  greetings
 				}""";
-		Map result = tester.document(document).execute().path("upstreamPublisher").entity(Map.class).get();
-		assertNotNull(result);
+		Map<String, Object> result = tester.document(document)
+			.execute()
+			.path("upstreamPublisher")
+			.entity(new ParameterizedTypeReference<Map<String, Object>>() {
+			})
+			.get();
+		assertThat(result).isNotNull().isNotEmpty();
 	}
 
 }

--- a/samples/spring-kafka/src/test/java/com/livk/kafka/controller/ProducerControllerTest.java
+++ b/samples/spring-kafka/src/test/java/com/livk/kafka/controller/ProducerControllerTest.java
@@ -36,7 +36,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -66,7 +66,7 @@ class ProducerControllerTest {
 	void producer() throws Exception {
 		mockMvc.perform(get("/kafka/send")).andDo(print()).andExpect(status().isOk());
 
-		Awaitility.waitAtMost(Duration.ofMinutes(4)).untilAsserted(() -> assertEquals(3, this.messages.size()));
+		Awaitility.waitAtMost(Duration.ofMinutes(4)).untilAsserted(() -> assertThat(messages).hasSize(3));
 	}
 
 	final List<String> messages = new ArrayList<>();

--- a/samples/spring-mail/src/test/java/com/livk/mail/MailTest.java
+++ b/samples/spring-mail/src/test/java/com/livk/mail/MailTest.java
@@ -40,8 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -90,7 +89,7 @@ class MailTest {
 		Template template = configuration.getTemplate("ac.ftl");
 		String text = FreeMarkerTemplateUtils.processTemplateIntoString(template, root);
 		System.out.println(text);
-		assertNotNull(text);
+		assertThat(text).isNotBlank();
 	}
 
 	@Test
@@ -100,9 +99,9 @@ class MailTest {
 		Template template = new Template("template", new StringReader(txt), configuration);
 		String result = "www.baidu.com -> 123456";
 		String s1 = FreemarkerUtils.processTemplateIntoString(template, map);
-		assertEquals(result, s1);
+		assertThat(s1).isNotBlank().isEqualTo(result);
 		String s2 = FreemarkerUtils.parse(txt, map);
-		assertEquals(result, s2);
+		assertThat(s2).isNotBlank().isEqualTo(result);
 	}
 
 	@Test
@@ -117,7 +116,7 @@ class MailTest {
 		String resultSql = "INSERT INTO sys_user(user_name,sex,age,address,status,create_time,update_time) VALUES (livk,1,26,shenzhen,1,"
 				+ format + "," + format + "),(livk,1,26,shenzhen,1," + format + "," + format + ")";
 		String parse = parse(sql, map);
-		assertEquals(resultSql, parse);
+		assertThat(parse).isNotBlank().isEqualTo(resultSql);
 	}
 
 	private String parse(String freemarker, Map<String, Object> model) {

--- a/samples/spring-protobuf-mq/protobuf-commons/src/test/java/com/livk/proto/UserConverterTest.java
+++ b/samples/spring-protobuf-mq/protobuf-commons/src/test/java/com/livk/proto/UserConverterTest.java
@@ -16,12 +16,9 @@
 
 package com.livk.proto;
 
-import com.livk.commons.util.ObjectUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -35,9 +32,9 @@ class UserConverterTest {
 		User user = new User(1L, "root", "123456@gmail.com", 0);
 
 		byte[] bytes = converter.convert(user);
-		assertNotNull(bytes);
-		assertFalse(ObjectUtils.isEmpty(bytes));
-		assertEquals(user, converter.convert(bytes));
+
+		assertThat(bytes).isNotNull().isNotEmpty();
+		assertThat(converter.convert(bytes)).isEqualTo(user);
 	}
 
 }

--- a/samples/spring-redis/redis-caffeine/src/test/java/com/livk/caffeine/controller/CacheControllerTest.java
+++ b/samples/spring-redis/redis-caffeine/src/test/java/com/livk/caffeine/controller/CacheControllerTest.java
@@ -37,7 +37,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -90,7 +90,7 @@ class CacheControllerTest {
 				.getContentAsString();
 			result.add(newUUID);
 		}
-		assertEquals(1, result.size());
+		assertThat(result).hasSize(1);
 	}
 
 	@Test
@@ -113,7 +113,7 @@ class CacheControllerTest {
 				.getContentAsString();
 			result.add(newUUID);
 		}
-		assertEquals(3, result.size());
+		assertThat(result).hasSize(3);
 	}
 
 	@Test
@@ -133,7 +133,7 @@ class CacheControllerTest {
 		try (Cursor<String> scan = redisOps.scan(options)) {
 			Set<String> keys = scan.stream().limit(1).collect(Collectors.toSet());
 			log.info("keys:{}", keys);
-			assertEquals(1, keys.size());
+			assertThat(keys).hasSize(1);
 		}
 	}
 

--- a/samples/spring-redis/redisson-order-expired/src/test/java/com/livk/redisson/order/controller/OrderControllerTest.java
+++ b/samples/spring-redis/redisson-order-expired/src/test/java/com/livk/redisson/order/controller/OrderControllerTest.java
@@ -33,7 +33,7 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,7 +67,7 @@ class OrderControllerTest {
 	void create() throws Exception {
 		mockMvc.perform(post("/order/create")).andDo(print()).andExpect(status().isOk());
 
-		Awaitility.waitAtMost(Duration.ofMinutes(4)).untilAsserted(() -> assertTrue(consumer.isEmpty()));
+		Awaitility.waitAtMost(Duration.ofMinutes(4)).untilAsserted(() -> assertThat(consumer.isEmpty()).isTrue());
 	}
 
 }

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/AotFactoriesProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/AotFactoriesProcessorTests.java
@@ -30,8 +30,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -58,8 +57,11 @@ class AotFactoriesProcessorTests {
 						properties.load(inputStream);
 						pro.putAll(properties);
 					}
-					assertTrue(pro.containsKey(factoryClass.getName()));
-					assertEquals(type.getName(), pro.get(factoryClass.getName()));
+					String key = factoryClass.getName();
+
+					assertThat(pro).containsKey(key);
+					assertThat(pro.get(key)).isEqualTo(type.getName());
+
 				}
 				catch (IOException ex) {
 					throw new CompilationException(ex, SourceFile.forTestClass(type));

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringAutoServiceProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringAutoServiceProcessorTests.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -65,7 +65,7 @@ class SpringAutoServiceProcessorTests {
 						String[] arr = new String(FileCopyUtils.copyToByteArray(inputStream)).split("\n");
 						configList.addAll(Arrays.stream(arr).map(String::trim).toList());
 					}
-					assertTrue(configList.contains(type.getName()));
+					assertThat(configList).contains(type.getName());
 				}
 				catch (IOException ex) {
 					throw new CompilationException(ex, SourceFile.forTestClass(type));

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringFactoriesProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringFactoriesProcessorTests.java
@@ -30,8 +30,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -59,8 +58,11 @@ class SpringFactoriesProcessorTests {
 						properties.load(inputStream);
 						pro.putAll(properties);
 					}
-					assertTrue(pro.containsKey(factoryClass.getName()));
-					assertEquals(type.getName(), pro.get(factoryClass.getName()));
+					String key = factoryClass.getName();
+
+					assertThat(pro).containsKey(key);
+					assertThat(pro.get(key)).isEqualTo(type.getName());
+
 				}
 				catch (IOException ex) {
 					throw new CompilationException(ex, SourceFile.forTestClass(type));

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTests.java
@@ -40,9 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -78,20 +76,21 @@ class TypeElementsTests {
 	void getAnnotationAttributes() {
 		Optional<Set<TypeElement>> autoServiceOption = TypeElements
 			.getAnnotationAttributes(get(SpringFactoryServiceImpl.class), AutoService.class, MergedAnnotation.VALUE);
-		assertTrue(autoServiceOption.isPresent());
-		ArrayList<TypeElement> list = autoServiceOption.map(ArrayList::new).get();
-		assertFalse(list.isEmpty());
-		assertEquals(1, list.size());
-		assertEquals(SpringFactoryService.class.getName(), TypeElements.getBinaryName(list.getFirst()));
+		assertThat(autoServiceOption).isPresent().map(ArrayList::new).hasValueSatisfying(list -> {
+			assertThat(list).isNotEmpty().hasSize(1);
+			assertThat(TypeElements.getBinaryName(list.getFirst())).isEqualTo(SpringFactoryService.class.getName());
+		});
 	}
 
 	@Test
 	void getBinaryName() {
-		assertEquals(String.class.getName(), TypeElements.getBinaryName(get(String.class)));
-		assertEquals(SpringAutoContext.class.getName(), TypeElements.getBinaryName(get(SpringAutoContext.class)));
-		assertEquals(SpringContext.class.getName(), TypeElements.getBinaryName(get(SpringContext.class)));
-		assertEquals(SpringFactoryServiceImpl.class.getName(),
-				TypeElements.getBinaryName(get(SpringFactoryServiceImpl.class)));
+		List<Class<?>> classes = List.of(String.class, SpringAutoContext.class, SpringContext.class,
+				SpringFactoryServiceImpl.class);
+
+		for (Class<?> type : classes) {
+			assertThat(TypeElements.getBinaryName(get(type))).isEqualTo(type.getName());
+		}
+
 	}
 
 	static TypeElement get(Class<?> type) {

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/curator/CuratorFactoryTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/curator/CuratorFactoryTests.java
@@ -21,8 +21,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -32,15 +31,15 @@ class CuratorFactoryTests {
 	static final CuratorProperties properties = new CuratorProperties();
 
 	@Test
-	void create() throws InterruptedException {
+	void create() {
 		RetryPolicy retryPolicy = CuratorFactory.retryPolicy(properties);
 		CuratorFramework framework = CuratorFactory.create(properties, retryPolicy, () -> null, () -> null, () -> null);
-		assertNotNull(framework);
+		assertThat(framework).isNotNull();
 	}
 
 	@Test
 	void retryPolicy() {
-		assertInstanceOf(ExponentialBackoffRetry.class, CuratorFactory.retryPolicy(properties));
+		assertThat(CuratorFactory.retryPolicy(properties)).isInstanceOf(ExponentialBackoffRetry.class);
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/curator/CuratorPropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/curator/CuratorPropertiesTests.java
@@ -22,8 +22,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -33,16 +32,16 @@ class CuratorPropertiesTests {
 	@Test
 	void curatorProperties() {
 		CuratorProperties properties = new CuratorProperties();
-		assertNotNull(properties);
+		assertThat(properties).isNotNull();
 
-		assertEquals("localhost:2181", properties.getConnectString());
-		assertEquals(50, properties.getBaseSleepTimeMs());
-		assertEquals(10, properties.getMaxRetries());
-		assertEquals(500, properties.getMaxSleepMs());
-		assertEquals(10, properties.getBlockUntilConnectedWait());
-		assertEquals(TimeUnit.SECONDS, properties.getBlockUntilConnectedUnit());
-		assertEquals(Duration.of(60 * 1000, ChronoUnit.MILLIS), properties.getSessionTimeout());
-		assertEquals(Duration.of(15 * 1000, ChronoUnit.MILLIS), properties.getConnectionTimeout());
+		assertThat(properties.getConnectString()).isEqualTo("localhost:2181");
+		assertThat(properties.getBaseSleepTimeMs()).isEqualTo(50);
+		assertThat(properties.getMaxRetries()).isEqualTo(10);
+		assertThat(properties.getMaxSleepMs()).isEqualTo(500);
+		assertThat(properties.getBlockUntilConnectedWait()).isEqualTo(10);
+		assertThat(properties.getBlockUntilConnectedUnit()).isEqualTo(TimeUnit.SECONDS);
+		assertThat(properties.getSessionTimeout()).isEqualTo(Duration.of(60 * 1000, ChronoUnit.MILLIS));
+		assertThat(properties.getConnectionTimeout()).isEqualTo(Duration.of(15 * 1000, ChronoUnit.MILLIS));
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/curator/actuator/CuratorHealthIndicatorTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/curator/actuator/CuratorHealthIndicatorTests.java
@@ -27,7 +27,7 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -46,8 +46,8 @@ class CuratorHealthIndicatorTests {
 			try (CuratorFramework framework = create(properties, retryPolicy)) {
 				CuratorHealthIndicator indicator = new CuratorHealthIndicator(framework);
 				Health health = indicator.health();
-				assertEquals(Status.DOWN, health.getStatus());
-				assertEquals(properties.getConnectString(), health.getDetails().get("connectionString"));
+				assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+				assertThat(health.getDetails().get("connectionString")).isEqualTo(properties.getConnectString());
 			}
 		}
 	}
@@ -60,7 +60,7 @@ class CuratorHealthIndicatorTests {
 		try (CuratorFramework framework = create(properties, retryPolicy)) {
 			CuratorHealthIndicator indicator = new CuratorHealthIndicator(framework);
 			Health health = indicator.health();
-			assertEquals(Status.DOWN, health.getStatus());
+			assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		}
 	}
 

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/fastexcel/FastExcelAutoConfigurationTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/fastexcel/FastExcelAutoConfigurationTests.java
@@ -35,7 +35,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author livk
@@ -67,7 +66,7 @@ class FastExcelAutoConfigurationTests {
 				.getBean(org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter.class);
 
 			Field customResolversField = ReflectionUtils.findField(ArgumentResolverConfigurer.class, "customResolvers");
-			assertNotNull(customResolversField);
+			assertThat(customResolversField).isNotNull();
 			List<HandlerMethodArgumentResolver> customResolvers = (List<HandlerMethodArgumentResolver>) ReflectionUtils
 				.getDeclaredFieldValue(customResolversField, adapter.getArgumentResolverConfigurer());
 			assertThat(customResolvers).isNotNull()

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisearch/LettuceModConnectionFactoryTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisearch/LettuceModConnectionFactoryTests.java
@@ -19,7 +19,7 @@ package com.livk.autoconfigure.redisearch;
 import io.lettuce.core.resource.ClientResources;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -31,7 +31,7 @@ class LettuceModConnectionFactoryTests {
 		RediSearchProperties properties = new RediSearchProperties();
 		ClientResources resources = ClientResources.builder().build();
 		LettuceModConnectionFactory factory = new LettuceModConnectionFactory(resources, properties);
-		assertNotNull(factory);
+		assertThat(factory).isNotNull();
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisearch/RedisModulesFactoryTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisearch/RedisModulesFactoryTests.java
@@ -23,8 +23,7 @@ import io.lettuce.core.resource.ClientResources;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -36,22 +35,22 @@ class RedisModulesFactoryTests {
 	@Test
 	void getClient() {
 		AbstractRedisClient client = factory.getClient(ClientResources.builder().build());
-		assertInstanceOf(RedisModulesClient.class, client);
+		assertThat(client).isInstanceOf(RedisModulesClient.class);
 	}
 
 	@Test
 	void createRedisURI() {
 		RedisURI uri = factory.createRedisURI("127.0.0.1:6379");
-		assertEquals("127.0.0.1", uri.getHost());
-		assertEquals(6379, uri.getPort());
+		assertThat(uri.getHost()).isEqualTo("127.0.0.1");
+		assertThat(uri.getPort()).isEqualTo(6379);
 	}
 
 	@Test
 	void getPoolConfig() {
 		GenericObjectPoolConfig<?> config = factory.getPoolConfig();
-		assertEquals(8, config.getMaxTotal());
-		assertEquals(8, config.getMaxIdle());
-		assertEquals(0, config.getMinIdle());
+		assertThat(config.getMaxTotal()).isEqualTo(8);
+		assertThat(config.getMaxIdle()).isEqualTo(8);
+		assertThat(config.getMinIdle()).isEqualTo(0);
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonClientFactoryTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonClientFactoryTests.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -80,7 +80,7 @@ class RedissonClientFactoryTests {
 	void createTest() {
 		RedissonClient redissonClient = RedissonClientFactory.create(redissonProperties, configCustomizers);
 
-		assertNotNull(redissonClient);
+		assertThat(redissonClient).isNotNull();
 		redissonClient.shutdown();
 	}
 
@@ -88,7 +88,7 @@ class RedissonClientFactoryTests {
 	void createByRedisPropertiesTest() {
 		RedissonClient redissonClient = RedissonClientFactory.create(redisProperties, configCustomizers);
 
-		assertNotNull(redissonClient);
+		assertThat(redissonClient).isNotNull();
 		redissonClient.shutdown();
 	}
 

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertiesTests.java
@@ -25,8 +25,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -42,11 +41,11 @@ class RedissonPropertiesTests {
 	@Test
 	void test() {
 		RedissonProperties properties = RedissonProperties.load(environment);
-		assertEquals("redis://livk.com:6379", properties.getConfig().useSingleServer().getAddress());
-		assertInstanceOf(JsonJacksonCodec.class, properties.getConfig().getCodec());
-		assertInstanceOf(DefaultNettyHook.class, properties.getConfig().getNettyHook());
-		assertInstanceOf(SequentialDnsAddressResolverFactory.class,
-				properties.getConfig().getAddressResolverGroupFactory());
+		assertThat(properties.getConfig().useSingleServer().getAddress()).isEqualTo("redis://livk.com:6379");
+		assertThat(properties.getConfig().getCodec()).isInstanceOf(JsonJacksonCodec.class);
+		assertThat(properties.getConfig().getNettyHook()).isInstanceOf(DefaultNettyHook.class);
+		assertThat(properties.getConfig().getAddressResolverGroupFactory())
+			.isInstanceOf(SequentialDnsAddressResolverFactory.class);
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrarTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrarTests.java
@@ -16,21 +16,21 @@
 
 package com.livk.autoconfigure.redisson;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.redisson.client.DefaultNettyHook;
 import org.redisson.client.NettyHook;
 import org.redisson.client.codec.Codec;
 import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.connection.AddressResolverGroupFactory;
-import org.redisson.connection.SequentialDnsAddressResolverFactory;
 import org.springframework.beans.SimpleTypeConverter;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
  */
+@Slf4j
 class RedissonPropertyEditorRegistrarTests {
 
 	@Test
@@ -41,17 +41,14 @@ class RedissonPropertyEditorRegistrarTests {
 		registrar.registerCustomEditors(converter);
 
 		Codec codec = converter.convertIfNecessary("!<org.redisson.codec.JsonJacksonCodec> {}", Codec.class);
-		assertNotNull(codec);
-		assertInstanceOf(JsonJacksonCodec.class, codec);
+		assertThat(codec).isNotNull().isInstanceOf(JsonJacksonCodec.class);
 
 		NettyHook hook = converter.convertIfNecessary("!<org.redisson.client.DefaultNettyHook> {}", NettyHook.class);
-		assertNotNull(hook);
-		assertInstanceOf(DefaultNettyHook.class, hook);
+		assertThat(hook).isNotNull().isInstanceOf(DefaultNettyHook.class);
 
 		AddressResolverGroupFactory factory = converter.convertIfNecessary(
 				"!<org.redisson.connection.SequentialDnsAddressResolverFactory> {}", AddressResolverGroupFactory.class);
-		assertNotNull(factory);
-		assertInstanceOf(SequentialDnsAddressResolverFactory.class, factory);
+		assertThat(factory).isNotNull().isInstanceOf(AddressResolverGroupFactory.class);
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/useragent/UserAgentAutoConfigurationTests.java
+++ b/spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/useragent/UserAgentAutoConfigurationTests.java
@@ -43,7 +43,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author livk
@@ -88,8 +87,8 @@ class UserAgentAutoConfigurationTests {
 			FilterRegistrationBean<UserAgentFilter> filterRegistrationBean = context
 				.<FilterRegistrationBean<UserAgentFilter>>getBeanProvider(resolvableType)
 				.getIfAvailable();
-			assertNotNull(filterRegistrationBean);
-			assertNotNull(filterRegistrationBean.getFilter());
+			assertThat(filterRegistrationBean).isNotNull();
+			assertThat(filterRegistrationBean.getFilter()).isNotNull();
 		});
 	}
 
@@ -104,7 +103,7 @@ class UserAgentAutoConfigurationTests {
 				.getBean(org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter.class);
 
 			Field customResolversField = ReflectionUtils.findField(ArgumentResolverConfigurer.class, "customResolvers");
-			assertNotNull(customResolversField);
+			assertThat(customResolversField).isNotNull();
 			List<HandlerMethodArgumentResolver> customResolvers = (List<HandlerMethodArgumentResolver>) ReflectionUtils
 				.getDeclaredFieldValue(customResolversField, adapter.getArgumentResolverConfigurer());
 			assertThat(customResolvers).isNotNull().hasAtLeastOneElementOfType(ReactiveUserAgentResolver.class);

--- a/spring-boot-extension-tests/curator-spring-boot-test/src/test/java/com/livk/curator/CuratorAppTests.java
+++ b/spring-boot-extension-tests/curator-spring-boot-test/src/test/java/com/livk/curator/CuratorAppTests.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -55,8 +55,8 @@ class CuratorAppTests {
 
 	@Test
 	void test() {
-		assertNotNull(curatorFramework);
-		assertNotNull(curatorFramework);
+		assertThat(curatorFramework).isNotNull();
+		assertThat(curatorTemplate).isNotNull();
 	}
 
 }

--- a/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webflux/src/test/java/com/livk/excel/reactive/controller/Info2ControllerTests.java
+++ b/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webflux/src/test/java/com/livk/excel/reactive/controller/Info2ControllerTests.java
@@ -34,8 +34,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -66,11 +65,11 @@ class Info2ControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./infoUploadDownLoad" + ResponseExcel.Suffix.XLSM.getName());
 		File outFile = new File("./infoUploadDownLoad" + ResponseExcel.Suffix.XLSM.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -88,11 +87,11 @@ class Info2ControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./infoDownload" + ResponseExcel.Suffix.XLSM.getName());
 		File outFile = new File("./infoDownload" + ResponseExcel.Suffix.XLSM.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webflux/src/test/java/com/livk/excel/reactive/controller/InfoControllerTests.java
+++ b/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webflux/src/test/java/com/livk/excel/reactive/controller/InfoControllerTests.java
@@ -32,8 +32,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -88,11 +87,11 @@ class InfoControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./uploadDownLoad" + ResponseExcel.Suffix.XLS.getName());
 		File outFile = new File("./uploadDownLoad" + ResponseExcel.Suffix.XLS.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -107,11 +106,11 @@ class InfoControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./uploadDownLoadMono" + ResponseExcel.Suffix.XLS.getName());
 		File outFile = new File("./uploadDownLoadMono" + ResponseExcel.Suffix.XLS.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -126,11 +125,11 @@ class InfoControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./uploadDownLoadFlux" + ResponseExcel.Suffix.XLS.getName());
 		File outFile = new File("./uploadDownLoadFlux" + ResponseExcel.Suffix.XLS.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webmvc/src/test/java/com/livk/excel/mvc/controller/Info2ControllerTests.java
+++ b/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webmvc/src/test/java/com/livk/excel/mvc/controller/Info2ControllerTests.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -69,8 +69,8 @@ class Info2ControllerTests {
 				FileUtils.download(in, "./infoUploadAndDownloadMock" + ResponseExcel.Suffix.XLSM.getName());
 			});
 		File outFile = new File("./infoUploadAndDownloadMock" + ResponseExcel.Suffix.XLSM.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -88,8 +88,8 @@ class Info2ControllerTests {
 				FileUtils.download(in, "./infoDownload" + ResponseExcel.Suffix.XLSM.getName());
 			});
 		File outFile = new File("./infoDownload" + ResponseExcel.Suffix.XLSM.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webmvc/src/test/java/com/livk/excel/mvc/controller/InfoControllerTests.java
+++ b/spring-boot-extension-tests/fastexcel-spring-boot-test/fastexcel-spring-boot-test-webmvc/src/test/java/com/livk/excel/mvc/controller/InfoControllerTests.java
@@ -31,7 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -68,8 +68,8 @@ class InfoControllerTests {
 			FileUtils.download(in, "./uploadAndDownloadMock" + ResponseExcel.Suffix.XLSM.getName());
 		});
 		File outFile = new File("./uploadAndDownloadMock" + ResponseExcel.Suffix.XLSM.getName());
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/http-spring-boot-test/src/test/java/com/livk/http/service/JavaServiceTests.java
+++ b/spring-boot-extension-tests/http-spring-boot-test/src/test/java/com/livk/http/service/JavaServiceTests.java
@@ -24,10 +24,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 /**
  * @author livk
@@ -43,16 +41,15 @@ class JavaServiceTests {
 
 	@BeforeEach
 	void setUp() {
-		when(javaService.java()).thenReturn(Map.of("java-version", "17", "mockito", "true"));
+		given(javaService.java()).willReturn(Map.of("java-version", "17", "mockito", "true"));
 	}
 
 	@Test
 	void java() {
 		Map<String, String> result = service.java();
 
-		assertNotEquals(result.get("java-version"), System.getProperty("java.version"));
-		assertEquals("17", result.get("java-version"));
-		assertTrue(Boolean.parseBoolean(result.get("mockito")));
+		assertThat(result.get("java-version")).isNotEqualTo(System.getProperty("java.version")).isEqualTo("17");
+		assertThat(result.get("mockito")).asBoolean().isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/http-spring-boot-test/src/test/java/com/livk/http/service/SpringBootServiceTests.java
+++ b/spring-boot-extension-tests/http-spring-boot-test/src/test/java/com/livk/http/service/SpringBootServiceTests.java
@@ -25,10 +25,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 /**
  * @author livk
@@ -44,16 +42,15 @@ class SpringBootServiceTests {
 
 	@BeforeEach
 	void setUp() {
-		when(bootService.springBoot()).thenReturn(Map.of("spring-boot-version", "1.0.0", "mockito", "true"));
+		given(bootService.springBoot()).willReturn(Map.of("spring-boot-version", "1.0.0", "mockito", "true"));
 	}
 
 	@Test
 	void springBoot() {
 		Map<String, String> result = service.springBoot();
 
-		assertNotEquals(result.get("spring-boot-version"), SpringBootVersion.getVersion());
-		assertEquals("1.0.0", result.get("spring-boot-version"));
-		assertTrue(Boolean.parseBoolean(result.get("mockito")));
+		assertThat(result.get("spring-boot-version")).isNotEqualTo(SpringBootVersion.getVersion()).isEqualTo("1.0.0");
+		assertThat(result.get("mockito")).asBoolean().isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/http-spring-boot-test/src/test/java/com/livk/http/service/SpringServiceTests.java
+++ b/spring-boot-extension-tests/http-spring-boot-test/src/test/java/com/livk/http/service/SpringServiceTests.java
@@ -25,10 +25,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 /**
  * @author livk
@@ -44,16 +42,15 @@ class SpringServiceTests {
 
 	@BeforeEach
 	void setUp() {
-		when(springService.spring()).thenReturn(Map.of("spring-version", "1.0.0", "mockito", "true"));
+		given(springService.spring()).willReturn(Map.of("spring-version", "1.0.0", "mockito", "true"));
 	}
 
 	@Test
 	void spring() {
 		Map<String, String> result = service.spring();
 
-		assertNotEquals(result.get("spring-version"), SpringVersion.getVersion());
-		assertEquals("1.0.0", result.get("spring-version"));
-		assertTrue(Boolean.parseBoolean(result.get("mockito")));
+		assertThat(result.get("spring-version")).isNotEqualTo(SpringVersion.getVersion()).isEqualTo("1.0.0");
+		assertThat(result.get("mockito")).asBoolean().isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/oss-spring-boot-test/minio-spring-boot-test/src/test/java/com/livk/oss/minio/controller/OssControllerTests.java
+++ b/spring-boot-extension-tests/oss-spring-boot-test/minio-spring-boot-test/src/test/java/com/livk/oss/minio/controller/OssControllerTests.java
@@ -34,7 +34,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -76,8 +76,8 @@ class OssControllerTests {
 			FileUtils.download(stream, "./test.jpg");
 		}
 		File file = new File("./test.jpg");
-		assertTrue(file.exists());
-		assertTrue(file.delete());
+		assertThat(file).exists().isFile();
+		assertThat(file.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webflux/src/test/java/com/livk/qrcode/webflux/controller/QRCode2ControllerTests.java
+++ b/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webflux/src/test/java/com/livk/qrcode/webflux/controller/QRCode2ControllerTests.java
@@ -33,9 +33,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -65,14 +63,14 @@ class QRCode2ControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./text." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("text." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -86,14 +84,14 @@ class QRCode2ControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./textMono." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("textMono." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -109,14 +107,14 @@ class QRCode2ControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./json." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("json." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -132,14 +130,14 @@ class QRCode2ControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./jsonMono." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("jsonMono." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webflux/src/test/java/com/livk/qrcode/webflux/controller/QrCodeControllerTests.java
+++ b/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webflux/src/test/java/com/livk/qrcode/webflux/controller/QrCodeControllerTests.java
@@ -33,9 +33,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -65,14 +63,14 @@ class QrCodeControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./text." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("text." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -86,14 +84,14 @@ class QrCodeControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./textMono." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("textMono." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -107,14 +105,14 @@ class QrCodeControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./text." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("text." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -130,14 +128,14 @@ class QrCodeControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./json." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("json." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -153,14 +151,14 @@ class QrCodeControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./jsonMono." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("jsonMono." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -176,14 +174,14 @@ class QrCodeControllerTests {
 			.returnResult()
 			.getResponseBody();
 
-		assertNotNull(resource);
+		assertThat(resource).isNotNull();
 		FileUtils.download(resource.getInputStream(), "./json." + PicType.JPG.name().toLowerCase());
 		File outFile = new File("json." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webmvc/src/test/java/com/livk/qrcode/mvc/controller/QRCode2ControllerTests.java
+++ b/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webmvc/src/test/java/com/livk/qrcode/mvc/controller/QRCode2ControllerTests.java
@@ -32,8 +32,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -60,10 +59,10 @@ class QRCode2ControllerTests {
 		});
 		File outFile = new File("text." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -77,10 +76,10 @@ class QRCode2ControllerTests {
 			});
 		File outFile = new File("json." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webmvc/src/test/java/com/livk/qrcode/mvc/controller/QrCodeControllerTests.java
+++ b/spring-boot-extension-tests/qrcode-spring-boot-test/qrcode-spring-boot-test-webmvc/src/test/java/com/livk/qrcode/mvc/controller/QrCodeControllerTests.java
@@ -32,8 +32,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -60,10 +59,10 @@ class QrCodeControllerTests {
 		});
 		File outFile = new File("text." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -77,10 +76,10 @@ class QrCodeControllerTests {
 			});
 		File outFile = new File("json." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -92,10 +91,10 @@ class QrCodeControllerTests {
 		});
 		File outFile = new File("text." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(text, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(text);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 	@Test
@@ -109,10 +108,10 @@ class QrCodeControllerTests {
 			});
 		File outFile = new File("json." + PicType.JPG.name().toLowerCase());
 		try (FileInputStream inputStream = new FileInputStream(outFile)) {
-			assertEquals(json, qrCodeManager.parser(inputStream));
+			assertThat(qrCodeManager.parser(inputStream)).isEqualTo(json);
 		}
-		assertTrue(outFile.exists());
-		assertTrue(outFile.delete());
+		assertThat(outFile).exists().isFile();
+		assertThat(outFile.delete()).isTrue();
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java
@@ -27,8 +27,7 @@ import org.springframework.core.ResolvableType;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -45,9 +44,9 @@ class SpringContextHolderTests {
 	void getBean() {
 		contextRunner.run(ctx -> {
 			SpringContextHolder.registerBean(bean, "test");
-			assertEquals(bean, SpringContextHolder.getBean("test"));
-			assertEquals(bean, SpringContextHolder.getBean(BeanTest.class));
-			assertEquals(bean, SpringContextHolder.getBean("test", BeanTest.class));
+			assertThat(SpringContextHolder.<BeanTest>getBean("test")).isSameAs(bean);
+			assertThat(SpringContextHolder.getBean(BeanTest.class)).isSameAs(bean);
+			assertThat(SpringContextHolder.getBean("test", BeanTest.class)).isSameAs(bean);
 			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
 				context.removeBeanDefinition("test");
 			}
@@ -59,8 +58,8 @@ class SpringContextHolderTests {
 		contextRunner.run(ctx -> {
 			SpringContextHolder.registerBean(bean, "test");
 			ResolvableType resolvableType = ResolvableType.forClass(BeanTest.class);
-			assertEquals(bean, SpringContextHolder.getBeanProvider(BeanTest.class).getIfAvailable());
-			assertEquals(bean, SpringContextHolder.getBeanProvider(resolvableType).getIfAvailable());
+			assertThat(SpringContextHolder.getBeanProvider(BeanTest.class).getIfAvailable()).isSameAs(bean);
+			assertThat(SpringContextHolder.getBeanProvider(resolvableType).getIfAvailable()).isSameAs(bean);
 			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
 				context.removeBeanDefinition("test");
 			}
@@ -71,7 +70,7 @@ class SpringContextHolderTests {
 	void getBeansOfType() {
 		contextRunner.run(ctx -> {
 			SpringContextHolder.registerBean(bean, "test");
-			assertEquals(Map.of("test", bean), SpringContextHolder.getBeansOfType(BeanTest.class));
+			assertThat(SpringContextHolder.getBeansOfType(BeanTest.class)).isEqualTo(Map.of("test", bean));
 			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
 				context.removeBeanDefinition("test");
 			}
@@ -81,19 +80,19 @@ class SpringContextHolderTests {
 	@Test
 	void getProperty() {
 		contextRunner.run(ctx -> {
-			assertEquals("livk.com", SpringContextHolder.getProperty("spring.data.redis.host"));
-			assertEquals("livk.com", SpringContextHolder.getProperty("spring.data.redis.host", String.class));
-			assertEquals("livk.com",
-					SpringContextHolder.getProperty("spring.data.redis.host", String.class, "livk.cn"));
-			assertEquals("livk.cn",
-					SpringContextHolder.getProperty("spring.data.redisson.host", String.class, "livk.cn"));
+			assertThat(SpringContextHolder.getProperty("spring.data.redis.host")).isEqualTo("livk.com");
+			assertThat(SpringContextHolder.getProperty("spring.data.redis.host", String.class)).isEqualTo("livk.com");
+			assertThat(SpringContextHolder.getProperty("spring.data.redis.host", String.class, "livk.cn"))
+				.isEqualTo("livk.com");
+			assertThat(SpringContextHolder.getProperty("spring.data.redisson.host", String.class, "livk.cn"))
+				.isEqualTo("livk.cn");
 		});
 	}
 
 	@Test
 	void resolvePlaceholders() {
-		contextRunner
-			.run(ctx -> assertEquals("livk.com", SpringContextHolder.resolvePlaceholders("${spring.data.redis.host}")));
+		contextRunner.run(ctx -> assertThat(SpringContextHolder.resolvePlaceholders("${spring.data.redis.host}"))
+			.isEqualTo("livk.com"));
 	}
 
 	@Test
@@ -101,19 +100,20 @@ class SpringContextHolderTests {
 		contextRunner.run(ctx -> {
 			Binder binder = SpringContextHolder.binder();
 			BindResult<String> result = binder.bind("spring.data.redis.host", String.class);
-			assertTrue(result.isBound());
-			assertEquals("livk.com", result.get());
+			assertThat(result.isBound()).isTrue();
+			assertThat(result.get()).isEqualTo("livk.com");
 		});
 	}
 
-	@Test
 	@SuppressWarnings("unchecked")
+	@Test
 	void registerBean() {
 		contextRunner.run(ctx -> {
 			SpringContextHolder.registerBean(bean, "test1");
 			RootBeanDefinition beanDefinition = new RootBeanDefinition((Class<BeanTest>) bean.getClass(), () -> bean);
 			SpringContextHolder.registerBean(beanDefinition, "test2");
-			assertEquals(Map.of("test1", bean, "test2", bean), SpringContextHolder.getBeansOfType(BeanTest.class));
+			assertThat(SpringContextHolder.getBeansOfType(BeanTest.class))
+				.isEqualTo(Map.of("test1", bean, "test2", bean));
 			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
 				context.removeBeanDefinition("test1");
 				context.removeBeanDefinition("test2");

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisorTests.java
@@ -17,10 +17,10 @@
 package com.livk.commons.aop;
 
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.IntroductionInterceptor;
 import org.springframework.aop.Pointcut;
-import org.jspecify.annotations.NonNull;
 import org.springframework.aop.support.ComposablePointcut;
 
 import java.lang.annotation.ElementType;
@@ -28,8 +28,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -40,15 +39,21 @@ class AnnotationAbstractPointcutAdvisorTests {
 	void test() throws NoSuchMethodException {
 		MyAnnotationAbstractPointcutAdvisor advisor = new MyAnnotationAbstractPointcutAdvisor();
 
-		assertEquals(MyAnnotation.class, advisor.annotationType);
-		assertTrue(advisor.implementsInterface(IntroductionInterceptor.class));
-		assertEquals(ComposablePointcut.class, advisor.getPointcut().getClass());
-		assertEquals(AnnotationPointcut.forTypeOrMethod().getPointcut(MyAnnotation.class), advisor.getPointcut());
+		assertThat(advisor.annotationType).isEqualTo(MyAnnotation.class);
 
-		assertTrue(advisor.getPointcut().getClassFilter().matches(AopProxyClass.class));
-		assertTrue(advisor.getPointcut()
+		assertThat(advisor.implementsInterface(IntroductionInterceptor.class)).isTrue();
+
+		assertThat(advisor.getPointcut()).isInstanceOf(ComposablePointcut.class);
+
+		assertThat(advisor.getPointcut())
+			.isEqualTo(AnnotationPointcut.forTypeOrMethod().getPointcut(MyAnnotation.class));
+
+		assertThat(advisor.getPointcut().getClassFilter().matches(AopProxyClass.class)).isTrue();
+
+		assertThat(advisor.getPointcut()
 			.getMethodMatcher()
-			.matches(AopProxyClass.class.getDeclaredMethod("testAop"), AopProxyClass.class));
+			.matches(AopProxyClass.class.getDeclaredMethod("testAop"), AopProxyClass.class)).isTrue();
+
 	}
 
 	@MyAnnotation

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutTypeAdvisorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutTypeAdvisorTests.java
@@ -25,9 +25,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -38,13 +36,16 @@ class AnnotationAbstractPointcutTypeAdvisorTests {
 	void test() {
 		MyAnnotationAbstractPointcutTypeAdvisor advisor = new MyAnnotationAbstractPointcutTypeAdvisor();
 
-		assertEquals(AnnotationMatchingPointcut.class, advisor.getPointcut().getClass());
-		assertEquals(AnnotationMatchingPointcut.forClassAnnotation(MyAnnotation.class), advisor.getPointcut());
+		assertThat(advisor.getPointcut()).isInstanceOf(AnnotationMatchingPointcut.class);
 
-		assertTrue(advisor.getPointcut().getClassFilter().matches(AopProxyClass.class));
-		assertFalse(advisor.getPointcut()
+		assertThat(advisor.getPointcut()).isEqualTo(AnnotationMatchingPointcut.forClassAnnotation(MyAnnotation.class));
+
+		assertThat(advisor.getPointcut().getClassFilter().matches(AopProxyClass.class)).isTrue();
+
+		assertThat(advisor.getPointcut()
 			.getClassFilter()
-			.matches(AnnotationAbstractPointcutAdvisorTests.AopProxyClass.class));
+			.matches(AnnotationAbstractPointcutAdvisorTests.AopProxyClass.class)).isFalse();
+
 	}
 
 	@MyAnnotation

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationPointcutTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationPointcutTests.java
@@ -26,8 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,34 +40,43 @@ class AnnotationPointcutTests {
 		Method method = AopProxyClass.class.getDeclaredMethod("testAop");
 		{
 			AnnotationPointcut pointcut = AnnotationPointcut.forTarget();
-			assertEquals(AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType),
-					pointcut.getPointcut(annotationType));
-			assertTrue(pointcut.getPointcut(annotationType).getClassFilter().matches(type));
-			assertTrue(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type));
+
+			assertThat(pointcut.getPointcut(annotationType))
+				.isEqualTo(AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType));
+
+			assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+
+			assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 		}
 
 		{
 			AnnotationPointcut pointcut = AnnotationPointcut.forType();
-			assertEquals(AnnotationMatchingPointcut.forClassAnnotation(annotationType),
-					pointcut.getPointcut(annotationType));
-			assertTrue(pointcut.getPointcut(annotationType).getClassFilter().matches(type));
-			assertTrue(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type));
+			assertThat(pointcut.getPointcut(annotationType))
+				.isEqualTo(AnnotationMatchingPointcut.forClassAnnotation(annotationType));
+
+			assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+
+			assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 		}
 
 		{
 			AnnotationPointcut pointcut = AnnotationPointcut.forMethod();
-			assertEquals(AnnotationMatchingPointcut.forMethodAnnotation(annotationType),
-					pointcut.getPointcut(annotationType));
-			assertTrue(pointcut.getPointcut(annotationType).getClassFilter().matches(type));
-			assertTrue(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type));
+			assertThat(pointcut.getPointcut(annotationType))
+				.isEqualTo(AnnotationMatchingPointcut.forMethodAnnotation(annotationType));
+
+			assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+
+			assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 		}
 
 		{
 			AnnotationPointcut pointcut = AnnotationPointcut.forTypeOrMethod();
-			assertEquals(AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType),
-					pointcut.getPointcut(annotationType));
-			assertTrue(pointcut.getPointcut(annotationType).getClassFilter().matches(type));
-			assertTrue(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type));
+			assertThat(pointcut.getPointcut(annotationType))
+				.isEqualTo(AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType));
+
+			assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+
+			assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 		}
 
 	}

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/ContextFactoryTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/ContextFactoryTests.java
@@ -23,9 +23,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -45,23 +43,24 @@ class ContextFactoryTests {
 	void create() {
 		{
 			Context context = contextFactory.create(method, new String[] { "livk" });
-			assertEquals(map.size(), context.asMap().size());
-			assertEquals(map.keySet(), context.asMap().keySet());
-			assertEquals(map.entrySet(), context.asMap().entrySet());
+			assertThat(context.asMap()).hasSize(map.size());
+			assertThat(context.asMap().keySet()).isEqualTo(map.keySet());
+			assertThat(context.asMap().entrySet()).isEqualTo(map.entrySet());
 		}
 		{
 			HashMap<String, Object> contextMap = Maps
 				.newHashMap(contextFactory.create(method, new String[] { "root" }).asMap());
 			contextMap.putAll(map);
 			Context context = Context.create(contextMap);
-			assertEquals(1, context.asMap().size());
-			assertEquals(contextMap.keySet(), context.asMap().keySet());
-			assertEquals(contextMap.entrySet(), context.asMap().entrySet());
-			assertTrue(context.asMap().containsKey("username"));
-			assertFalse(context.asMap().containsValue("root"));
-			assertTrue(context.asMap().containsValue("livk"));
-			assertEquals("livk", context.asMap().get("username"));
+			assertThat(context.asMap()).hasSize(1);
+			assertThat(context.asMap().keySet()).isEqualTo(contextMap.keySet());
+			assertThat(context.asMap().entrySet()).isEqualTo(contextMap.entrySet());
+			assertThat(context.asMap()).containsKey("username");
+			assertThat(context.asMap()).doesNotContainValue("root");
+			assertThat(context.asMap()).containsValue("livk");
+			assertThat(context.asMap().get("username")).isEqualTo("livk");
 		}
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/aviator/AviatorExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/aviator/AviatorExpressionResolverTests.java
@@ -32,8 +32,7 @@ import org.springframework.context.annotation.Bean;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -57,38 +56,47 @@ class AviatorExpressionResolverTests {
 	@Test
 	void evaluate() {
 		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
-		assertTrue(resolver.evaluate("'livk'==#username", method, args, Boolean.class));
+		assertThat(resolver.evaluate("'livk'==#username", method, args, Boolean.class)).isTrue();
 
-		assertEquals("livk", resolver.evaluate("#username", method, args));
+		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
 
-		assertTrue(resolver.evaluate("'livk'==#username", map, Boolean.class));
-		assertEquals("livk", resolver.evaluate("#username", map));
+		assertThat(resolver.evaluate("'livk'==#username", map, Boolean.class)).isTrue();
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+#username", method, args));
-		assertEquals("root:livk:123456", resolver.evaluate("'root:'+#username+':'+#password", context));
+		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+#username", map));
-		assertEquals("livk:" + System.getProperty("user.dir"),
-				resolver.evaluate("#username+':'+System.getProperty(\"user.dir\")", map));
+		assertThat(resolver.evaluate("'root:'+#username", method, args)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+#username", method, args));
-		assertEquals("livk", resolver.evaluate("#username", method, args));
-		assertEquals("livk", resolver.evaluate("'livk'", method, args));
+		assertThat(resolver.evaluate("'root:'+#username+':'+#password", context)).isEqualTo("root:livk:123456");
 
-		assertEquals("root:livk:123456", resolver.evaluate("'root:'+#username+':'+#password", context));
-		assertEquals("livk123456", resolver.evaluate("#username+#password", context));
+		assertThat(resolver.evaluate("'root:'+#username", map)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+#username", map));
-		assertEquals("livk", resolver.evaluate("#username", map));
-		assertEquals("livk:" + System.getProperty("user.dir"),
-				resolver.evaluate("#username+':'+System.getProperty(\"user.dir\")", map));
+		assertThat(resolver.evaluate("#username+':'+System.getProperty(\"user.dir\")", map))
+			.isEqualTo("livk:" + System.getProperty("user.dir"));
+
+		assertThat(resolver.evaluate("'root:'+#username", method, args)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("'root:'+#username+':'+#password", context)).isEqualTo("root:livk:123456");
+
+		assertThat(resolver.evaluate("#username+#password", context)).isEqualTo("livk123456");
+
+		assertThat(resolver.evaluate("'root:'+#username", map)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("#username+':'+System.getProperty(\"user.dir\")", map))
+			.isEqualTo("livk:" + System.getProperty("user.dir"));
 
 		contextRunner.run(ctx -> {
-			assertEquals("livk123", resolver.evaluate("add(x,y)", Map.of("x", "livk", "y", "123")));
+			assertThat(resolver.evaluate("add(x,y)", Map.of("x", "livk", "y", "123"))).isEqualTo("livk123");
 
-			assertEquals(4,
-					resolver.evaluate("ifElse(a==c,b,d)", Map.of("a", 1, "b", 2, "c", 3, "d", 4), Integer.class));
+			assertThat(resolver.evaluate("ifElse(a==c,b,d)", Map.of("a", 1, "b", 2, "c", 3, "d", 4), Integer.class))
+				.isEqualTo(4);
 		});
+
 	}
 
 	@TestConfiguration

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolverTests.java
@@ -26,8 +26,8 @@ import org.springframework.expression.ExpressionException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -48,26 +48,33 @@ class FreeMarkerExpressionResolverTests {
 	@Test
 	void evaluate() {
 		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
-		assertEquals("livk", resolver.evaluate("${username}", method, args));
+		assertThat(resolver.evaluate("${username}", method, args)).isEqualTo("livk");
 
-		assertEquals("livk", resolver.evaluate("${username}", map));
+		assertThat(resolver.evaluate("${username}", map)).isEqualTo("livk");
 
-		assertEquals("root:livk", resolver.evaluate("root:${username}", method, args));
-		assertEquals("root:livk:123456", resolver.evaluate("root:${username}:${password}", context));
+		assertThat(resolver.evaluate("root:${username}", method, args)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("root:${username}", map));
+		assertThat(resolver.evaluate("root:${username}:${password}", context)).isEqualTo("root:livk:123456");
 
-		assertEquals("root:livk", resolver.evaluate("root:${username}", method, args));
-		assertEquals("livk", resolver.evaluate("${username}", method, args));
-		assertEquals("livk", resolver.evaluate("livk", method, args));
+		assertThat(resolver.evaluate("root:${username}", map)).isEqualTo("root:livk");
 
-		assertEquals("root:livk:123456", resolver.evaluate("root:${username}:${password}", context));
-		assertEquals("livk123456", resolver.evaluate("${username}${password}", context));
+		assertThat(resolver.evaluate("root:${username}", method, args)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("root:${username}", map));
-		assertEquals("livk", resolver.evaluate("${username}", map));
+		assertThat(resolver.evaluate("${username}", method, args)).isEqualTo("livk");
 
-		assertThrowsExactly(ExpressionException.class, () -> resolver.evaluate("${username}", map, Integer.class));
+		assertThat(resolver.evaluate("livk", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("root:${username}:${password}", context)).isEqualTo("root:livk:123456");
+
+		assertThat(resolver.evaluate("${username}${password}", context)).isEqualTo("livk123456");
+
+		assertThat(resolver.evaluate("root:${username}", map)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("${username}", map)).isEqualTo("livk");
+
+		assertThatThrownBy(() -> resolver.evaluate("${username}", map, Integer.class))
+			.isExactlyInstanceOf(ExpressionException.class);
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/jexl3/JexlExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/jexl3/JexlExpressionResolverTests.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -47,27 +46,34 @@ class JexlExpressionResolverTests {
 	@Test
 	void evaluate() {
 		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
-		assertTrue(resolver.evaluate("'livk'==username", method, args, Boolean.class));
+		assertThat(resolver.evaluate("'livk'==username", method, args, Boolean.class)).isTrue();
 
-		assertEquals("livk", resolver.evaluate("username", method, args));
+		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
 
-		assertTrue(resolver.evaluate("'livk'==username", map, Boolean.class));
-		assertEquals("livk", resolver.evaluate("username", map));
+		assertThat(resolver.evaluate("'livk'==username", map, Boolean.class)).isTrue();
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", method, args));
-		assertEquals("root:livk:123456", resolver.evaluate("'root:'+username+':'+password", context));
+		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", map));
+		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", method, args));
-		assertEquals("livk", resolver.evaluate("username", method, args));
-		assertEquals("livk", resolver.evaluate("'livk'", method, args));
+		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
 
-		assertEquals("root:livk:123456", resolver.evaluate("'root:'+username+':'+password", context));
-		assertEquals("livk123456", resolver.evaluate("username+password", context));
+		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", map));
-		assertEquals("livk", resolver.evaluate("username", map));
+		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
+
+		assertThat(resolver.evaluate("username+password", context)).isEqualTo("livk123456");
+
+		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/mvel2/MvelExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/mvel2/MvelExpressionResolverTests.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -47,31 +46,40 @@ class MvelExpressionResolverTests {
 	@Test
 	void evaluate() {
 		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
-		assertTrue(resolver.evaluate("'livk'==username", method, args, Boolean.class));
+		assertThat(resolver.evaluate("'livk'==username", method, args, Boolean.class)).isTrue();
 
-		assertEquals("livk", resolver.evaluate("username", method, args));
+		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
 
-		assertTrue(resolver.evaluate("'livk'==username", map, Boolean.class));
-		assertEquals("livk", resolver.evaluate("username", map));
+		assertThat(resolver.evaluate("'livk'==username", map, Boolean.class)).isTrue();
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", method, args));
-		assertEquals("root:livk:123456", resolver.evaluate("'root:'+username+':'+password", context));
+		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", map));
-		assertEquals("livk:" + System.getProperty("user.dir"),
-				resolver.evaluate("username+':'+System.getProperty(\"user.dir\")", map));
+		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", method, args));
-		assertEquals("livk", resolver.evaluate("username", method, args));
-		assertEquals("livk", resolver.evaluate("'livk'", method, args));
+		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
 
-		assertEquals("root:livk:123456", resolver.evaluate("'root:'+username+':'+password", context));
-		assertEquals("livk123456", resolver.evaluate("username+password", context));
+		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
 
-		assertEquals("root:livk", resolver.evaluate("'root:'+username", map));
-		assertEquals("livk", resolver.evaluate("username", map));
-		assertEquals("livk:" + System.getProperty("user.dir"),
-				resolver.evaluate("username+':'+System.getProperty(\"user.dir\")", map));
+		assertThat(resolver.evaluate("username+':'+System.getProperty(\"user.dir\")", map))
+			.isEqualTo("livk:" + System.getProperty("user.dir"));
+
+		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
+
+		assertThat(resolver.evaluate("username+password", context)).isEqualTo("livk123456");
+
+		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
+
+		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
+
+		assertThat(resolver.evaluate("username+':'+System.getProperty(\"user.dir\")", map))
+			.isEqualTo("livk:" + System.getProperty("user.dir"));
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/spring/SpringExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/spring/SpringExpressionResolverTests.java
@@ -28,8 +28,7 @@ import org.springframework.core.env.Environment;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -56,45 +55,48 @@ class SpringExpressionResolverTests {
 	@Test
 	void evaluate() {
 		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
-		assertTrue(resolver.evaluate("'livk'==#username", method, args, Boolean.class));
-		assertEquals("livk", resolver.evaluate("#username", method, args));
+		assertThat(resolver.evaluate("'livk'==#username", method, args, Boolean.class)).isTrue();
+		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
 
-		assertTrue(resolver.evaluate("'livk'==#username", map, Boolean.class));
-		assertEquals("livk", resolver.evaluate("#username", map));
+		assertThat(resolver.evaluate("'livk'==#username", map, Boolean.class)).isTrue();
+		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
 
-		assertEquals("root:livk", resolver.evaluate("root:#{#username}", method, args));
-		assertEquals("root:livk:123456", resolver.evaluate("root:#{#username}:#{#password}", context));
+		assertThat(resolver.evaluate("root:#{#username}", method, args)).isEqualTo("root:livk");
+		assertThat(resolver.evaluate("root:#{#username}:#{#password}", context)).isEqualTo("root:livk:123456");
 
-		assertEquals("root:livk", resolver.evaluate("root:#{#username}", map));
-		assertEquals("livk:" + System.getProperty("user.dir"),
-				resolver.evaluate(("#{#username}:#{T(java.lang.System).getProperty(\"user.dir\")}"), map));
+		assertThat(resolver.evaluate("root:#{#username}", map)).isEqualTo("root:livk");
+		assertThat(resolver.evaluate("#{#username}:#{T(java.lang.System).getProperty(\"user.dir\")}", map))
+			.isEqualTo("livk:" + System.getProperty("user.dir"));
 
-		assertEquals("root:livk", resolver.evaluate("root:#{#username}", method, args));
-		assertEquals("livk", resolver.evaluate("#username", method, args));
-		assertEquals("livk", resolver.evaluate("livk", method, args));
+		assertThat(resolver.evaluate("root:#{#username}", method, args)).isEqualTo("root:livk");
+		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
+		assertThat(resolver.evaluate("livk", method, args)).isEqualTo("livk");
 
-		assertEquals("root:livk:123456", resolver.evaluate("root:#{#username}:#{#password}", context));
-		assertEquals("livk123456", resolver.evaluate("#username+#password", context));
+		assertThat(resolver.evaluate("root:#{#username}:#{#password}", context)).isEqualTo("root:livk:123456");
+		assertThat(resolver.evaluate("#username+#password", context)).isEqualTo("livk123456");
 
-		assertEquals("root:livk", resolver.evaluate("root:#{#username}", map));
-		assertEquals("livk", resolver.evaluate("#username", map));
-		assertEquals("livk:" + System.getProperty("user.dir"),
-				resolver.evaluate("#{#username}:#{T(java.lang.System).getProperty(\"user.dir\")}", map));
+		assertThat(resolver.evaluate("root:#{#username}", map)).isEqualTo("root:livk");
+		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
+		assertThat(resolver.evaluate("#{#username}:#{T(java.lang.System).getProperty(\"user.dir\")}", map))
+			.isEqualTo("livk:" + System.getProperty("user.dir"));
 
 		contextRunner.run(ctx -> {
-			assertEquals("livk:livk", resolver.evaluate(
+			assertThat(resolver.evaluate(
 					"#{#username}:#{T(" + springContextHolderName + ").getProperty(\"spring.application.root.name\")}",
-					map));
+					map))
+				.isEqualTo("livk:livk");
 
-			assertEquals("livk:livk", resolver.evaluate(
+			assertThat(resolver.evaluate(
 					"#{#username}:#{T(" + springContextHolderName + ").getProperty(\"spring.application.root.name\")}",
-					map));
+					map))
+				.isEqualTo("livk:livk");
 
 			Map<String, Object> envMap = Map.of("username", "livk", "env",
 					SpringContextHolder.getBean(Environment.class));
-			assertEquals("livk:livk",
-					resolver.evaluate("#{#username}:#{#env.getProperty(\"spring.application.root.name\")}", envMap));
+			assertThat(resolver.evaluate("#{#username}:#{#env.getProperty(\"spring.application.root.name\")}", envMap))
+				.isEqualTo("livk:livk");
 		});
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/HttpClientImportSelectorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/HttpClientImportSelectorTests.java
@@ -21,7 +21,7 @@ import com.livk.commons.http.annotation.HttpClientType;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -35,23 +35,24 @@ class HttpClientImportSelectorTests {
 		{
 			String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(AllConfig.class));
 			@SuppressWarnings("deprecation")
-			String[] result = new String[] { WebClientConfiguration.class.getName(),
+			String[] expected = new String[] { WebClientConfiguration.class.getName(),
 					RestClientConfiguration.class.getName(), RestTemplateConfiguration.class.getName() };
-			assertArrayEquals(result, imports);
+			assertThat(imports).containsExactly(expected);
 		}
 
 		{
 			String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(TwoConfig.class));
-			String[] result = new String[] { WebClientConfiguration.class.getName(),
+			String[] expected = new String[] { WebClientConfiguration.class.getName(),
 					RestClientConfiguration.class.getName() };
-			assertArrayEquals(result, imports);
+			assertThat(imports).containsExactly(expected);
 		}
 
 		{
 			String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(OneConfig.class));
-			String[] result = new String[] { WebClientConfiguration.class.getName() };
-			assertArrayEquals(result, imports);
+			String[] expected = new String[] { WebClientConfiguration.class.getName() };
+			assertThat(imports).containsExactly(expected);
 		}
+
 	}
 
 	@SuppressWarnings("deprecation")

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/annotation/HttpClientTypeTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/annotation/HttpClientTypeTests.java
@@ -18,7 +18,7 @@ package com.livk.commons.http.annotation;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -28,9 +28,10 @@ class HttpClientTypeTests {
 	@Test
 	@SuppressWarnings("deprecation")
 	void annotationType() {
-		assertEquals(EnableRestClient.class, HttpClientType.REST_CLIENT.annotationType());
-		assertEquals(EnableRestTemplate.class, HttpClientType.REST_TEMPLATE.annotationType());
-		assertEquals(EnableWebClient.class, HttpClientType.WEB_CLIENT.annotationType());
+		assertThat(HttpClientType.REST_CLIENT.annotationType()).isEqualTo(EnableRestClient.class);
+		assertThat(HttpClientType.REST_TEMPLATE.annotationType()).isEqualTo(EnableRestTemplate.class);
+		assertThat(HttpClientType.WEB_CLIENT.annotationType()).isEqualTo(EnableWebClient.class);
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/io/FileUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/io/FileUtilsTests.java
@@ -28,8 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -40,20 +39,23 @@ class FileUtilsTests {
 	void download() throws IOException {
 		InputStream inputStream = new ByteArrayInputStream("livk".getBytes());
 		FileUtils.download(inputStream, "./username.txt");
-		assertTrue(new File("./username.txt").delete());
+		File file = new File("./username.txt");
+		assertThat(file.exists()).isTrue();
+		assertThat(file.delete()).isTrue();
 	}
 
 	@Test
 	void createNewFile() throws IOException {
 		File file = new File("./file.txt");
-		assertTrue(FileUtils.createNewFile(file));
-		assertTrue(file.delete());
+		assertThat(FileUtils.createNewFile(file)).isTrue();
+		assertThat(file.delete()).isTrue();
 	}
 
 	@Test
 	void gzip() throws IOException {
 		InputStream inputStream = new ClassPathResource("data.json").getInputStream();
 		String data = JsonMapperUtils.readValue(inputStream, JsonNode.class).toString();
+
 		File file = new File("./data.gzip");
 		FileUtils.createNewFile(file);
 		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
@@ -62,8 +64,8 @@ class FileUtilsTests {
 
 		try (FileInputStream fileInputStream = new FileInputStream(file)) {
 			String copyData = new String(FileUtils.gzipDecompress(fileInputStream));
-			assertEquals(data, copyData);
-			assertTrue(file.delete());
+			assertThat(copyData).isEqualTo(data);
+			assertThat(file.delete()).isTrue();
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/io/ResourceUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/io/ResourceUtilsTests.java
@@ -23,7 +23,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -37,11 +37,11 @@ class ResourceUtilsTests {
 
 		File file = ResourceUtils.getFile(ResourceUtils.CLASSPATH_URL_PREFIX + fileName);
 
-		assertEquals(file, resource.getFile());
+		assertThat(resource.getFile()).isEqualTo(file);
 
 		Resource[] resources = ResourceUtils.getResources(ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + fileName);
 		for (Resource resourceObj : resources) {
-			assertEquals(file, resourceObj.getFile());
+			assertThat(resourceObj.getFile()).isEqualTo(file);
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonMapperUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonMapperUtilsTests.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.MapType;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.livk.commons.util.Pair;
 import org.intellij.lang.annotations.Language;
@@ -41,9 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -67,210 +64,212 @@ class JsonMapperUtilsTests {
 		JsonFactory jsonFactory = new JsonFactory();
 		try (JsonParser parser = jsonFactory.createParser(json)) {
 			JsonNode parserJsonNode = JsonMapperUtils.readValue(parser, JsonNode.class);
-			assertNotNull(parserJsonNode);
-			assertEquals("1", parserJsonNode.get("c").asText());
-			assertEquals("2", parserJsonNode.get("a").asText());
-			assertEquals(3, parserJsonNode.get("b").get("c").asInt());
+			assertThat(parserJsonNode).isNotNull();
+			assertThat(parserJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(parserJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 
 		try (JsonParser parser = jsonFactory.createParser(json)) {
 			JsonNode parserJsonNode = JsonMapperUtils.readValue(parser, new TypeReference<>() {
 			});
-			assertNotNull(parserJsonNode);
-			assertEquals("1", parserJsonNode.get("c").asText());
-			assertEquals("2", parserJsonNode.get("a").asText());
-			assertEquals(3, parserJsonNode.get("b").get("c").asInt());
+			assertThat(parserJsonNode).isNotNull();
+			assertThat(parserJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(parserJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 
 		try (JsonParser parser = jsonFactory.createParser(json)) {
 			JsonNode parserJsonNode = JsonMapperUtils.readValue(parser, javaType);
-			assertNotNull(parserJsonNode);
-			assertEquals("1", parserJsonNode.get("c").asText());
-			assertEquals("2", parserJsonNode.get("a").asText());
-			assertEquals(3, parserJsonNode.get("b").get("c").asInt());
+			assertThat(parserJsonNode).isNotNull();
+			assertThat(parserJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(parserJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 	}
 
 	@Test
 	void readValueFile() throws IOException {
 		File file = new ClassPathResource("input.json").getFile();
+
 		JsonNode fileJsonNode = JsonMapperUtils.readValue(file, JsonNode.class);
-		assertNotNull(fileJsonNode);
-		assertEquals("1", fileJsonNode.get("c").asText());
-		assertEquals("2", fileJsonNode.get("a").asText());
-		assertEquals(3, fileJsonNode.get("b").get("c").asInt());
+		assertThat(fileJsonNode).isNotNull();
+		assertThat(fileJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(fileJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		fileJsonNode = JsonMapperUtils.readValue(file, new TypeReference<>() {
 		});
-		assertNotNull(fileJsonNode);
-		assertEquals("1", fileJsonNode.get("c").asText());
-		assertEquals("2", fileJsonNode.get("a").asText());
-		assertEquals(3, fileJsonNode.get("b").get("c").asInt());
+		assertThat(fileJsonNode).isNotNull();
+		assertThat(fileJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(fileJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		fileJsonNode = JsonMapperUtils.readValue(file, javaType);
-		assertNotNull(fileJsonNode);
-		assertEquals("1", fileJsonNode.get("c").asText());
-		assertEquals("2", fileJsonNode.get("a").asText());
-		assertEquals(3, fileJsonNode.get("b").get("c").asInt());
+		assertThat(fileJsonNode).isNotNull();
+		assertThat(fileJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(fileJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+
 	}
 
 	@Test
 	void readValueURL() throws IOException {
 		URL url = new ClassPathResource("input.json").getURL();
+
 		JsonNode urlJsonNode = JsonMapperUtils.readValue(url, JsonNode.class);
-		assertNotNull(urlJsonNode);
-		assertEquals("1", urlJsonNode.get("c").asText());
-		assertEquals("2", urlJsonNode.get("a").asText());
-		assertEquals(3, urlJsonNode.get("b").get("c").asInt());
+		assertThat(urlJsonNode).isNotNull();
+		assertThat(urlJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(urlJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		urlJsonNode = JsonMapperUtils.readValue(url, new TypeReference<>() {
 		});
-		assertNotNull(urlJsonNode);
-		assertEquals("1", urlJsonNode.get("c").asText());
-		assertEquals("2", urlJsonNode.get("a").asText());
-		assertEquals(3, urlJsonNode.get("b").get("c").asInt());
+		assertThat(urlJsonNode).isNotNull();
+		assertThat(urlJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(urlJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		urlJsonNode = JsonMapperUtils.readValue(url, javaType);
-		assertNotNull(urlJsonNode);
-		assertEquals("1", urlJsonNode.get("c").asText());
-		assertEquals("2", urlJsonNode.get("a").asText());
-		assertEquals(3, urlJsonNode.get("b").get("c").asInt());
+		assertThat(urlJsonNode).isNotNull();
+		assertThat(urlJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(urlJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+
 	}
 
 	@Test
 	void readValueStr() {
 		JsonNode strJsonNode = JsonMapperUtils.readValue(json, JsonNode.class);
-		assertNotNull(strJsonNode);
-		assertEquals("1", strJsonNode.get("c").asText());
-		assertEquals("2", strJsonNode.get("a").asText());
-		assertEquals(3, strJsonNode.get("b").get("c").asInt());
+		assertThat(strJsonNode).isNotNull();
+		assertThat(strJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(strJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(strJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode typeReferenceJsonNode = JsonMapperUtils.readValue(json, new TypeReference<>() {
 		});
-		assertNotNull(typeReferenceJsonNode);
-		assertEquals("1", typeReferenceJsonNode.get("c").asText());
-		assertEquals("2", typeReferenceJsonNode.get("a").asText());
-		assertEquals(3, typeReferenceJsonNode.get("b").get("c").asInt());
+		assertThat(typeReferenceJsonNode).isNotNull();
+		assertThat(typeReferenceJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(typeReferenceJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(typeReferenceJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode javaTypeJsonNode = JsonMapperUtils.readValue(json, javaType);
-		assertNotNull(javaTypeJsonNode);
-		assertEquals("1", javaTypeJsonNode.get("c").asText());
-		assertEquals("2", javaTypeJsonNode.get("a").asText());
-		assertEquals(3, javaTypeJsonNode.get("b").get("c").asInt());
+		assertThat(javaTypeJsonNode).isNotNull();
+		assertThat(javaTypeJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(javaTypeJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(javaTypeJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+
 	}
 
 	@Test
 	void readValueReader() throws IOException {
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
-			InputStreamReader reader = new InputStreamReader(inputStream);
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+				InputStreamReader reader = new InputStreamReader(inputStream)) {
 			JsonNode readerJsonNode = JsonMapperUtils.readValue(reader, JsonNode.class);
-			assertNotNull(readerJsonNode);
-			assertEquals("1", readerJsonNode.get("c").asText());
-			assertEquals("2", readerJsonNode.get("a").asText());
-			assertEquals(3, readerJsonNode.get("b").get("c").asInt());
+			assertThat(readerJsonNode).isNotNull();
+			assertThat(readerJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(readerJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
-			InputStreamReader reader = new InputStreamReader(inputStream);
+
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+				InputStreamReader reader = new InputStreamReader(inputStream)) {
 			JsonNode readerJsonNode = JsonMapperUtils.readValue(reader, new TypeReference<>() {
 			});
-			assertNotNull(readerJsonNode);
-			assertEquals("1", readerJsonNode.get("c").asText());
-			assertEquals("2", readerJsonNode.get("a").asText());
-			assertEquals(3, readerJsonNode.get("b").get("c").asInt());
+			assertThat(readerJsonNode).isNotNull();
+			assertThat(readerJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(readerJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
-			InputStreamReader reader = new InputStreamReader(inputStream);
+
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+				InputStreamReader reader = new InputStreamReader(inputStream)) {
 			JsonNode readerJsonNode = JsonMapperUtils.readValue(reader, javaType);
-			assertNotNull(readerJsonNode);
-			assertEquals("1", readerJsonNode.get("c").asText());
-			assertEquals("2", readerJsonNode.get("a").asText());
-			assertEquals(3, readerJsonNode.get("b").get("c").asInt());
+			assertThat(readerJsonNode).isNotNull();
+			assertThat(readerJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(readerJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 	}
 
 	@Test
 	void readValueInputStream() throws IOException {
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			JsonNode inputStreamJsonNode = JsonMapperUtils.readValue(inputStream, JsonNode.class);
-			assertNotNull(inputStreamJsonNode);
-			assertEquals("1", inputStreamJsonNode.get("c").asText());
-			assertEquals("2", inputStreamJsonNode.get("a").asText());
-			assertEquals(3, inputStreamJsonNode.get("b").get("c").asInt());
+			assertThat(inputStreamJsonNode).isNotNull();
+			assertThat(inputStreamJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(inputStreamJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			JsonNode inputStreamJsonNode = JsonMapperUtils.readValue(inputStream, new TypeReference<>() {
 			});
-			assertNotNull(inputStreamJsonNode);
-			assertEquals("1", inputStreamJsonNode.get("c").asText());
-			assertEquals("2", inputStreamJsonNode.get("a").asText());
-			assertEquals(3, inputStreamJsonNode.get("b").get("c").asInt());
+			assertThat(inputStreamJsonNode).isNotNull();
+			assertThat(inputStreamJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(inputStreamJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			JsonNode inputStreamJsonNode = JsonMapperUtils.readValue(inputStream, javaType);
-			assertNotNull(inputStreamJsonNode);
-			assertEquals("1", inputStreamJsonNode.get("c").asText());
-			assertEquals("2", inputStreamJsonNode.get("a").asText());
-			assertEquals(3, inputStreamJsonNode.get("b").get("c").asInt());
+			assertThat(inputStreamJsonNode).isNotNull();
+			assertThat(inputStreamJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(inputStreamJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 	}
 
 	@Test
 	void readValueByteArray() {
-		JsonNode byteArrayJsonNode = JsonMapperUtils.readValue(json.getBytes(), JsonNode.class);
-		assertNotNull(byteArrayJsonNode);
-		assertEquals("1", byteArrayJsonNode.get("c").asText());
-		assertEquals("2", byteArrayJsonNode.get("a").asText());
-		assertEquals(3, byteArrayJsonNode.get("b").get("c").asInt());
+		byte[] jsonBytes = json.getBytes();
 
-		byteArrayJsonNode = JsonMapperUtils.readValue(json.getBytes(), new TypeReference<>() {
+		JsonNode byteArrayJsonNode = JsonMapperUtils.readValue(jsonBytes, JsonNode.class);
+		assertThat(byteArrayJsonNode).isNotNull();
+		assertThat(byteArrayJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(byteArrayJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+
+		byteArrayJsonNode = JsonMapperUtils.readValue(jsonBytes, new TypeReference<>() {
 		});
-		assertNotNull(byteArrayJsonNode);
-		assertEquals("1", byteArrayJsonNode.get("c").asText());
-		assertEquals("2", byteArrayJsonNode.get("a").asText());
-		assertEquals(3, byteArrayJsonNode.get("b").get("c").asInt());
+		assertThat(byteArrayJsonNode).isNotNull();
+		assertThat(byteArrayJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(byteArrayJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
-		byteArrayJsonNode = JsonMapperUtils.readValue(json.getBytes(), javaType);
-		assertNotNull(byteArrayJsonNode);
-		assertEquals("1", byteArrayJsonNode.get("c").asText());
-		assertEquals("2", byteArrayJsonNode.get("a").asText());
-		assertEquals(3, byteArrayJsonNode.get("b").get("c").asInt());
+		byteArrayJsonNode = JsonMapperUtils.readValue(jsonBytes, javaType);
+		assertThat(byteArrayJsonNode).isNotNull();
+		assertThat(byteArrayJsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(byteArrayJsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 	}
 
 	@Test
 	void readValueDataInput() throws IOException {
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			DataInput dataInput = new DataInputStream(inputStream);
 			JsonNode dataInputJsonNode = JsonMapperUtils.readValue(dataInput, JsonNode.class);
-			assertNotNull(dataInputJsonNode);
-			assertEquals("1", dataInputJsonNode.get("c").asText());
-			assertEquals("2", dataInputJsonNode.get("a").asText());
-			assertEquals(3, dataInputJsonNode.get("b").get("c").asInt());
+			assertThat(dataInputJsonNode).isNotNull();
+			assertThat(dataInputJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(dataInputJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(dataInputJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			DataInput dataInput = new DataInputStream(inputStream);
-			JsonNode dataInputJsonNode = JsonMapperUtils.readValue(dataInput, new TypeReference<>() {
+			JsonNode jsonNode = JsonMapperUtils.readValue(dataInput, new TypeReference<JsonNode>() {
 			});
-			assertNotNull(dataInputJsonNode);
-			assertEquals("1", dataInputJsonNode.get("c").asText());
-			assertEquals("2", dataInputJsonNode.get("a").asText());
-			assertEquals(3, dataInputJsonNode.get("b").get("c").asInt());
+			assertThat(jsonNode).isNotNull();
+			assertThat(jsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(jsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(jsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-		{
-			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
+		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			DataInput dataInput = new DataInputStream(inputStream);
-			JsonNode dataInputJsonNode = JsonMapperUtils.readValue(dataInput, javaType);
-			assertNotNull(dataInputJsonNode);
-			assertEquals("1", dataInputJsonNode.get("c").asText());
-			assertEquals("2", dataInputJsonNode.get("a").asText());
-			assertEquals(3, dataInputJsonNode.get("b").get("c").asInt());
+			JsonNode jsonNode = JsonMapperUtils.readValue(dataInput, javaType);
+			assertThat(jsonNode).isNotNull();
+			assertThat(jsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(jsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(jsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 	}
 
@@ -278,10 +277,10 @@ class JsonMapperUtilsTests {
 	void writeValueAsString() {
 		String result = JsonMapperUtils.writeValueAsString(Map.of("username", "password"));
 		String json = "{\"username\":\"password\"}";
-		assertEquals(json, result);
+		assertThat(result).isEqualTo(json);
 
 		byte[] bytes = JsonMapperUtils.writeValueAsBytes(Map.of("username", "password"));
-		assertArrayEquals(json.getBytes(), bytes);
+		assertThat(bytes).isEqualTo(json.getBytes());
 	}
 
 	@Test
@@ -297,26 +296,27 @@ class JsonMapperUtilsTests {
 				  }
 				]""";
 		List<JsonNode> result = JsonMapperUtils.readValueList(json, JsonNode.class);
-		assertNotNull(result);
-		assertEquals(1, result.get(0).get("a").asInt());
-		assertEquals(1, result.get(1).get("a").asInt());
+		assertThat(result).isNotNull();
+		assertThat(result.get(0).get("a").asInt()).isEqualTo(1);
+		assertThat(result.get(1).get("a").asInt()).isEqualTo(1);
+
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
 	void readValueMap() throws IOException {
 		Map<String, Object> result = JsonMapperUtils.readValueMap(json, String.class, Object.class);
-		assertNotNull(result);
-		assertEquals("1", result.get("c"));
-		assertEquals("2", result.get("a"));
-		assertEquals(3, ((Map<String, Object>) result.get("b")).get("c"));
+		assertThat(result).isNotNull();
+		assertThat(result).containsEntry("c", "1");
+		assertThat(result).containsEntry("a", "2");
+		assertThat((Map<String, Object>) result.get("b")).containsEntry("c", 3);
 
 		Map<String, Object> result1 = JsonMapperUtils.readValueMap(new ClassPathResource("input.json").getInputStream(),
 				String.class, Object.class);
-		assertNotNull(result1);
-		assertEquals("1", result1.get("c"));
-		assertEquals("2", result1.get("a"));
-		assertEquals(3, ((Map<String, Object>) result1.get("b")).get("c"));
+		assertThat(result1).isNotNull();
+		assertThat(result1).containsEntry("c", "1");
+		assertThat(result1).containsEntry("a", "2");
+		assertThat((Map<String, Object>) result1.get("b")).containsEntry("c", 3);
 	}
 
 	@Test
@@ -325,65 +325,58 @@ class JsonMapperUtilsTests {
 			JsonFactory jsonFactory = new JsonFactory();
 			try (JsonParser parser = jsonFactory.createParser(json)) {
 				JsonNode parserJsonNode = JsonMapperUtils.readTree(parser);
-				assertNotNull(parserJsonNode);
-				assertEquals("1", parserJsonNode.get("c").asText());
-				assertEquals("2", parserJsonNode.get("a").asText());
-				assertEquals(3, parserJsonNode.get("b").get("c").asInt());
+				assertThat(parserJsonNode).isNotNull();
+				assertThat(parserJsonNode.get("c").asText()).isEqualTo("1");
+				assertThat(parserJsonNode.get("a").asText()).isEqualTo("2");
+				assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 			}
 		}
-
 		{
 			File file = new ClassPathResource("input.json").getFile();
 			JsonNode fileJsonNode = JsonMapperUtils.readTree(file);
-			assertNotNull(fileJsonNode);
-			assertEquals("1", fileJsonNode.get("c").asText());
-			assertEquals("2", fileJsonNode.get("a").asText());
-			assertEquals(3, fileJsonNode.get("b").get("c").asInt());
+			assertThat(fileJsonNode).isNotNull();
+			assertThat(fileJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(fileJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-
 		{
 			URL url = new ClassPathResource("input.json").getURL();
 			JsonNode urlJsonNode = JsonMapperUtils.readTree(url);
-			assertNotNull(urlJsonNode);
-			assertEquals("1", urlJsonNode.get("c").asText());
-			assertEquals("2", urlJsonNode.get("a").asText());
-			assertEquals(3, urlJsonNode.get("b").get("c").asInt());
+			assertThat(urlJsonNode).isNotNull();
+			assertThat(urlJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(urlJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-
 		{
 			JsonNode result = JsonMapperUtils.readTree(json);
-			assertNotNull(result);
-			assertEquals("1", result.get("c").asText());
-			assertEquals("2", result.get("a").asText());
-			assertEquals(3, result.get("b").get("c").asInt());
+			assertThat(result).isNotNull();
+			assertThat(result.get("c").asText()).isEqualTo("1");
+			assertThat(result.get("a").asText()).isEqualTo("2");
+			assertThat(result.get("b").get("c").asInt()).isEqualTo(3);
 		}
-
 		{
 			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 			InputStreamReader reader = new InputStreamReader(inputStream);
 			JsonNode readerJsonNode = JsonMapperUtils.readTree(reader);
-			assertNotNull(readerJsonNode);
-			assertEquals("1", readerJsonNode.get("c").asText());
-			assertEquals("2", readerJsonNode.get("a").asText());
-			assertEquals(3, readerJsonNode.get("b").get("c").asInt());
+			assertThat(readerJsonNode).isNotNull();
+			assertThat(readerJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(readerJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-
 		{
 			InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 			JsonNode inputStreamJsonNode = JsonMapperUtils.readTree(inputStream);
-			assertNotNull(inputStreamJsonNode);
-			assertEquals("1", inputStreamJsonNode.get("c").asText());
-			assertEquals("2", inputStreamJsonNode.get("a").asText());
-			assertEquals(3, inputStreamJsonNode.get("b").get("c").asInt());
+			assertThat(inputStreamJsonNode).isNotNull();
+			assertThat(inputStreamJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(inputStreamJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
-
 		{
-
 			JsonNode byteArrayJsonNode = JsonMapperUtils.readTree(json.getBytes());
-			assertNotNull(byteArrayJsonNode);
-			assertEquals("1", byteArrayJsonNode.get("c").asText());
-			assertEquals("2", byteArrayJsonNode.get("a").asText());
-			assertEquals(3, byteArrayJsonNode.get("b").get("c").asInt());
+			assertThat(byteArrayJsonNode).isNotNull();
+			assertThat(byteArrayJsonNode.get("c").asText()).isEqualTo("1");
+			assertThat(byteArrayJsonNode.get("a").asText()).isEqualTo("2");
+			assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
 		}
 	}
 
@@ -391,14 +384,14 @@ class JsonMapperUtilsTests {
 	void convertValueList() {
 		Set<String> set = Set.of("username", "password");
 		List<String> list = JsonMapperUtils.convertValueList(set, String.class);
-		assertEquals(Lists.newArrayList(set), list);
+		assertThat(list).containsExactlyElementsOf(set);
 	}
 
 	@Test
 	void convertValueMap() {
 		Pair<String, String> pair = Pair.of("username", "password");
 		Map<String, String> map = JsonMapperUtils.convertValueMap(pair, String.class, String.class);
-		assertEquals(Map.of(pair.key(), pair.value()), map);
+		assertThat(map).containsExactly(Map.entry(pair.key(), pair.value()));
 	}
 
 	@Test
@@ -427,17 +420,25 @@ class JsonMapperUtilsTests {
 				"spring-boot-starter-json");
 		MapType mapType = TypeFactoryUtils.mapType(String.class, String.class);
 		List<JsonNode> jsonNodeList = Streams.stream(dependencyArray.elements()).toList();
-		assertEquals(loggingDependency, JsonMapperUtils.convertValue(jsonNodeList.get(0), mapType));
-		assertEquals(jsonDependency, JsonMapperUtils.convertValue(jsonNodeList.get(1), mapType));
+
+		assertThat(JsonMapperUtils.<Map<String, String>>convertValue(jsonNodeList.get(0), mapType))
+			.containsExactlyInAnyOrderEntriesOf(loggingDependency);
+
+		assertThat(JsonMapperUtils.<Map<String, String>>convertValue(jsonNodeList.get(1), mapType))
+			.containsExactlyInAnyOrderEntriesOf(jsonDependency);
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
 		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
-		assertEquals(dependencyList, JsonMapperUtils.convertValue(dependencyArray, collectionType));
+
+		assertThat(JsonMapperUtils.<List<Map<String, String>>>convertValue(dependencyArray, collectionType))
+			.containsExactlyElementsOf(dependencyList);
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);
 		Map<String, List<Map<String, String>>> dependencyManagement = Map.of("dependency", dependencyList);
 		MapType constructMapType = TypeFactoryUtils.mapType(javaType, collectionType);
-		assertEquals(dependencyManagement, JsonMapperUtils.convertValue(jsonNode, constructMapType));
+
+		assertThat(JsonMapperUtils.<Map<String, List<Map<String, String>>>>convertValue(jsonNode, constructMapType))
+			.containsExactlyEntriesOf(dependencyManagement);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonNodeUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonNodeUtilsTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -44,21 +44,21 @@ class JsonNodeUtilsTests {
 	@Test
 	void findStringValue() {
 		String username = JsonNodeUtils.findStringValue(node, "username");
-		assertEquals("root", username);
+		assertThat(username).isEqualTo("root");
 	}
 
 	@Test
 	void findValue() {
 		Map<String, Object> map = JsonNodeUtils.findValue(node, "info", JsonNodeUtils.STRING_OBJECT_MAP,
 				JsonMapper.builder().build());
-		assertEquals(Map.of("name", "livk", "email", "1375632510@qq.com"), map);
+		assertThat(map).containsExactlyInAnyOrderEntriesOf(Map.of("name", "livk", "email", "1375632510@qq.com"));
 	}
 
 	@Test
 	void findObjectNode() {
 		JsonNode jsonNode = JsonNodeUtils.findObjectNode(node, "info");
-		assertEquals("livk", jsonNode.get("name").asText());
-		assertEquals("1375632510@qq.com", jsonNode.get("email").asText());
+		assertThat(jsonNode.get("name").asText()).isEqualTo("livk");
+		assertThat(jsonNode.get("email").asText()).isEqualTo("1375632510@qq.com");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/TypeFactoryUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/TypeFactoryUtilsTests.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,43 +41,42 @@ class TypeFactoryUtilsTests {
 
 	@Test
 	void instance() {
-		assertEquals(new ObjectMapper().getTypeFactory(), TypeFactoryUtils.instance());
+		assertThat(TypeFactoryUtils.instance()).isEqualTo(new ObjectMapper().getTypeFactory());
 	}
 
 	@Test
 	void javaType() {
 		SimpleType strType = SimpleType.constructUnsafe(String.class);
 		{
-			assertEquals(strType, TypeFactoryUtils.javaType(String.class));
-			assertEquals(strType, TypeFactoryUtils.javaType(new TypeReference<String>() {
-
-			}));
-			assertEquals(strType, TypeFactoryUtils.javaType(ResolvableType.forClass(String.class)));
+			assertThat(TypeFactoryUtils.javaType(String.class)).isEqualTo(strType);
+			assertThat(TypeFactoryUtils.javaType(new TypeReference<String>() {
+			})).isEqualTo(strType);
+			assertThat(TypeFactoryUtils.javaType(ResolvableType.forClass(String.class))).isEqualTo(strType);
 		}
 
 		{
 			TypeBindings bindings = TypeBindings.createIfNeeded(List.class, strType);
 			CollectionType collectionType = CollectionType.construct(List.class, bindings,
 					SimpleType.constructUnsafe(Collection.class), null, strType);
-			assertEquals(collectionType, TypeFactoryUtils.javaType(List.class, String.class));
-			assertEquals(collectionType, TypeFactoryUtils.javaType(List.class, strType));
-			assertEquals(collectionType, TypeFactoryUtils.javaType(new TypeReference<List<String>>() {
-			}));
-			assertEquals(collectionType,
-					TypeFactoryUtils.javaType(ResolvableType.forClassWithGenerics(List.class, String.class)));
+			assertThat(TypeFactoryUtils.javaType(List.class, String.class)).isEqualTo(collectionType);
+			assertThat(TypeFactoryUtils.javaType(List.class, strType)).isEqualTo(collectionType);
+			assertThat(TypeFactoryUtils.javaType(new TypeReference<List<String>>() {
+			})).isEqualTo(collectionType);
+			assertThat(TypeFactoryUtils.javaType(ResolvableType.forClassWithGenerics(List.class, String.class)))
+				.isEqualTo(collectionType);
 		}
 
 		{
 			TypeBindings bindings = TypeBindings.createIfNeeded(Map.class, new JavaType[] { strType, strType });
 			MapType mapType = MapType.construct(Map.class, bindings, TypeFactory.unknownType(), null, strType, strType);
-			assertEquals(mapType, TypeFactoryUtils.javaType(Map.class, String.class, String.class));
-			assertEquals(mapType, TypeFactoryUtils.javaType(Map.class, strType, strType));
-			assertEquals(mapType, TypeFactoryUtils.javaType(new TypeReference<Map<String, String>>() {
-			}));
-			assertEquals(mapType, TypeFactoryUtils
-				.javaType(ResolvableType.forClassWithGenerics(Map.class, String.class, String.class)));
+			assertThat(TypeFactoryUtils.javaType(Map.class, String.class, String.class)).isEqualTo(mapType);
+			assertThat(TypeFactoryUtils.javaType(Map.class, strType, strType)).isEqualTo(mapType);
+			assertThat(TypeFactoryUtils.javaType(new TypeReference<Map<String, String>>() {
+			})).isEqualTo(mapType);
+			assertThat(TypeFactoryUtils
+				.javaType(ResolvableType.forClassWithGenerics(Map.class, String.class, String.class)))
+				.isEqualTo(mapType);
 		}
-
 	}
 
 	@Test
@@ -86,18 +85,18 @@ class TypeFactoryUtilsTests {
 		TypeBindings bindings = TypeBindings.createIfNeeded(List.class, strType);
 		CollectionType listType = CollectionType.construct(List.class, bindings,
 				SimpleType.constructUnsafe(Iterable.class), null, strType);
-		assertEquals(listType, TypeFactoryUtils.listType(String.class));
-		assertEquals(listType, TypeFactoryUtils.listType(strType));
+		assertThat(TypeFactoryUtils.listType(String.class)).isEqualTo(listType);
+		assertThat(TypeFactoryUtils.listType(strType)).isEqualTo(listType);
 	}
 
 	@Test
-	void seyType() {
+	void setType() {
 		SimpleType strType = SimpleType.constructUnsafe(String.class);
 		TypeBindings bindings = TypeBindings.createIfNeeded(Set.class, strType);
 		CollectionType setType = CollectionType.construct(Set.class, bindings,
 				SimpleType.constructUnsafe(Iterable.class), null, strType);
-		assertEquals(setType, TypeFactoryUtils.setType(String.class));
-		assertEquals(setType, TypeFactoryUtils.setType(strType));
+		assertThat(TypeFactoryUtils.setType(String.class)).isEqualTo(setType);
+		assertThat(TypeFactoryUtils.setType(strType)).isEqualTo(setType);
 	}
 
 	@Test
@@ -105,8 +104,8 @@ class TypeFactoryUtilsTests {
 		SimpleType strType = SimpleType.constructUnsafe(String.class);
 		TypeBindings bindings = TypeBindings.createIfNeeded(Map.class, new JavaType[] { strType, strType });
 		MapType mapType = MapType.construct(Map.class, bindings, TypeFactory.unknownType(), null, strType, strType);
-		assertEquals(mapType, TypeFactoryUtils.mapType(String.class, String.class));
-		assertEquals(mapType, TypeFactoryUtils.mapType(strType, strType));
+		assertThat(TypeFactoryUtils.mapType(String.class, String.class)).isEqualTo(mapType);
+		assertThat(TypeFactoryUtils.mapType(strType, strType)).isEqualTo(mapType);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * @author livk
@@ -40,20 +40,26 @@ class NumberJsonSerializerTests {
 		big.f = 0.333333f;
 		big.count = BigDecimal.valueOf(0.333333);
 		big.sunCount = BigDecimal.valueOf(0.333333);
+
 		String json = JsonMapperUtils.writeValueAsString(big);
 		Big bean = JsonMapperUtils.readValue(json, Big.class);
-		assertNotNull(bean);
-		assertEquals(33L, bean.l);
-		assertEquals(0.33d, bean.d);
-		assertEquals(0.3f, bean.f);
-		assertEquals(0.33d, bean.count.doubleValue());
-		assertEquals(0.333d, bean.sunCount.doubleValue());
+
+		assertThat(bean).isNotNull();
+		assertThat(bean.l).isEqualTo(33L);
+
+		assertThat(bean.d).isCloseTo(0.33d, within(0.0001));
+		assertThat(bean.f).isCloseTo(0.3f, within(0.0001f));
+		assertThat(bean.count.doubleValue()).isCloseTo(0.33d, within(0.0001));
+		assertThat(bean.sunCount.doubleValue()).isCloseTo(0.333d, within(0.0001));
+
 		JsonNode jsonNode = JsonMapperUtils.readTree(json);
-		assertEquals("0033", jsonNode.get(BeanLambda.fieldName(Big::getL)).asText());
-		assertEquals(0.33d, jsonNode.get(BeanLambda.fieldName(Big::getD)).asDouble());
-		assertEquals(0.3d, jsonNode.get(BeanLambda.fieldName(Big::getF)).asDouble());
-		assertEquals(0.33d, jsonNode.get(BeanLambda.fieldName(Big::getCount)).asDouble());
-		assertEquals(0.333d, jsonNode.get(BeanLambda.fieldName(Big::getSunCount)).asDouble());
+
+		assertThat(jsonNode.get(BeanLambda.fieldName(Big::getL)).asText()).isEqualTo("0033");
+		assertThat(jsonNode.get(BeanLambda.fieldName(Big::getD)).asDouble()).isCloseTo(0.33d, within(0.0001));
+		assertThat(jsonNode.get(BeanLambda.fieldName(Big::getF)).asDouble()).isCloseTo(0.3d, within(0.0001));
+		assertThat(jsonNode.get(BeanLambda.fieldName(Big::getCount)).asDouble()).isCloseTo(0.33d, within(0.0001));
+		assertThat(jsonNode.get(BeanLambda.fieldName(Big::getSunCount)).asDouble()).isCloseTo(0.333d, within(0.0001));
+
 	}
 
 	@Getter

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/support/JacksonSupportTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/support/JacksonSupportTests.java
@@ -37,9 +37,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -83,127 +81,127 @@ class JacksonSupportTests {
 
 	@Test
 	void javaType() {
-		assertEquals(String.class, TypeFactoryUtils.javaType(String.class).getRawClass());
-		assertEquals(Integer.class, TypeFactoryUtils.javaType(Integer.class).getRawClass());
-		assertEquals(Long.class, TypeFactoryUtils.javaType(Long.class).getRawClass());
+		assertThat(TypeFactoryUtils.javaType(String.class).getRawClass()).isEqualTo(String.class);
+		assertThat(TypeFactoryUtils.javaType(Integer.class).getRawClass()).isEqualTo(Integer.class);
+		assertThat(TypeFactoryUtils.javaType(Long.class).getRawClass()).isEqualTo(Long.class);
 
 		JavaType javaType = TypeFactoryUtils.javaType(Pair.class, String.class, Integer.class);
-		assertEquals(Pair.class, javaType.getRawClass());
-		assertEquals(String.class, javaType.getBindings().getBoundType(0).getRawClass());
-		assertEquals(Integer.class, javaType.getBindings().getBoundType(1).getRawClass());
+		assertThat(javaType.getRawClass()).isEqualTo(Pair.class);
+		assertThat(javaType.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+		assertThat(javaType.getBindings().getBoundType(1).getRawClass()).isEqualTo(Integer.class);
 
 		ResolvableType resolvableType = ResolvableType.forClassWithGenerics(Pair.class, String.class, Integer.class);
 		JavaType type = TypeFactoryUtils.javaType(resolvableType);
-		assertEquals(Pair.class, type.getRawClass());
-		assertEquals(String.class, type.getBindings().getBoundType(0).getRawClass());
-		assertEquals(Integer.class, type.getBindings().getBoundType(1).getRawClass());
+		assertThat(type.getRawClass()).isEqualTo(Pair.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+		assertThat(type.getBindings().getBoundType(1).getRawClass()).isEqualTo(Integer.class);
 
-		assertEquals(String.class, TypeFactoryUtils.listType(String.class).getBindings().getBoundType(0).getRawClass());
-		assertEquals(Integer.class,
-				TypeFactoryUtils.listType(Integer.class).getBindings().getBoundType(0).getRawClass());
-		assertEquals(Long.class, TypeFactoryUtils.setType(Long.class).getBindings().getBoundType(0).getRawClass());
+		assertThat(TypeFactoryUtils.listType(String.class).getBindings().getBoundType(0).getRawClass())
+			.isEqualTo(String.class);
+		assertThat(TypeFactoryUtils.listType(Integer.class).getBindings().getBoundType(0).getRawClass())
+			.isEqualTo(Integer.class);
+		assertThat(TypeFactoryUtils.setType(Long.class).getBindings().getBoundType(0).getRawClass())
+			.isEqualTo(Long.class);
 
-		assertEquals(List.of(TypeFactoryUtils.javaType(String.class), TypeFactoryUtils.javaType(String.class)),
-				TypeFactoryUtils.mapType(String.class, String.class).getBindings().getTypeParameters());
-		assertEquals(List.of(TypeFactoryUtils.javaType(String.class), TypeFactoryUtils.javaType(Integer.class)),
-				TypeFactoryUtils.mapType(String.class, Integer.class).getBindings().getTypeParameters());
-		assertEquals(List.of(TypeFactoryUtils.javaType(Integer.class), TypeFactoryUtils.javaType(String.class)),
-				TypeFactoryUtils.mapType(Integer.class, String.class).getBindings().getTypeParameters());
-		assertEquals(List.of(TypeFactoryUtils.javaType(Integer.class), TypeFactoryUtils.javaType(Integer.class)),
-				TypeFactoryUtils.mapType(Integer.class, Integer.class).getBindings().getTypeParameters());
+		assertThat(TypeFactoryUtils.mapType(String.class, String.class).getBindings().getTypeParameters())
+			.isEqualTo(List.of(TypeFactoryUtils.javaType(String.class), TypeFactoryUtils.javaType(String.class)));
+		assertThat(TypeFactoryUtils.mapType(String.class, Integer.class).getBindings().getTypeParameters())
+			.isEqualTo(List.of(TypeFactoryUtils.javaType(String.class), TypeFactoryUtils.javaType(Integer.class)));
+		assertThat(TypeFactoryUtils.mapType(Integer.class, String.class).getBindings().getTypeParameters())
+			.isEqualTo(List.of(TypeFactoryUtils.javaType(Integer.class), TypeFactoryUtils.javaType(String.class)));
+		assertThat(TypeFactoryUtils.mapType(Integer.class, Integer.class).getBindings().getTypeParameters())
+			.isEqualTo(List.of(TypeFactoryUtils.javaType(Integer.class), TypeFactoryUtils.javaType(Integer.class)));
 	}
 
 	@Test
 	void testJsonReadValue() throws IOException {
-
 		JsonNode result1 = JSON.readValue(json, JsonNode.class);
-		assertNotNull(result1);
-		assertEquals("1", result1.get("c").asText());
-		assertEquals("2", result1.get("a").asText());
-		assertEquals(3, result1.get("b").get("c").asInt());
+		assertThat(result1).isNotNull();
+		assertThat(result1.get("c").asText()).isEqualTo("1");
+		assertThat(result1.get("a").asText()).isEqualTo("2");
+		assertThat(result1.get("b").get("c").asInt()).isEqualTo(3);
 
 		InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 		JsonNode result2 = JSON.readValue(inputStream, JsonNode.class);
-		assertNotNull(result2);
-		assertEquals("1", result2.get("c").asText());
-		assertEquals("2", result2.get("a").asText());
-		assertEquals(3, result2.get("b").get("c").asInt());
+		assertThat(result2).isNotNull();
+		assertThat(result2.get("c").asText()).isEqualTo("1");
+		assertThat(result2.get("a").asText()).isEqualTo("2");
+		assertThat(result2.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode result3 = JSON.readValue(json, new TypeReference<>() {
 		});
-		assertNotNull(result3);
-		assertEquals("1", result3.get("c").asText());
-		assertEquals("2", result3.get("a").asText());
-		assertEquals(3, result3.get("b").get("c").asInt());
+		assertThat(result3).isNotNull();
+		assertThat(result3.get("c").asText()).isEqualTo("1");
+		assertThat(result3.get("a").asText()).isEqualTo("2");
+		assertThat(result3.get("b").get("c").asInt()).isEqualTo(3);
 
 		JavaType javaType = TypeFactoryUtils.javaType(JsonNode.class);
 		JsonNode result4 = JSON.readValue(json, javaType);
-		assertNotNull(result3);
-		assertEquals("1", result4.get("c").asText());
-		assertEquals("2", result4.get("a").asText());
-		assertEquals(3, result4.get("b").get("c").asInt());
+		assertThat(result4).isNotNull();
+		assertThat(result4.get("c").asText()).isEqualTo("1");
+		assertThat(result4.get("a").asText()).isEqualTo("2");
+		assertThat(result4.get("b").get("c").asInt()).isEqualTo(3);
 	}
 
 	@Test
 	void testYamlReadValue() throws IOException {
-
 		JsonNode result1 = YAML.readValue(yaml, JsonNode.class);
-		assertNotNull(result1);
-		assertEquals("1", result1.get("c").asText());
-		assertEquals("2", result1.get("a").asText());
-		assertEquals(3, result1.get("b").get("c").asInt());
+		assertThat(result1).isNotNull();
+		assertThat(result1.get("c").asText()).isEqualTo("1");
+		assertThat(result1.get("a").asText()).isEqualTo("2");
+		assertThat(result1.get("b").get("c").asInt()).isEqualTo(3);
 
 		InputStream inputStream = new ClassPathResource("input.yml").getInputStream();
 		JsonNode result2 = YAML.readValue(inputStream, JsonNode.class);
-		assertNotNull(result2);
-		assertEquals("1", result2.get("c").asText());
-		assertEquals("2", result2.get("a").asText());
-		assertEquals(3, result2.get("b").get("c").asInt());
+		assertThat(result2).isNotNull();
+		assertThat(result2.get("c").asText()).isEqualTo("1");
+		assertThat(result2.get("a").asText()).isEqualTo("2");
+		assertThat(result2.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode result3 = YAML.readValue(yaml, new TypeReference<>() {
 		});
-		assertNotNull(result3);
-		assertEquals("1", result3.get("c").asText());
-		assertEquals("2", result3.get("a").asText());
-		assertEquals(3, result3.get("b").get("c").asInt());
+		assertThat(result3).isNotNull();
+		assertThat(result3.get("c").asText()).isEqualTo("1");
+		assertThat(result3.get("a").asText()).isEqualTo("2");
+		assertThat(result3.get("b").get("c").asInt()).isEqualTo(3);
 
 		JavaType javaType = TypeFactoryUtils.javaType(JsonNode.class);
 		JsonNode result4 = YAML.readValue(yaml, javaType);
-		assertNotNull(result3);
-		assertEquals("1", result4.get("c").asText());
-		assertEquals("2", result4.get("a").asText());
-		assertEquals(3, result4.get("b").get("c").asInt());
+		assertThat(result4).isNotNull();
+		assertThat(result4.get("c").asText()).isEqualTo("1");
+		assertThat(result4.get("a").asText()).isEqualTo("2");
+		assertThat(result4.get("b").get("c").asInt()).isEqualTo(3);
+
 	}
 
 	@Test
 	void testXmlReadValue() throws IOException {
-
 		JsonNode result1 = XML.readValue(xml, JsonNode.class);
-		assertNotNull(result1);
-		assertEquals("1", result1.get("c").asText());
-		assertEquals("2", result1.get("a").asText());
-		assertEquals(3, result1.get("b").get("c").asInt());
+		assertThat(result1).isNotNull();
+		assertThat(result1.get("c").asText()).isEqualTo("1");
+		assertThat(result1.get("a").asText()).isEqualTo("2");
+		assertThat(result1.get("b").get("c").asInt()).isEqualTo(3);
 
 		InputStream inputStream = new ClassPathResource("input.xml").getInputStream();
 		JsonNode result2 = XML.readValue(inputStream, JsonNode.class);
-		assertNotNull(result2);
-		assertEquals("1", result2.get("c").asText());
-		assertEquals("2", result2.get("a").asText());
-		assertEquals(3, result2.get("b").get("c").asInt());
+		assertThat(result2).isNotNull();
+		assertThat(result2.get("c").asText()).isEqualTo("1");
+		assertThat(result2.get("a").asText()).isEqualTo("2");
+		assertThat(result2.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode result3 = XML.readValue(xml, new TypeReference<>() {
 		});
-		assertNotNull(result3);
-		assertEquals("1", result3.get("c").asText());
-		assertEquals("2", result3.get("a").asText());
-		assertEquals(3, result3.get("b").get("c").asInt());
+		assertThat(result3).isNotNull();
+		assertThat(result3.get("c").asText()).isEqualTo("1");
+		assertThat(result3.get("a").asText()).isEqualTo("2");
+		assertThat(result3.get("b").get("c").asInt()).isEqualTo(3);
 
 		JavaType javaType = TypeFactoryUtils.javaType(JsonNode.class);
 		JsonNode result4 = XML.readValue(xml, javaType);
-		assertNotNull(result3);
-		assertEquals("1", result4.get("c").asText());
-		assertEquals("2", result4.get("a").asText());
-		assertEquals(3, result4.get("b").get("c").asInt());
+		assertThat(result4).isNotNull();
+		assertThat(result4.get("c").asText()).isEqualTo("1");
+		assertThat(result4.get("a").asText()).isEqualTo("2");
+		assertThat(result4.get("b").get("c").asInt()).isEqualTo(3);
 	}
 
 	@Test
@@ -211,10 +209,10 @@ class JacksonSupportTests {
 		String result = JSON.writeValueAsString(Map.of("username", "password"));
 		@Language("json")
 		String json = "{\"username\":\"password\"}";
-		assertEquals(json, result);
+		assertThat(result).isEqualTo(json);
 
 		byte[] bytes = JSON.writeValueAsBytes(Map.of("username", "password"));
-		assertArrayEquals(json.getBytes(), bytes);
+		assertThat(bytes).isEqualTo(json.getBytes());
 	}
 
 	@Test
@@ -225,10 +223,10 @@ class JacksonSupportTests {
 				---
 				username: "password"
 				""";
-		assertEquals(yml, result);
+		assertThat(result).isEqualTo(yml);
 
 		byte[] bytes = YAML.writeValueAsBytes(Map.of("username", "password"));
-		assertArrayEquals(yml.getBytes(), bytes);
+		assertThat(bytes).isEqualTo(yml.getBytes());
 	}
 
 	@Test
@@ -236,31 +234,31 @@ class JacksonSupportTests {
 		String result = XML.writeValueAsString(Map.of("username", "password"));
 		@Language("xml")
 		String xml = "<Map1><username>password</username></Map1>";
-		assertEquals(xml, result);
+		assertThat(result).isEqualTo(xml);
 
 		byte[] bytes = XML.writeValueAsBytes(Map.of("username", "password"));
-		assertArrayEquals(xml.getBytes(), bytes);
+		assertThat(bytes).isEqualTo(xml.getBytes());
 	}
 
 	@Test
 	void testReadTree() {
 		JsonNode jsonNode = JSON.readTree(json);
-		assertNotNull(jsonNode);
-		assertEquals("1", jsonNode.get("c").asText());
-		assertEquals("2", jsonNode.get("a").asText());
-		assertEquals(3, jsonNode.get("b").get("c").asInt());
+		assertThat(jsonNode).isNotNull();
+		assertThat(jsonNode.get("c").asText()).isEqualTo("1");
+		assertThat(jsonNode.get("a").asText()).isEqualTo("2");
+		assertThat(jsonNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode yamlNode = YAML.readTree(yaml);
-		assertNotNull(yamlNode);
-		assertEquals("1", yamlNode.get("c").asText());
-		assertEquals("2", yamlNode.get("a").asText());
-		assertEquals(3, yamlNode.get("b").get("c").asInt());
+		assertThat(yamlNode).isNotNull();
+		assertThat(yamlNode.get("c").asText()).isEqualTo("1");
+		assertThat(yamlNode.get("a").asText()).isEqualTo("2");
+		assertThat(yamlNode.get("b").get("c").asInt()).isEqualTo(3);
 
 		JsonNode xmlNode = XML.readTree(xml);
-		assertNotNull(xmlNode);
-		assertEquals("1", xmlNode.get("c").asText());
-		assertEquals("2", xmlNode.get("a").asText());
-		assertEquals(3, xmlNode.get("b").get("c").asInt());
+		assertThat(xmlNode).isNotNull();
+		assertThat(xmlNode.get("c").asText()).isEqualTo("1");
+		assertThat(xmlNode.get("a").asText()).isEqualTo("2");
+		assertThat(xmlNode.get("b").get("c").asInt()).isEqualTo(3);
 	}
 
 	@Test
@@ -287,19 +285,25 @@ class JacksonSupportTests {
 				"spring-boot-starter-logging");
 		Map<String, String> jsonDependency = Map.of("groupId", "org.springframework.boot", "artifactId",
 				"spring-boot-starter-json");
+
 		MapType mapType = TypeFactoryUtils.mapType(String.class, String.class);
 		List<JsonNode> jsonNodeList = Streams.stream(dependencyArray.elements()).toList();
-		assertEquals(loggingDependency, JSON.convertValue(jsonNodeList.get(0), mapType));
-		assertEquals(jsonDependency, JSON.convertValue(jsonNodeList.get(1), mapType));
+
+		assertThat(JSON.<Map<String, String>>convertValue(jsonNodeList.get(0), mapType)).isEqualTo(loggingDependency);
+		assertThat(JSON.<Map<String, String>>convertValue(jsonNodeList.get(1), mapType)).isEqualTo(jsonDependency);
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
 		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
-		assertEquals(dependencyList, JSON.convertValue(dependencyArray, collectionType));
+
+		assertThat(JSON.<List<Map<String, String>>>convertValue(dependencyArray, collectionType))
+			.isEqualTo(dependencyList);
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);
 		Map<String, List<Map<String, String>>> dependencyManagement = Map.of("dependency", dependencyList);
 		MapType constructMapType = TypeFactoryUtils.mapType(javaType, collectionType);
-		assertEquals(dependencyManagement, JSON.convertValue(jsonNode, constructMapType));
+
+		assertThat(JSON.<Map<String, List<Map<String, String>>>>convertValue(jsonNode, constructMapType))
+			.isEqualTo(dependencyManagement);
 	}
 
 	@Test
@@ -320,19 +324,26 @@ class JacksonSupportTests {
 				"spring-boot-starter-logging");
 		Map<String, String> jsonDependency = Map.of("groupId", "org.springframework.boot", "artifactId",
 				"spring-boot-starter-json");
+
 		MapType mapType = TypeFactoryUtils.mapType(String.class, String.class);
 		List<JsonNode> jsonNodeList = Streams.stream(dependencyArray.elements()).toList();
-		assertEquals(loggingDependency, YAML.convertValue(jsonNodeList.get(0), mapType));
-		assertEquals(jsonDependency, YAML.convertValue(jsonNodeList.get(1), mapType));
+
+		assertThat(YAML.<Map<String, String>>convertValue(jsonNodeList.getFirst(), mapType))
+			.isEqualTo(loggingDependency);
+		assertThat(YAML.<Map<String, String>>convertValue(jsonNodeList.get(1), mapType)).isEqualTo(jsonDependency);
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
 		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
-		assertEquals(dependencyList, YAML.convertValue(dependencyArray, collectionType));
+
+		assertThat(YAML.<List<Map<String, String>>>convertValue(dependencyArray, collectionType))
+			.isEqualTo(dependencyList);
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);
 		Map<String, List<Map<String, String>>> dependencyManagement = Map.of("dependency", dependencyList);
 		MapType constructMapType = TypeFactoryUtils.mapType(javaType, collectionType);
-		assertEquals(dependencyManagement, YAML.convertValue(jsonNode, constructMapType));
+
+		assertThat(YAML.<Map<String, List<Map<String, String>>>>convertValue(jsonNode, constructMapType))
+			.isEqualTo(dependencyManagement);
 	}
 
 	@Test
@@ -357,19 +368,26 @@ class JacksonSupportTests {
 				"spring-boot-starter-logging");
 		Map<String, String> jsonDependency = Map.of("groupId", "org.springframework.boot", "artifactId",
 				"spring-boot-starter-json");
+
 		MapType mapType = TypeFactoryUtils.mapType(String.class, String.class);
 		List<JsonNode> jsonNodeList = Streams.stream(dependencyArray.elements()).toList();
-		assertEquals(loggingDependency, XML.convertValue(jsonNodeList.get(0), mapType));
-		assertEquals(jsonDependency, XML.convertValue(jsonNodeList.get(1), mapType));
+
+		assertThat(XML.<Map<String, String>>convertValue(jsonNodeList.get(0), mapType)).isEqualTo(loggingDependency);
+		assertThat(XML.<Map<String, String>>convertValue(jsonNodeList.get(1), mapType)).isEqualTo(jsonDependency);
 
 		List<Map<String, String>> dependencyList = List.of(loggingDependency, jsonDependency);
 		CollectionType collectionType = TypeFactoryUtils.listType(mapType);
-		assertEquals(dependencyList, XML.convertValue(dependencyArray, collectionType));
+
+		assertThat(XML.<List<Map<String, String>>>convertValue(dependencyArray, collectionType))
+			.isEqualTo(dependencyList);
 
 		JavaType javaType = TypeFactoryUtils.javaType(String.class);
 		Map<String, List<Map<String, String>>> dependencyManagement = Map.of("dependency", dependencyList);
 		MapType constructMapType = TypeFactoryUtils.mapType(javaType, collectionType);
-		assertEquals(dependencyManagement, XML.convertValue(jsonNode, constructMapType));
+
+		assertThat(XML.<Map<String, List<Map<String, String>>>>convertValue(jsonNode, constructMapType))
+			.isEqualTo(dependencyManagement);
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/spring/AnnotationBasePackageSupportTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/spring/AnnotationBasePackageSupportTests.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -42,11 +42,11 @@ class AnnotationBasePackageSupportTests {
 	void getBasePackages() {
 		AnnotationMetadata metadata = AnnotationMetadata.introspect(Config.class);
 		String[] basePackages = AnnotationBasePackageSupport.getBasePackages(metadata, AnnotationScan.class);
-		assertArrayEquals(new String[] { "com.livk.commons.spring" }, basePackages);
+		assertThat(basePackages).containsExactly("com.livk.commons.spring");
 
 		contextRunner.run(context -> {
 			String[] packages = AnnotationBasePackageSupport.getBasePackages(context);
-			assertArrayEquals(new String[] { "com.livk.commons.spring" }, packages);
+			assertThat(packages).containsExactly("com.livk.commons.spring");
 		});
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/spring/AnnotationBeanDefinitionScannerTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/spring/AnnotationBeanDefinitionScannerTests.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,7 +41,7 @@ class AnnotationBeanDefinitionScannerTests {
 		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
 		ClassPathBeanDefinitionScanner scanner = new MyAnnotationBeanDefinitionScanner(registry);
 		scanner.scan("com.livk.commons.spring");
-		assertTrue(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config"));
+		assertThat(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config")).isTrue();
 	}
 
 	static class MyAnnotationBeanDefinitionScanner extends AnnotationBeanDefinitionScanner<MyAnnotationScanner> {

--- a/spring-extension-commons/src/test/java/com/livk/commons/spring/AutoImportSelectorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/spring/AutoImportSelectorTests.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -38,7 +38,7 @@ class AutoImportSelectorTests {
 	void test() {
 		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(Config.class));
 		String[] result = new String[] { ImportConfig.class.getName() };
-		assertArrayEquals(result, imports);
+		assertThat(imports).containsExactly(result);
 	}
 
 	@AutoImport

--- a/spring-extension-commons/src/test/java/com/livk/commons/spring/SpringAbstractImportSelectorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/spring/SpringAbstractImportSelectorTests.java
@@ -25,8 +25,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -36,11 +35,11 @@ class SpringAbstractImportSelectorTests {
 	@Test
 	void testFindAnnotation() {
 		MyAnnotationImportSelector selector = new MyAnnotationImportSelector();
-		assertEquals(MyAnnotation.class, selector.getAnnotationClass());
+		assertThat(selector.getAnnotationClass()).isEqualTo(MyAnnotation.class);
 
 		String[] imports = selector.selectImports(AnnotationMetadata.introspect(Config.class));
 		String[] result = new String[] { MyAnnotationConfig.class.getName() };
-		assertArrayEquals(result, imports);
+		assertThat(imports).containsExactly(result);
 	}
 
 	@Target(ElementType.TYPE)

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationMetadataResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationMetadataResolverTests.java
@@ -27,9 +27,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -43,10 +42,11 @@ class AnnotationMetadataResolverTests {
 		contextRunner.run(ctx -> {
 			AnnotationMetadataResolver resolver = new AnnotationMetadataResolver(ctx);
 
-			assertEquals(Set.of(A.class, TestController.class),
-					resolver.find(TestAnnotation.class, AnnotationMetadataResolverTests.class.getPackageName()));
+			assertThat(resolver.find(TestAnnotation.class, AnnotationMetadataResolverTests.class.getPackageName()))
+				.containsExactlyInAnyOrder(A.class, TestController.class);
 
-			assertEquals(Set.of(A.class, TestController.class), resolver.find(TestAnnotation.class, ctx));
+			assertThat(resolver.find(TestAnnotation.class, ctx)).containsExactlyInAnyOrder(A.class,
+					TestController.class);
 		});
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationUtilsTests.java
@@ -31,11 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.lang.reflect.Method;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -51,31 +47,31 @@ class AnnotationUtilsTests {
 
 	@Test
 	void getAnnotationElement() {
-		assertNotNull(AnnotationUtils.getAnnotationElement(methodParameter, RequestMapping.class));
-		assertNotNull(AnnotationUtils.getAnnotationElement(methodParameter, GetMapping.class));
-		assertNotNull(AnnotationUtils.getAnnotationElement(methodParameter, Controller.class));
-		assertNotNull(AnnotationUtils.getAnnotationElement(methodParameter, RestController.class));
-		assertNull(AnnotationUtils.getAnnotationElement(methodParameter, RequestBody.class));
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RequestMapping.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, GetMapping.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, Controller.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RestController.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RequestBody.class)).isNull();
 
-		assertNotNull(AnnotationUtils.getAnnotationElement(method, RequestMapping.class));
-		assertNotNull(AnnotationUtils.getAnnotationElement(method, GetMapping.class));
-		assertNotNull(AnnotationUtils.getAnnotationElement(method, Controller.class));
-		assertNotNull(AnnotationUtils.getAnnotationElement(method, RestController.class));
-		assertNull(AnnotationUtils.getAnnotationElement(method, RequestBody.class));
+		assertThat(AnnotationUtils.getAnnotationElement(method, RequestMapping.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(method, GetMapping.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(method, Controller.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(method, RestController.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(method, RequestBody.class)).isNull();
 	}
 
 	@Test
 	void hasAnnotationElement() {
-		assertTrue(AnnotationUtils.hasAnnotationElement(methodParameter, RequestMapping.class));
-		assertTrue(AnnotationUtils.hasAnnotationElement(methodParameter, GetMapping.class));
-		assertTrue(AnnotationUtils.hasAnnotationElement(methodParameter, Controller.class));
-		assertTrue(AnnotationUtils.hasAnnotationElement(methodParameter, RestController.class));
-		assertFalse(AnnotationUtils.hasAnnotationElement(methodParameter, RequestBody.class));
+		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RequestMapping.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, GetMapping.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, Controller.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RestController.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RequestBody.class)).isFalse();
 
-		assertTrue(AnnotationUtils.hasAnnotationElement(method, RequestMapping.class));
-		assertTrue(AnnotationUtils.hasAnnotationElement(method, Controller.class));
-		assertTrue(AnnotationUtils.hasAnnotationElement(method, RestController.class));
-		assertFalse(AnnotationUtils.hasAnnotationElement(method, RequestBody.class));
+		assertThat(AnnotationUtils.hasAnnotationElement(method, RequestMapping.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(method, Controller.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(method, RestController.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(method, RequestBody.class)).isFalse();
 	}
 
 	@Test
@@ -85,12 +81,12 @@ class AnnotationUtilsTests {
 		for (MethodMetadata metadata : methods) {
 			AnnotationAttributes attributes = AnnotationUtils.attributesFor(metadata, RequestMapping.class);
 			RequestMethod[] requestMethods = AnnotationUtils.getValue(attributes, "method");
-			assertArrayEquals(new RequestMethod[] { RequestMethod.GET }, requestMethods);
+			assertThat(requestMethods).containsExactly(RequestMethod.GET);
 
 			AnnotationAttributes attributesFor = AnnotationUtils.attributesFor(metadata,
 					RequestMapping.class.getName());
 			RequestMethod[] requestMethodsArr = AnnotationUtils.getValue(attributesFor, "method");
-			assertArrayEquals(new RequestMethod[] { RequestMethod.GET }, requestMethodsArr);
+			assertThat(requestMethodsArr).containsExactly(RequestMethod.GET);
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaDescriptorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaDescriptorTests.java
@@ -22,8 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -32,29 +31,29 @@ class BeanLambdaDescriptorTests {
 
 	@Test
 	void create() {
-		assertNotNull(BeanLambdaDescriptor.create(Maker::getNo));
+		assertThat(BeanLambdaDescriptor.create(Maker::getNo)).isNotNull();
 	}
 
 	@Test
 	void getFieldName() {
-		assertEquals("no", BeanLambdaDescriptor.create(Maker::getNo).getFieldName());
+		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getFieldName()).isEqualTo("no");
 	}
 
 	@Test
 	void getField() throws NoSuchFieldException {
 		Field field = Maker.class.getDeclaredField("no");
-		assertEquals(field, BeanLambdaDescriptor.create(Maker::getNo).getField());
+		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getField()).isEqualTo(field);
 	}
 
 	@Test
 	void getMethodName() {
-		assertEquals("getNo", BeanLambdaDescriptor.create(Maker::getNo).getMethodName());
+		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getMethodName()).isEqualTo("getNo");
 	}
 
 	@Test
 	void getMethod() throws NoSuchMethodException {
 		Method method = Maker.class.getMethod("getNo");
-		assertEquals(method, BeanLambdaDescriptor.create(Maker::getNo).getMethod());
+		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getMethod()).isEqualTo(method);
 	}
 
 	@Data

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -42,20 +42,20 @@ class BeanLambdaTests {
 
 	@Test
 	void method() {
-		assertEquals(method1.getName(), BeanLambda.methodName(Maker::getNo));
-		assertEquals(method2.getName(), BeanLambda.methodName(Maker::getUsername));
+		assertThat(BeanLambda.methodName(Maker::getNo)).isEqualTo(method1.getName());
+		assertThat(BeanLambda.methodName(Maker::getUsername)).isEqualTo(method2.getName());
 
-		assertEquals(method1, BeanLambda.method(Maker::getNo));
-		assertEquals(method2, BeanLambda.method(Maker::getUsername));
+		assertThat(BeanLambda.method(Maker::getNo)).isEqualTo(method1);
+		assertThat(BeanLambda.method(Maker::getUsername)).isEqualTo(method2);
 	}
 
 	@Test
 	void field() {
-		assertEquals(field1.getName(), BeanLambda.fieldName(Maker::getNo));
-		assertEquals(field2.getName(), BeanLambda.fieldName(Maker::getUsername));
+		assertThat(BeanLambda.fieldName(Maker::getNo)).isEqualTo(field1.getName());
+		assertThat(BeanLambda.fieldName(Maker::getUsername)).isEqualTo(field2.getName());
 
-		assertEquals(field1, BeanLambda.field(Maker::getNo));
-		assertEquals(field2, BeanLambda.field(Maker::getUsername));
+		assertThat(BeanLambda.field(Maker::getNo)).isEqualTo(field1);
+		assertThat(BeanLambda.field(Maker::getUsername)).isEqualTo(field2);
 	}
 
 	@Data

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTests.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -40,21 +40,21 @@ class BeanUtilsTests {
 	void copy() {
 		TargetBean result = BeanUtils.copy(bean, TargetBean.class);
 		TargetBean targetBean = new TargetBean("source", 10);
-		assertEquals(result, targetBean);
+		assertThat(result).isEqualTo(targetBean);
 	}
 
 	@Test
 	void copySupplier() {
 		TargetBean result = BeanUtils.copy(bean, TargetBean::new);
 		TargetBean targetBean = new TargetBean("source", 10);
-		assertEquals(result, targetBean);
+		assertThat(result).isEqualTo(targetBean);
 	}
 
 	@Test
 	void copyList() {
 		List<TargetBean> result = BeanUtils.copyList(beanList, TargetBean.class);
 		List<TargetBean> targetBeans = List.of(new TargetBean("source", 10), new TargetBean("target", 9));
-		assertEquals(result, targetBeans);
+		assertThat(result).isEqualTo(targetBeans);
 	}
 
 	@Test
@@ -62,23 +62,23 @@ class BeanUtilsTests {
 		{
 			TargetBean source = new TargetBean("source", 10);
 			Map<String, Object> convert = BeanUtils.convert(source);
-			assertEquals("source", convert.get("beanName"));
-			assertEquals(10, convert.get("beanNo"));
-			assertEquals(TargetBean.class, convert.get("class"));
+			assertThat(convert).containsEntry("beanName", "source")
+				.containsEntry("beanNo", 10)
+				.containsEntry("class", TargetBean.class);
 
 			TargetBean target = BeanUtils.convert(convert);
-			assertEquals(source, target);
+			assertThat(target).isEqualTo(source);
 		}
 
 		{
 			SourceBean source = new SourceBean("source", 10);
 			Map<String, Object> convert = BeanUtils.convert(source);
-			assertEquals("source", convert.get("beanName"));
-			assertEquals(10, convert.get("beanNo"));
-			assertEquals(SourceBean.class, convert.get("class"));
+			assertThat(convert).containsEntry("beanName", "source")
+				.containsEntry("beanNo", 10)
+				.containsEntry("class", SourceBean.class);
 
-			assertThrowsExactly(IllegalArgumentException.class, () -> BeanUtils.convert(convert),
-					"Missing no-argument constructor");
+			assertThatThrownBy(() -> BeanUtils.convert(convert)).isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing no-argument constructor");
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java
@@ -16,9 +16,8 @@
 
 package com.livk.commons.util;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
@@ -27,7 +26,8 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -36,22 +36,22 @@ class ClassUtilsTests {
 
 	@Test
 	void toClassTest() {
-		assertEquals(String.class, ClassUtils.toClass(String.class));
+		assertThat(ClassUtils.toClass(String.class)).isEqualTo(String.class);
 
 		Type listType = new ListType();
-
-		assertEquals(List.class, ClassUtils.toClass(listType));
+		assertThat(ClassUtils.toClass(listType)).isEqualTo(List.class);
 
 		TypeVariable<?> typeVar = MyGeneric.class.getTypeParameters()[0];
-		assertEquals(Number.class, ClassUtils.toClass(typeVar));
+		assertThat(ClassUtils.toClass(typeVar)).isEqualTo(Number.class);
 
 		Type arrayType = new StringGenericArrayType();
-		assertEquals(String[].class, ClassUtils.toClass(arrayType));
+		assertThat(ClassUtils.toClass(arrayType)).isEqualTo(String[].class);
 
 		WildcardType wildcardType = new NumberWildcardType();
-		assertEquals(Number.class, ClassUtils.toClass(wildcardType));
+		assertThat(ClassUtils.toClass(wildcardType)).isEqualTo(Number.class);
 
-		Assertions.assertThrows(IllegalArgumentException.class, () -> ClassUtils.toClass(null), "Type cannot be null");
+		assertThatThrownBy(() -> ClassUtils.toClass(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Type cannot be null");
 	}
 
 	static class NumberWildcardType implements WildcardType {

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/DateUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/DateUtilsTests.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -35,49 +35,49 @@ class DateUtilsTests {
 	@Test
 	void timestampTest() {
 		Long result = DateUtils.timestamp(LocalDateTime.now());
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void localDateTimeTest() {
 		LocalDateTime result = DateUtils.localDateTime(1663063303L);
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void dateTest() {
 		Date result = DateUtils.date(LocalDate.now());
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void testDateTest() {
 		Date result = DateUtils.date(LocalDateTime.now());
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void toLocalDateTimeTest() {
 		LocalDateTime result = DateUtils.localDateTime(new Date());
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void formatTest() {
 		String result = DateUtils.format(LocalDateTime.now(), DateTimeFormatter.ofPattern(DateUtils.YMD_HMS));
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void testFormatTest() {
 		String result = DateUtils.format(LocalDateTime.now(), DateUtils.YMD_HMS);
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 	@Test
 	void parseTest() {
 		LocalDateTime result = DateUtils.parse("2022-09-13 18:05:12", DateUtils.YMD_HMS);
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/GenericWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/GenericWrapperTests.java
@@ -22,8 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -34,15 +33,16 @@ class GenericWrapperTests {
 	void test() {
 		String value = "livk";
 		StringBuilder builder = new StringBuilder(value).reverse();
+
 		GenericWrapper<String> wrapper = GenericWrapper.of(value);
-		assertEquals(value, wrapper.unwrap());
+		assertThat(wrapper.unwrap()).isEqualTo(value);
 
 		GenericWrapper<String> map = GenericWrapper.of(reverse(wrapper.unwrap()));
-		assertEquals(builder.toString(), map.unwrap());
-		assertNotEquals(value, map.unwrap());
+		assertThat(map.unwrap()).isEqualTo(builder.toString());
+		assertThat(map.unwrap()).isNotEqualTo(value);
 
 		GenericWrapper<String> flatmap = GenericWrapper.of(wrapper.unwrap());
-		assertEquals(value, flatmap.unwrap());
+		assertThat(flatmap.unwrap()).isEqualTo(value);
 	}
 
 	String reverse(String str) {

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/HttpServletUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/HttpServletUtilsTests.java
@@ -31,11 +31,9 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletWebRequest;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -56,8 +54,10 @@ class HttpServletUtilsTests {
 	void request() {
 		ServletWebRequest servletWebRequest = new ServletWebRequest(request, response);
 		RequestContextHolder.setRequestAttributes(servletWebRequest);
+
 		HttpServletRequest req = HttpServletUtils.request();
-		assertEquals(request, req);
+		assertThat(req).isSameAs(request);
+
 		RequestContextHolder.resetRequestAttributes();
 	}
 
@@ -65,8 +65,10 @@ class HttpServletUtilsTests {
 	void response() {
 		ServletWebRequest servletWebRequest = new ServletWebRequest(request, response);
 		RequestContextHolder.setRequestAttributes(servletWebRequest);
+
 		HttpServletResponse resp = HttpServletUtils.response();
-		assertEquals(response, resp);
+		assertThat(resp).isSameAs(response);
+
 		RequestContextHolder.resetRequestAttributes();
 	}
 
@@ -76,9 +78,9 @@ class HttpServletUtilsTests {
 		request.addHeader(HttpHeaders.USER_AGENT, "test");
 
 		HttpHeaders headers = HttpServletUtils.headers(request);
-		assertEquals(MediaType.APPLICATION_JSON_VALUE, headers.getFirst(HttpHeaders.CONTENT_TYPE));
-		assertEquals("test", headers.getFirst(HttpHeaders.USER_AGENT));
-		assertEquals(2, headers.size());
+		assertThat(headers.getFirst(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+		assertThat(headers.getFirst(HttpHeaders.USER_AGENT)).isEqualTo("test");
+		assertThat(headers.size()).isEqualTo(2);
 	}
 
 	@Test
@@ -87,9 +89,7 @@ class HttpServletUtilsTests {
 		request.setAttribute("password", "123456");
 
 		Map<String, Object> attributes = HttpServletUtils.attributes(request);
-		assertEquals("livk", attributes.get("username"));
-		assertEquals("123456", attributes.get("password"));
-		assertEquals(2, attributes.size());
+		assertThat(attributes).containsEntry("username", "livk").containsEntry("password", "123456").hasSize(2);
 	}
 
 	@Test
@@ -98,14 +98,14 @@ class HttpServletUtilsTests {
 		request.addParameter("password", "123456");
 
 		HttpParameters parameters = HttpServletUtils.params(request);
-		assertEquals(List.of("livk", "root", "admin"), parameters.get("username"));
-		assertLinesMatch(List.of("123456"), parameters.get("password"));
-		assertEquals(2, parameters.size());
+		assertThat(parameters.get("username")).containsExactly("livk", "root", "admin");
+		assertThat(parameters.get("password")).containsExactly("123456");
+		assertThat(parameters).hasSize(2);
 	}
 
 	@Test
 	void realIp() {
-		assertEquals("127.0.0.1", HttpServletUtils.realIp(request));
+		assertThat(HttpServletUtils.realIp(request)).isEqualTo("127.0.0.1");
 	}
 
 	@Test
@@ -114,8 +114,8 @@ class HttpServletUtilsTests {
 		HttpServletUtils.outJson(response, result);
 
 		JsonNode node = JsonMapperUtils.readTree(response.getContentAsByteArray());
-		assertEquals("livk", node.get("username").asText());
-		assertEquals("123456", node.get("password").asText());
+		assertThat(node.get("username").asText()).isEqualTo("livk");
+		assertThat(node.get("password").asText()).isEqualTo("123456");
 	}
 
 	@Test
@@ -123,7 +123,7 @@ class HttpServletUtilsTests {
 		HttpServletUtils.out(response, "out buffer text", MediaType.TEXT_PLAIN_VALUE);
 
 		String result = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
-		assertEquals("out buffer text", result);
+		assertThat(result).isEqualTo("out buffer text");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/MultiValueMapSplitterTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/MultiValueMapSplitterTests.java
@@ -23,7 +23,7 @@ import org.springframework.util.MultiValueMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -38,14 +38,16 @@ class MultiValueMapSplitterTests {
 
 			Map<String, List<String>> map = Map.of("names", List.of("admin", "root"), "password", List.of("123456"));
 
-			assertEquals(CollectionUtils.toMultiValueMap(map), valueMap);
+			assertThat(valueMap).isEqualTo(CollectionUtils.toMultiValueMap(map));
 		}
 
 		{
 			String str = "root=1,2,3&root=4&a=b&a=c";
 			Map<String, List<String>> map = Map.of("root", List.of("1", "2", "3", "4"), "a", List.of("b", "c"));
+
 			MultiValueMap<String, String> multiValueMap = MultiValueMapSplitter.of("&", "=").split(str, ",");
-			assertEquals(CollectionUtils.toMultiValueMap(map), multiValueMap);
+
+			assertThat(multiValueMap).isEqualTo(CollectionUtils.toMultiValueMap(map));
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/PairTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/PairTests.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -38,42 +37,41 @@ class PairTests {
 	void pairJsonSerializerTest() {
 		String json = "{\"livk\":123456}";
 		String result = JsonMapperUtils.writeValueAsString(pair);
-		assertEquals(json, result);
+		assertThat(result).isEqualTo(json);
 	}
 
 	@Test
 	void pairJsonDeserializerTest() {
-
 		Pair<String, Integer> empty = JsonMapperUtils.readValue("{}", new TypeReference<>() {
 		});
-		assertNull(empty.key());
-		assertNull(empty.value());
-		assertEquals(Pair.EMPTY, empty);
+		assertThat(empty.key()).isNull();
+		assertThat(empty.value()).isNull();
+		assertThat(empty).isEqualTo(Pair.EMPTY);
 
 		@Language("JSON")
 		String json = "{\"livk\":123456}";
 		Pair<String, Integer> result = JsonMapperUtils.readValue(json, new TypeReference<>() {
 		});
-		assertEquals("livk", result.key());
-		assertEquals(123456, result.value());
-		assertEquals(pair, result);
+		assertThat(result.key()).isEqualTo("livk");
+		assertThat(result.value()).isEqualTo(123456);
+		assertThat(result).isEqualTo(pair);
 
 		@Language("JSON")
 		String json2 = """
 				{"livk": {"root": "username"}}""";
 		Pair<String, Pair<String, String>> result2 = JsonMapperUtils.readValue(json2, new TypeReference<>() {
 		});
-		assertEquals("livk", result2.key());
-		assertEquals("root", result2.value().key());
-		assertEquals("username", result2.value().value());
+		assertThat(result2.key()).isEqualTo("livk");
+		assertThat(result2.value().key()).isEqualTo("root");
+		assertThat(result2.value().value()).isEqualTo("username");
 
 		@Language("JSON")
 		String json3 = """
 				{"livk":  [1,2,3]}""";
 		Pair<String, List<Integer>> result3 = JsonMapperUtils.readValue(json3, new TypeReference<>() {
 		});
-		assertEquals("livk", result3.key());
-		assertEquals(List.of(1, 2, 3), result3.value());
+		assertThat(result3.key()).isEqualTo("livk");
+		assertThat(result3.value()).containsExactly(1, 2, 3);
 
 		@Language("JSON")
 		String json4 = """
@@ -85,8 +83,8 @@ class PairTests {
 				}""";
 		Pair<String, Map<String, String>> result4 = JsonMapperUtils.readValue(json4, new TypeReference<>() {
 		});
-		assertEquals("livk", result4.key());
-		assertEquals(Map.of("username", "root", "password", "root"), result4.value());
+		assertThat(result4.key()).isEqualTo("livk");
+		assertThat(result4.value()).containsAllEntriesOf(Map.of("username", "root", "password", "root"));
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/ReflectionUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/ReflectionUtilsTests.java
@@ -26,8 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -43,7 +42,7 @@ class ReflectionUtilsTests {
 	void setFieldAndAccessibleTest() {
 		Maker maker = new Maker();
 		ReflectionUtils.setFieldAndAccessible(fieldNo, maker, 2);
-		assertEquals(2, maker.getNo());
+		assertThat(maker.getNo()).isEqualTo(2);
 	}
 
 	@Test
@@ -52,12 +51,12 @@ class ReflectionUtilsTests {
 		maker.setNo(10);
 		maker.setUsername("root");
 		Method readMethod = ReflectionUtils.getReadMethod(Maker.class, fieldNo);
-		assertEquals("getNo", readMethod.getName());
-		assertEquals(10, readMethod.invoke(maker));
+		assertThat(readMethod.getName()).isEqualTo("getNo");
+		assertThat(readMethod.invoke(maker)).isEqualTo(10);
 
 		Set<Method> readMethods = ReflectionUtils.getReadMethods(Maker.class);
-		Set<String> set = readMethods.stream().map(Method::getName).collect(Collectors.toSet());
-		assertEquals(Set.of("getNo", "getUsername"), set);
+		Set<String> methodNames = readMethods.stream().map(Method::getName).collect(Collectors.toSet());
+		assertThat(methodNames).containsExactlyInAnyOrder("getNo", "getUsername");
 	}
 
 	@Test
@@ -66,20 +65,21 @@ class ReflectionUtilsTests {
 		maker.setNo(10);
 		maker.setUsername("root");
 		Method writeMethod = ReflectionUtils.getWriteMethod(Maker.class, fieldNo);
-		assertEquals("setNo", writeMethod.getName());
+		assertThat(writeMethod.getName()).isEqualTo("setNo");
+
 		writeMethod.invoke(maker, 20);
-		assertEquals(20, maker.getNo());
+		assertThat(maker.getNo()).isEqualTo(20);
 
 		Set<Method> writeMethods = ReflectionUtils.getWriteMethods(Maker.class);
-		Set<String> set = writeMethods.stream().map(Method::getName).collect(Collectors.toSet());
-		assertEquals(Set.of("setNo", "setUsername"), set);
+		Set<String> methodNames = writeMethods.stream().map(Method::getName).collect(Collectors.toSet());
+		assertThat(methodNames).containsExactlyInAnyOrder("setNo", "setUsername");
 	}
 
 	@Test
 	void getAllFields() {
-		List<Field> fieldList = ReflectionUtils.getAllFields(Maker.class);
-		List<String> list = fieldList.stream().map(Field::getName).collect(Collectors.toList());
-		assertLinesMatch(List.of("no", "username"), list);
+		List<Field> fields = ReflectionUtils.getAllFields(Maker.class);
+		List<String> fieldNames = fields.stream().map(Field::getName).collect(Collectors.toList());
+		assertThat(fieldNames).containsExactly("no", "username");
 	}
 
 	@Data

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/SnowflakeIdGeneratorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/SnowflakeIdGeneratorTests.java
@@ -27,9 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -53,8 +51,9 @@ class SnowflakeIdGeneratorTests {
 			}
 			countDownLatch.await();
 			service.shutdown();
-			Set<Long> set = new HashSet<>(list);
-			assertEquals(set.size(), list.size(), "ID 的数量不匹配，可能有重复 ID");
+
+			// 用 AssertJ 断言 list 中无重复元素
+			assertThat(list).doesNotHaveDuplicates();
 		}
 	}
 
@@ -64,46 +63,31 @@ class SnowflakeIdGeneratorTests {
 		Set<Long> idSet = new HashSet<>();
 		for (int i = 0; i < num; i++) {
 			long id = generator.nextId();
-			assertFalse(idSet.contains(id), "ID 生成重复：" + id);
+			assertThat(idSet).doesNotContain(id);
 			idSet.add(id);
 		}
 	}
 
-	/**
-	 * 测试时间回拨的处理
-	 */
 	@Test
 	void testTimeRollbackHandling() throws InterruptedException {
-		// 模拟时间回拨的情况，检查是否会抛出异常
-		System.currentTimeMillis();
-
-		// 生成一个 ID
 		long id1 = generator.nextId();
 
-		// 人为改变系统时间，使其回到过去
 		System.setProperty("user.timezone", "UTC"); // 模拟时区变化
-		Thread.sleep(1000); // 暂停一秒钟
+		Thread.sleep(1000);
 
-		// 再次生成 ID，验证是否正常
 		long id2 = generator.nextId();
 
-		// 验证生成的两个 ID 是否不同，且没有时间回拨导致的问题
-		assertNotEquals(id1, id2, "生成的 ID 相同，时间回拨没有处理正确");
+		assertThat(id1).isNotEqualTo(id2).withFailMessage("生成的 ID 相同，时间回拨没有处理正确");
 	}
 
-	/**
-	 * 测试序列号溢出
-	 */
 	@Test
 	void testSequenceOverflow() {
 		long startTime = System.currentTimeMillis();
 		long lastId = generator.nextId();
 
-		// 模拟多次生成 ID，观察序列号是否正确溢出
 		for (int i = 0; i < 10000; i++) {
 			long currentId = generator.nextId();
-			// 验证生成的 ID 不重复
-			assertNotEquals(lastId, currentId, "ID 重复：" + currentId);
+			assertThat(currentId).isNotEqualTo(lastId).withFailMessage("ID 重复：" + currentId);
 			lastId = currentId;
 		}
 
@@ -111,17 +95,13 @@ class SnowflakeIdGeneratorTests {
 		log.info("生成 10000 个 ID 耗时：{} 毫秒", endTime - startTime);
 	}
 
-	/**
-	 * 测试边界条件，生成 ID 时跨毫秒溢出
-	 */
 	@Test
 	void testBoundaryCondition() throws InterruptedException {
-		// 测试生成 ID 时，序列号溢出后的行为
 		long lastId = generator.nextId();
-		Thread.sleep(2); // 等待一毫秒
-
+		Thread.sleep(2);
 		long newId = generator.nextId();
-		assertNotEquals(lastId, newId, "跨毫秒生成的 ID 重复");
+
+		assertThat(newId).isNotEqualTo(lastId).withFailMessage("跨毫秒生成的 ID 重复");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/SqlParserUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/SqlParserUtilsTests.java
@@ -18,11 +18,8 @@ package com.livk.commons.util;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -31,24 +28,36 @@ class SqlParserUtilsTests {
 
 	@Test
 	void parseTable() {
-		assertEquals(Set.of("user"), SqlParserUtils.parseTable("select * from user"));
-		assertEquals(Set.of("user", "account"),
-				SqlParserUtils.parseTable("select * from user u left join account a on u.id = a.user_id"));
-		assertEquals(Set.of("user"), SqlParserUtils.parseTable("insert into user values (1,'root','root')"));
-		assertEquals(Set.of("user"), SqlParserUtils.parseTable("update user set username = 'root' where id = 1"));
-		assertEquals(Set.of("user"), SqlParserUtils.parseTable("delete from user where id = 1"));
+		assertThat(SqlParserUtils.parseTable("select * from user")).containsExactly("user");
+
+		assertThat(SqlParserUtils.parseTable("select * from user u left join account a on u.id = a.user_id"))
+			.containsExactlyInAnyOrder("user", "account");
+
+		assertThat(SqlParserUtils.parseTable("insert into user values (1,'root','root')")).containsExactly("user");
+
+		assertThat(SqlParserUtils.parseTable("update user set username = 'root' where id = 1")).containsExactly("user");
+
+		assertThat(SqlParserUtils.parseTable("delete from user where id = 1")).containsExactly("user");
+
+		assertThatThrownBy(() -> SqlParserUtils.parseTable("")).isInstanceOf(NullPointerException.class);
+
+		assertThatThrownBy(() -> SqlParserUtils.parseTable(null)).isInstanceOf(NullPointerException.class);
 	}
 
 	@Test
 	void getParams() {
-		assertLinesMatch(List.of("id", "username", "password"),
-				SqlParserUtils.getParams("select id,username,password from user"));
-		assertLinesMatch(List.of("u.id", "u.username", "a.account_name"), SqlParserUtils
-			.getParams("select u.id,u.username,a.account_name from user u left join account a on u.id = a.user_id"));
-		assertLinesMatch(List.of("id", "username", "password"),
-				SqlParserUtils.getParams("insert into user (id,username,password) values (1,'root','root')"));
-		assertLinesMatch(List.of("username"),
-				SqlParserUtils.getParams("update user set username = 'root' where id = 1"));
+		assertThat(SqlParserUtils.getParams("select id,username,password from user")).containsExactly("id", "username",
+				"password");
+
+		assertThat(SqlParserUtils
+			.getParams("select u.id,u.username,a.account_name from user u left join account a on u.id = a.user_id"))
+			.containsExactly("u.id", "u.username", "a.account_name");
+
+		assertThat(SqlParserUtils.getParams("insert into user (id,username,password) values (1,'root','root')"))
+			.containsExactly("id", "username", "password");
+
+		assertThat(SqlParserUtils.getParams("update user set username = 'root' where id = 1"))
+			.containsExactly("username");
 	}
 
 	@Test
@@ -58,8 +67,10 @@ class SqlParserUtilsTests {
 				FROM user_account AS ua
 				LEFT JOIN user_info AS ui ON ua.user_id = ui.id
 				WHERE ui.id = 1""";
-		String formatSQL = "SELECT * FROM user_account AS ua LEFT JOIN user_info AS ui ON ua.user_id = ui.id WHERE ui.id = 1";
-		assertEquals(formatSQL, SqlParserUtils.formatSql(sql));
+
+		String expected = "SELECT * FROM user_account AS ua LEFT JOIN user_info AS ui ON ua.user_id = ui.id WHERE ui.id = 1";
+
+		assertThat(SqlParserUtils.formatSql(sql)).isEqualToNormalizingWhitespace(expected);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/StreamUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/StreamUtilsTests.java
@@ -22,14 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -42,45 +38,45 @@ class StreamUtilsTests {
 				Map.of("username", "root", "host", "192.168.1.1"));
 		Map<String, List<String>> listMap1 = Map.of("username", List.of("livk", "root"), "password", List.of("123456"),
 				"host", List.of("192.168.1.1"));
-		assertEquals(listMap1, result1);
+		assertThat(result1).isEqualTo(listMap1);
 
 		Map<String, List<String>> result2 = StreamUtils.concat(Map.of("username", "livk", "password", "123456"),
 				Map.of("username", "root", "host", "192.168.1.1"), Map.of("username", "admin", "host", "192.168.1.2"));
 		Map<String, List<String>> listMap2 = Map.of("username", List.of("livk", "root", "admin"), "password",
 				List.of("123456"), "host", List.of("192.168.1.1", "192.168.1.2"));
-		assertEquals(listMap2, result2);
+		assertThat(result2).isEqualTo(listMap2);
 	}
 
 	@Test
 	void testConcatArray() {
 		int[] result1 = StreamUtils.concat(new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 }, new int[] { 7, 8, 9 });
 		int[] intArray = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-		assertArrayEquals(intArray, result1);
+		assertThat(result1).containsExactly(intArray);
 
 		long[] result2 = StreamUtils.concat(new long[] { 1, 2, 3 }, new long[] { 4, 5, 6 }, new long[] { 7, 8, 9 });
 		long[] longArray = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-		assertArrayEquals(longArray, result2);
+		assertThat(result2).containsExactly(longArray);
 
 		double[] result3 = StreamUtils.concat(new double[] { 1, 2, 3 }, new double[] { 4, 5, 6 },
 				new double[] { 7, 8, 9 });
 		double[] doubleArray = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-		assertArrayEquals(doubleArray, result3);
+		assertThat(result3).containsExactly(doubleArray);
 
 		String[] result4 = StreamUtils.concat(false, new String[] { "1", "2", "3" }, new String[] { "4", "5", "6" },
 				new String[] { "1", "2", "3" });
 		String[] stringArray = { "1", "2", "3", "4", "5", "6", "1", "2", "3" };
-		assertArrayEquals(stringArray, result4);
+		assertThat(result4).containsExactly(stringArray);
 
 		String[] result5 = StreamUtils.concatDistinct(new String[] { "1", "2", "3" }, new String[] { "4", "5", "6" },
 				new String[] { "1", "2", "3" });
 		String[] stringArrayDistinct = { "1", "2", "3", "4", "5", "6" };
-		assertArrayEquals(stringArrayDistinct, result5);
+		assertThat(result5).containsExactly(stringArrayDistinct);
 
 		Recode[] result6 = StreamUtils
 			.concat(new Recode[] { Recode.of("root"), Recode.of("admin") }, new Recode[] { Recode.of("guest") })
 			.toArray(Recode[]::new);
 		Recode[] recodeArray = { Recode.of("root"), Recode.of("admin"), Recode.of("guest") };
-		assertArrayEquals(recodeArray, result6);
+		assertThat(result6).containsExactly(recodeArray);
 	}
 
 	@Test
@@ -88,12 +84,12 @@ class StreamUtilsTests {
 		List<Integer> list = Stream.of(1, 1, 2, 2, 3, 3, 4, 4)
 			.filter(StreamUtils.distinct(Function.identity()))
 			.toList();
-		assertEquals(list, List.of(1, 2, 3, 4));
+		assertThat(list).containsExactly(1, 2, 3, 4);
 
 		List<User> users = Stream.of(new User(1, "1"), new User(1, "11"), new User(2, "2"), new User(2, "2"))
 			.filter(StreamUtils.distinct(User::id))
 			.toList();
-		assertEquals(users, List.of(new User(1, "1"), new User(2, "2")));
+		assertThat(users).containsExactly(new User(1, "1"), new User(2, "2"));
 	}
 
 	@Test
@@ -101,15 +97,16 @@ class StreamUtilsTests {
 		List<String> list = List.of("root", "livk", "admin");
 		List<User> users1 = List.of(new User(0, "root"), new User(1, "livk"), new User(2, "admin"));
 		List<User> result1 = list.stream().map(StreamUtils.mapWithIndex(0, (s, i) -> new User(i, s))).toList();
-		assertIterableEquals(users1, result1);
+		assertThat(result1).containsExactlyElementsOf(users1);
 
 		List<User> users2 = List.of(new User(10, "root"), new User(11, "livk"), new User(12, "admin"));
 		List<User> result2 = list.stream().map(StreamUtils.mapWithIndex(10, (s, i) -> new User(i, s))).toList();
-		assertIterableEquals(users2, result2);
+		assertThat(result2).containsExactlyElementsOf(users2);
 	}
 
 	@Test
 	void forEachWithIndex() {
+		// 这里断言不涉及状态变化，所以保留打印；如果需要断言，可以用Mockito等捕获调用
 		List.of("root", "livk", "admin")
 			.forEach(StreamUtils.forEachWithIndex(0, (s, i) -> System.out.println("index:" + i + " data:" + s)));
 
@@ -119,11 +116,12 @@ class StreamUtilsTests {
 
 	@Test
 	void zip() {
-		Stream<String> result = Stream.of("1", "2", "3", "4", "5", "6");
-		Stream<String> zip = StreamUtils.zip(stream -> stream.map(Objects::toString), Stream.of(1, 2), Stream.of(3, 4),
-				Stream.of(5, 6));
+		Stream<String> expected = Stream.of("1", "2", "3", "4", "5", "6");
+		Stream<String> zipped = StreamUtils.zip(stream -> stream.map(Object::toString), Stream.of(1, 2),
+				Stream.of(3, 4), Stream.of(5, 6));
 
-		assertLinesMatch(result, zip);
+		// 断言两个流元素内容相同（先收集为List断言）
+		assertThat(zipped).containsExactlyElementsOf(expected.toList());
 	}
 
 	@Data

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/TreeNodeTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/TreeNodeTests.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,7 +41,7 @@ class TreeNodeTests {
 	void createRoot() {
 		root = TreeNode.createRoot(0L, "root");
 		log.info("{}", root);
-		assertNotNull(root);
+		assertThat(root).isNotNull();
 	}
 
 	@Order(2)
@@ -56,7 +56,7 @@ class TreeNodeTests {
 		root.setChildren(nodes);
 		log.info("{}", root);
 		log.info("{}", JsonMapperUtils.writeValueAsString(root));
-		assertNotNull(root);
+		assertThat(root).isNotNull();
 	}
 
 	@Order(3)

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/YamlUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/YamlUtilsTests.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,14 +41,14 @@ class YamlUtilsTests {
 	void convertMapToYaml() throws IOException {
 		Map<String, Object> load = new Yaml().load(yml.getInputStream());
 		Map<String, Object> result = YamlUtils.convertMapToYaml(map);
-		assertEquals(load, result);
+		assertThat(result).isEqualTo(load);
 	}
 
 	@Test
 	void convertYamlToMap() throws IOException {
 		Map<String, Object> load = new Yaml().load(yml.getInputStream());
 		Properties result = YamlUtils.convertYamlToMap(load);
-		assertEquals(map, result);
+		assertThat(result).isEqualTo(map);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/HttpParametersTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/HttpParametersTests.java
@@ -20,9 +20,7 @@ import com.livk.commons.util.HttpServletUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -34,10 +32,13 @@ class HttpParametersTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addParameter("username", "livk", "root", "admin");
 		request.addParameter("password", "123456");
+
 		HttpParameters parameters = HttpServletUtils.params(request);
-		assertEquals(List.of("livk", "root", "admin"), parameters.get("username"));
-		assertEquals("livk", parameters.getFirst("username"));
-		assertEquals("123456", parameters.getFirst("password"));
+
+		assertThat(parameters.get("username")).containsExactly("livk", "root", "admin");
+		assertThat(parameters.getFirst("username")).isEqualTo("livk");
+		assertThat(parameters.getFirst("password")).isEqualTo("123456");
+
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java
@@ -25,12 +25,9 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -49,9 +46,9 @@ class RequestWrapperTests {
 		Map<String, String> map = Map.of("root", "root");
 		wrapper.body(JsonMapperUtils.writeValueAsBytes(map));
 
-		assertArrayEquals(JsonMapperUtils.writeValueAsBytes(map), wrapper.getContentAsByteArray());
-		assertEquals(JsonMapperUtils.writeValueAsString(map), wrapper.getContentAsString());
-		assertEquals(MediaType.APPLICATION_JSON_VALUE, wrapper.getContentType());
+		assertThat(wrapper.getContentAsByteArray()).isEqualTo(JsonMapperUtils.writeValueAsBytes(map));
+		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(map));
+		assertThat(wrapper.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
 	}
 
 	@Test
@@ -61,10 +58,10 @@ class RequestWrapperTests {
 		wrapper.addHeader(HttpHeaders.AGE, "20");
 
 		HttpHeaders headers = HttpServletUtils.headers(wrapper);
-		assertEquals(MediaType.APPLICATION_JSON_VALUE, headers.getFirst(HttpHeaders.CONTENT_TYPE));
-		assertEquals("test", headers.getFirst(HttpHeaders.USER_AGENT));
-		assertEquals("20", headers.getFirst(HttpHeaders.AGE));
-		assertEquals(3, headers.size());
+		assertThat(headers.getFirst(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+		assertThat(headers.getFirst(HttpHeaders.USER_AGENT)).isEqualTo("test");
+		assertThat(headers.getFirst(HttpHeaders.AGE)).isEqualTo("20");
+		assertThat(headers.size()).isEqualTo(3);
 	}
 
 	@Test
@@ -73,9 +70,9 @@ class RequestWrapperTests {
 		wrapper.addParameter("password", "123456");
 
 		HttpParameters parameters = HttpServletUtils.params(wrapper);
-		assertEquals(List.of("livk", "root", "admin"), parameters.get("username"));
-		assertLinesMatch(List.of("123456"), parameters.get("password"));
-		assertEquals(2, parameters.size());
+		assertThat(parameters.get("username")).containsExactly("livk", "root", "admin");
+		assertThat(parameters.get("password")).containsExactly("123456");
+		assertThat(parameters).hasSize(2);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/ResponseWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/ResponseWrapperTests.java
@@ -24,8 +24,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -40,14 +39,14 @@ class ResponseWrapperTests {
 		ResponseWrapper wrapper = new ResponseWrapper(response);
 		HttpServletUtils.outJson(wrapper, result);
 
-		assertArrayEquals(JsonMapperUtils.writeValueAsBytes(result), wrapper.getContentAsByteArray());
-		assertEquals(JsonMapperUtils.writeValueAsString(result), wrapper.getContentAsString());
+		assertThat(wrapper.getContentAsByteArray()).isEqualTo(JsonMapperUtils.writeValueAsBytes(result));
+		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(result));
 
 		wrapper.replaceBody(JsonMapperUtils.writeValueAsBytes(Map.of("root", "root")));
 
-		assertArrayEquals(JsonMapperUtils.writeValueAsBytes(Map.of("root", "root")), wrapper.getContentAsByteArray());
-		assertEquals(JsonMapperUtils.writeValueAsString(Map.of("root", "root")), wrapper.getContentAsString());
-
+		assertThat(wrapper.getContentAsByteArray())
+			.isEqualTo(JsonMapperUtils.writeValueAsBytes(Map.of("root", "root")));
+		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(Map.of("root", "root")));
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/curator/CuratorOperationsTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/curator/CuratorOperationsTests.java
@@ -41,11 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -72,7 +68,7 @@ class CuratorOperationsTests {
 	@Order(1)
 	void createNode() {
 		String data = curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertEquals("/node", data);
+		assertThat(data).isEqualTo("/node");
 		curatorOperations.deleteNode("/node");
 	}
 
@@ -80,8 +76,8 @@ class CuratorOperationsTests {
 	@Order(2)
 	void getNode() {
 		String data = curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertEquals("/node", data);
-		assertArrayEquals("data".getBytes(StandardCharsets.UTF_8), curatorOperations.getNode("/node"));
+		assertThat(data).isEqualTo("/node");
+		assertThat(curatorOperations.getNode("/node")).containsExactly("data".getBytes(StandardCharsets.UTF_8));
 		curatorOperations.deleteNode("/node");
 	}
 
@@ -90,25 +86,25 @@ class CuratorOperationsTests {
 	void createTypeNode() {
 		String persistent = curatorOperations.createTypeNode(CreateMode.PERSISTENT, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertEquals("/node", persistent);
+		assertThat(persistent).isEqualTo("/node");
 		curatorOperations.deleteNode("/node");
 
 		String persistentSequential = curatorOperations.createTypeNode(CreateMode.PERSISTENT_SEQUENTIAL, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(persistentSequential.startsWith("/node"));
+		assertThat(persistentSequential).startsWith("/node");
 
 		String ephemeral = curatorOperations.createTypeNode(CreateMode.EPHEMERAL, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertEquals("/node", ephemeral);
+		assertThat(ephemeral).isEqualTo("/node");
 		curatorOperations.deleteNode("/node");
 
 		String ephemeralSequential = curatorOperations.createTypeNode(CreateMode.EPHEMERAL_SEQUENTIAL, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(ephemeralSequential.startsWith("/node"));
+		assertThat(ephemeralSequential).startsWith("/node");
 
 		String container = curatorOperations.createTypeNode(CreateMode.CONTAINER, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertEquals("/node", container);
+		assertThat(container).isEqualTo("/node");
 		curatorOperations.deleteNode("/node");
 	}
 
@@ -117,33 +113,33 @@ class CuratorOperationsTests {
 	void createTypeSeqNode() {
 		String persistent = curatorOperations.createTypeSeqNode(CreateMode.PERSISTENT, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(persistent.endsWith("node"));
+		assertThat(persistent).endsWith("node");
 
 		String persistentSequential = curatorOperations.createTypeSeqNode(CreateMode.PERSISTENT_SEQUENTIAL, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(persistentSequential.contains("node"));
+		assertThat(persistentSequential).contains("node");
 
 		String ephemeral = curatorOperations.createTypeSeqNode(CreateMode.EPHEMERAL, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(ephemeral.endsWith("node"));
+		assertThat(ephemeral).endsWith("node");
 
 		String ephemeralSequential = curatorOperations.createTypeSeqNode(CreateMode.EPHEMERAL_SEQUENTIAL, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(ephemeralSequential.contains("node"));
+		assertThat(ephemeralSequential).contains("node");
 
 		String container = curatorOperations.createTypeSeqNode(CreateMode.CONTAINER, "/node",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertTrue(container.endsWith("node"));
+		assertThat(container).endsWith("node");
 	}
 
 	@Test
 	@Order(5)
 	void setData() {
 		curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertArrayEquals("data".getBytes(StandardCharsets.UTF_8), curatorOperations.getNode("/node"));
+		assertThat(curatorOperations.getNode("/node")).containsExactly("data".getBytes(StandardCharsets.UTF_8));
 		Stat data = curatorOperations.setData("/node", "setData".getBytes(StandardCharsets.UTF_8));
-		assertNotNull(data);
-		assertArrayEquals("setData".getBytes(), curatorOperations.getNode("/node"));
+		assertThat(data).isNotNull();
+		assertThat(curatorOperations.getNode("/node")).containsExactly("setData".getBytes());
 		curatorOperations.deleteNode("/node");
 	}
 
@@ -151,14 +147,16 @@ class CuratorOperationsTests {
 	@Order(6)
 	void setDataAsync() {
 		curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertArrayEquals("data".getBytes(), curatorOperations.getNode("/node"));
+		assertThat(curatorOperations.getNode("/node")).containsExactly("data".getBytes(StandardCharsets.UTF_8));
+
 		curatorOperations.setDataAsync("/node", "setData".getBytes(StandardCharsets.UTF_8), (client, event) -> {
 			if (CuratorEventType.SET_DATA.equals(event.getType())) {
-				assertEquals("/node", event.getPath());
-				assertNotNull(event.getStat());
+				assertThat(event.getPath()).isEqualTo("/node");
+				assertThat(event.getStat()).isNotNull();
 			}
 		});
-		assertArrayEquals("setData".getBytes(), curatorOperations.getNode("/node"));
+
+		assertThat(curatorOperations.getNode("/node")).containsExactly("setData".getBytes(StandardCharsets.UTF_8));
 		curatorOperations.deleteNode("/node");
 	}
 
@@ -174,10 +172,11 @@ class CuratorOperationsTests {
 	void watchedGetChildren() {
 		for (int i = 0; i < 10; i++) {
 			String data = curatorOperations.createNode("/node/" + i, "data".getBytes(StandardCharsets.UTF_8));
-			assertEquals("/node/" + i, data);
+			assertThat(data).as("Created node path /node/%d", i).isEqualTo("/node/" + i);
 		}
+
 		List<String> paths = curatorOperations.watchedGetChildren("/node");
-		assertLinesMatch(List.of("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), paths);
+		assertThat(paths).as("Children of /node").containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
 		curatorOperations.deleteNode("/node");
 	}
 
@@ -186,14 +185,16 @@ class CuratorOperationsTests {
 	void testWatchedGetChildren() {
 		for (int i = 0; i < 10; i++) {
 			String data = curatorOperations.createNode("/node/" + i, "data".getBytes(StandardCharsets.UTF_8));
-			assertEquals("/node/" + i, data);
+			assertThat(data).as("Created node path /node/%d", i).isEqualTo("/node/" + i);
 		}
+
 		List<String> paths = curatorOperations.watchedGetChildren("/node", event -> {
-			assertEquals(Watcher.Event.KeeperState.SyncConnected, event.getState());
-			assertEquals(Watcher.Event.EventType.NodeChildrenChanged, event.getType());
-			assertEquals("/node", event.getPath());
+			assertThat(event.getState()).as("Watcher event state").isEqualTo(Watcher.Event.KeeperState.SyncConnected);
+			assertThat(event.getType()).as("Watcher event type").isEqualTo(Watcher.Event.EventType.NodeChildrenChanged);
+			assertThat(event.getPath()).as("Watcher event path").isEqualTo("/node");
 		});
-		assertLinesMatch(List.of("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), paths);
+
+		assertThat(paths).as("Children of /node").containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
 
 		curatorOperations.deleteNode("/node");
 	}
@@ -202,18 +203,18 @@ class CuratorOperationsTests {
 	@Order(10)
 	void getLock() throws Exception {
 		InterProcessLock lock = curatorOperations.getLock("/node/lock", ZkLockType.REENTRANT);
-		assertEquals(InterProcessMutex.class, lock.getClass());
-		assertTrue(lock.acquire(3, TimeUnit.SECONDS));
+		assertThat(lock.getClass()).isEqualTo(InterProcessMutex.class);
+		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
 		lock.release();
 
 		InterProcessLock read = curatorOperations.getLock("/node/lock", ZkLockType.READ);
-		assertEquals(InterProcessReadWriteLock.ReadLock.class, read.getClass());
-		assertTrue(read.acquire(3, TimeUnit.SECONDS));
+		assertThat(read.getClass()).isEqualTo(InterProcessReadWriteLock.ReadLock.class);
+		assertThat(read.acquire(3, TimeUnit.SECONDS)).isTrue();
 		read.release();
 
 		InterProcessLock write = curatorOperations.getLock("/node/lock", ZkLockType.WRITE);
-		assertEquals(InterProcessReadWriteLock.WriteLock.class, write.getClass());
-		assertTrue(write.acquire(3, TimeUnit.SECONDS));
+		assertThat(write.getClass()).isEqualTo(InterProcessReadWriteLock.WriteLock.class);
+		assertThat(write.acquire(3, TimeUnit.SECONDS)).isTrue();
 		write.release();
 
 		curatorOperations.deleteNode("/node");
@@ -223,9 +224,11 @@ class CuratorOperationsTests {
 	@Order(11)
 	void getDistributedId() {
 		String data = curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertEquals("/node", data);
+		assertThat(data).as("Created node path").isEqualTo("/node");
+
 		String distributedId = curatorOperations.getDistributedId("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertNotNull(distributedId);
+		assertThat(distributedId).as("Distributed ID").isNotNull();
+
 		curatorOperations.deleteNode("/node");
 	}
 

--- a/spring-extension-context/src/test/java/com/livk/context/curator/CuratorTemplateTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/curator/CuratorTemplateTests.java
@@ -35,9 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -61,31 +59,31 @@ class CuratorTemplateTests {
 	CuratorTemplate template;
 
 	@Test
-	void setDataAsync() throws Exception {
+	void setDataAsync() {
 		template.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertArrayEquals("data".getBytes(), template.getNode("/node"));
+		assertThat(template.getNode("/node")).containsExactly("data".getBytes());
 		template.setDataAsync("/node", "setData".getBytes(StandardCharsets.UTF_8));
-		assertArrayEquals("setData".getBytes(), template.getNode("/node"));
+		assertThat(template.getNode("/node")).containsExactly("setData".getBytes());
 		template.deleteNode("/node");
 	}
 
 	@Test
 	void getLock() throws Exception {
 		InterProcessLock lock = template.getLock("/node/lock", ZkLockType.REENTRANT);
-		assertEquals(InterProcessMutex.class, lock.getClass());
-		assertTrue(lock.acquire(3, TimeUnit.SECONDS));
+		assertThat(lock.getClass()).isEqualTo(InterProcessMutex.class);
+		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
 		lock.release();
 		template.deleteNode("/node");
 
 		InterProcessLock read = template.getLock("/node/lock", ZkLockType.READ);
-		assertEquals(InterProcessReadWriteLock.ReadLock.class, read.getClass());
-		assertTrue(read.acquire(3, TimeUnit.SECONDS));
+		assertThat(read.getClass()).isEqualTo(InterProcessReadWriteLock.ReadLock.class);
+		assertThat(read.acquire(3, TimeUnit.SECONDS)).isTrue();
 		read.release();
 		template.deleteNode("/node");
 
 		InterProcessLock write = template.getLock("/node/lock", ZkLockType.WRITE);
-		assertEquals(InterProcessReadWriteLock.WriteLock.class, write.getClass());
-		assertTrue(write.acquire(3, TimeUnit.SECONDS));
+		assertThat(write.getClass()).isEqualTo(InterProcessReadWriteLock.WriteLock.class);
+		assertThat(write.acquire(3, TimeUnit.SECONDS)).isTrue();
 		write.release();
 
 		template.deleteNode("/node");

--- a/spring-extension-context/src/test/java/com/livk/context/disruptor/ClassPathDisruptorScannerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/disruptor/ClassPathDisruptorScannerTests.java
@@ -24,7 +24,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.ResolvableType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -36,10 +36,10 @@ class ClassPathDisruptorScannerTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ClassPathDisruptorScanner scanner = new ClassPathDisruptorScanner(context, DefaultBeanNameGenerator.INSTANCE);
 		int result = scanner.scan(ClassPathDisruptorScannerTests.class.getPackageName());
-		assertEquals(1, result);
+		assertThat(result).isEqualTo(1);
 
 		ResolvableType type = ResolvableType.forClassWithGenerics(SpringDisruptor.class, Entity.class);
-		assertEquals(1, context.getBeanProvider(type).stream().count());
+		assertThat(context.getBeanProvider(type)).hasSize(1);
 	}
 
 	@Test
@@ -47,9 +47,9 @@ class ClassPathDisruptorScannerTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ClassPathDisruptorScanner scanner = new ClassPathDisruptorScanner(context, DefaultBeanNameGenerator.INSTANCE);
 		int result = scanner.scan(ClassPathDisruptorScannerTests.class.getPackageName() + ".empty");
-		assertEquals(0, result);
-		assertEquals(0, context.getBeanProvider(SpringDisruptor.class).stream().count());
-		assertEquals(0, context.getBeanNamesForType(DisruptorFactoryBean.class).length);
+		assertThat(result).isEqualTo(0);
+		assertThat(context.getBeanProvider(SpringDisruptor.class).stream()).isEmpty();
+		assertThat(context.getBeanNamesForType(DisruptorFactoryBean.class)).isEmpty();
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/disruptor/DisruptorScanRegistrarTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/disruptor/DisruptorScanRegistrarTests.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -42,7 +42,7 @@ class DisruptorScanRegistrarTests {
 		registrar.registerBeanDefinitions(metadata, context, DefaultBeanNameGenerator.INSTANCE);
 
 		ResolvableType type = ResolvableType.forClassWithGenerics(SpringDisruptor.class, Entity.class);
-		assertEquals(1, context.getBeanProvider(type).stream().count());
+		assertThat(context.getBeanProvider(type)).hasSize(1);
 
 	}
 

--- a/spring-extension-context/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTests.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,7 +41,7 @@ class DisruptorFactoryBeanTests {
 		DisruptorFactoryBean<Entity> factoryBean = new DisruptorFactoryBean<>(Entity.class);
 		DisruptorEvent event = Entity.class.getAnnotation(DisruptorEvent.class);
 		factoryBean.setBeanFactory(beanFactory);
-		assertNotNull(event);
+		assertThat(event).isNotNull();
 		factoryBean.setBufferSize(event.bufferSize());
 		factoryBean.setProducerType(event.type());
 		factoryBean.setThreadFactory(BeanUtils.instantiateClass(event.threadFactory()));
@@ -50,7 +50,7 @@ class DisruptorFactoryBeanTests {
 		factoryBean.setWaitStrategy(BeanUtils.instantiateClass(event.strategy()));
 		factoryBean.setStrategyBeanName(event.strategyBeanName());
 		factoryBean.afterPropertiesSet();
-		assertNotNull(factoryBean.getObject());
+		assertThat(factoryBean.getObject()).isNotNull();
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/disruptor/support/DisruptorEventWrapperTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/disruptor/support/DisruptorEventWrapperTests.java
@@ -18,7 +18,7 @@ package com.livk.context.disruptor.support;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -29,9 +29,9 @@ class DisruptorEventWrapperTests {
 	void test() {
 		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
 		wrapper.wrap("root");
-		assertEquals("root", wrapper.unwrap());
+		assertThat(wrapper.unwrap()).isEqualTo("root");
 		wrapper.wrap("child");
-		assertEquals("root", wrapper.unwrap());
+		assertThat(wrapper.unwrap()).isEqualTo("root");
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/dynamic/DataSourceContextHolderTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/dynamic/DataSourceContextHolderTests.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -32,17 +31,19 @@ class DataSourceContextHolderTests {
 	@Test
 	void test() {
 
-		try (ExecutorService service = Executors.newFixedThreadPool(1)) {
+		try (ExecutorService service = Executors.newFixedThreadPool(2)) {
 			String datasource = "mysql";
 
 			DataSourceContextHolder.switchDataSource(datasource, true);
-			assertEquals(datasource, DataSourceContextHolder.getDataSource());
-			service.execute(() -> assertEquals(datasource, DataSourceContextHolder.getDataSource()));
+			assertThat(DataSourceContextHolder.getDataSource()).isEqualTo(datasource);
+			service.execute(() -> assertThat(DataSourceContextHolder.getDataSource()).isEqualTo(datasource));
 			DataSourceContextHolder.clear();
 
+			assertThat(DataSourceContextHolder.getDataSource()).isNull();
+
 			DataSourceContextHolder.switchDataSource(datasource, false);
-			assertEquals(datasource, DataSourceContextHolder.getDataSource());
-			service.execute(() -> assertNull(DataSourceContextHolder.getDataSource()));
+			assertThat(DataSourceContextHolder.getDataSource()).isEqualTo(datasource);
+			service.execute(() -> assertThat(DataSourceContextHolder.getDataSource()).isNull());
 			DataSourceContextHolder.clear();
 		}
 	}

--- a/spring-extension-context/src/test/java/com/livk/context/dynamic/DynamicDatasourceTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/dynamic/DynamicDatasourceTests.java
@@ -25,8 +25,7 @@ import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import java.sql.SQLException;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -51,21 +50,21 @@ class DynamicDatasourceTests {
 
 	@Test
 	void test() throws SQLException {
-		assertEquals(primary, dynamicDatasource.getResolvedDefaultDataSource());
-		assertEquals(primary, dynamicDatasource.unwrap(HikariDataSource.class));
-		assertTrue(dynamicDatasource.isWrapperFor(HikariDataSource.class));
+		assertThat(dynamicDatasource.getResolvedDefaultDataSource()).isEqualTo(primary);
+		assertThat(dynamicDatasource.unwrap(HikariDataSource.class)).isEqualTo(primary);
+		assertThat(dynamicDatasource.isWrapperFor(HikariDataSource.class)).isTrue();
 
 		DataSourceContextHolder.switchDataSource("slave1");
-		assertEquals(slave1, dynamicDatasource.unwrap(DriverManagerDataSource.class));
-		assertTrue(dynamicDatasource.isWrapperFor(DriverManagerDataSource.class));
+		assertThat(dynamicDatasource.unwrap(DriverManagerDataSource.class)).isEqualTo(slave1);
+		assertThat(dynamicDatasource.isWrapperFor(DriverManagerDataSource.class)).isTrue();
 
 		DataSourceContextHolder.switchDataSource("slave2");
-		assertEquals(slave2, dynamicDatasource.unwrap(SingleConnectionDataSource.class));
-		assertTrue(dynamicDatasource.isWrapperFor(SingleConnectionDataSource.class));
+		assertThat(dynamicDatasource.unwrap(SingleConnectionDataSource.class)).isEqualTo(slave2);
+		assertThat(dynamicDatasource.isWrapperFor(SingleConnectionDataSource.class)).isTrue();
 
 		DataSourceContextHolder.clear();
-		assertEquals(primary, dynamicDatasource.unwrap(HikariDataSource.class));
-		assertTrue(dynamicDatasource.isWrapperFor(HikariDataSource.class));
+		assertThat(dynamicDatasource.unwrap(HikariDataSource.class)).isEqualTo(primary);
+		assertThat(dynamicDatasource.isWrapperFor(HikariDataSource.class)).isTrue();
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/FastExcelSupportTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/FastExcelSupportTests.java
@@ -23,9 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -37,11 +35,11 @@ class FastExcelSupportTests {
 		Map<String, List<Info>> data = Map.of("0", List.of(new Info("123456789"), new Info("987654321")));
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
-		assertEquals(0, stream.toByteArray().length);
+		assertThat(stream.toByteArray()).isEmpty();
 
 		FastExcelSupport.write(stream, Info.class, null, data);
 
-		assertNotEquals(0, stream.toByteArray().length);
+		assertThat(stream.toByteArray()).isNotEmpty();
 	}
 
 	@Test
@@ -49,8 +47,8 @@ class FastExcelSupportTests {
 		ResponseExcel responseExcel = this.getClass()
 			.getDeclaredMethod("fileNameResponse")
 			.getAnnotation(ResponseExcel.class);
-		assertNotNull(responseExcel);
-		assertEquals("outFile.xls", ResponseExcel.Utils.parseName(responseExcel));
+		assertThat(responseExcel).isNotNull();
+		assertThat(ResponseExcel.Utils.parseName(responseExcel)).isEqualTo("outFile.xls");
 	}
 
 	@ResponseExcel(fileName = "outFile", suffix = ResponseExcel.Suffix.XLS)

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/listener/DefaultExcelMapReadListenerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/listener/DefaultExcelMapReadListenerTests.java
@@ -24,10 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -42,11 +40,10 @@ class DefaultExcelMapReadListenerTests {
 		listener.execute(inputStream, Info.class, true);
 
 		Map<String, ? extends Collection<Object>> map = listener.getMapData();
-		assertFalse(map.isEmpty());
-
-		assertEquals(1, map.size());
-		assertEquals(Set.of("0"), map.keySet());
-		assertEquals(100, map.values().stream().mapToLong(Collection::size).sum());
+		assertThat(map).isNotEmpty();
+		assertThat(map).hasSize(1);
+		assertThat(map).containsKey("0");
+		assertThat(map.values().stream().mapToLong(Collection::size).sum()).isEqualTo(100);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ExcelMethodArgumentResolverTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ExcelMethodArgumentResolverTests.java
@@ -27,9 +27,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -49,7 +47,7 @@ class ExcelMethodArgumentResolverTests {
 
 	@Test
 	void supportsParameter() {
-		assertTrue(resolver.supportsParameter(parameter));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
 	@Test
@@ -62,12 +60,12 @@ class ExcelMethodArgumentResolverTests {
 
 		Object result = resolver.resolveArgument(parameter, null, webRequest, null);
 
-		assertInstanceOf(List.class, result);
+		assertThat(result).isInstanceOf(List.class);
 
 		@SuppressWarnings("unchecked")
 		List<Info> list = (List<Info>) result;
 
-		assertEquals(100, list.size());
+		assertThat(list).hasSize(100);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ExcelMethodReturnValueHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ExcelMethodReturnValueHandlerTests.java
@@ -28,9 +28,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -49,7 +47,7 @@ class ExcelMethodReturnValueHandlerTests {
 
 	@Test
 	void supportsReturnType() {
-		assertTrue(handler.supportsReturnType(parameter));
+		assertThat(handler.supportsReturnType(parameter)).isTrue();
 	}
 
 	@Test
@@ -58,12 +56,12 @@ class ExcelMethodReturnValueHandlerTests {
 		ModelAndViewContainer mavContainer = new ModelAndViewContainer();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		assertEquals(0, response.getContentAsByteArray().length);
+		assertThat(response.getContentAsByteArray()).isEmpty();
 
 		ServletWebRequest webRequest = new ServletWebRequest(new MockHttpServletRequest(), response);
 		handler.handleReturnValue(list, parameter, mavContainer, webRequest);
 
-		assertNotEquals(0, response.getContentAsByteArray().length);
+		assertThat(response.getContentAsByteArray()).isNotEmpty();
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodArgumentResolverTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodArgumentResolverTests.java
@@ -42,7 +42,7 @@ import reactor.test.StepVerifier;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -67,7 +67,7 @@ class ReactiveExcelMethodArgumentResolverTests {
 
 	@Test
 	void supportsParameter() {
-		assertTrue(resolver.supportsParameter(parameter));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
 	@Test

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodReturnValueHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodReturnValueHandlerTests.java
@@ -32,7 +32,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -55,7 +55,7 @@ class ReactiveExcelMethodReturnValueHandlerTests {
 
 	@Test
 	void supports() {
-		assertTrue(handler.supports(result));
+		assertThat(handler.supports(result)).isTrue();
 	}
 
 	@Test

--- a/spring-extension-context/src/test/java/com/livk/context/http/ClassPathHttpScannerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/http/ClassPathHttpScannerTests.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -33,9 +33,9 @@ class ClassPathHttpScannerTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ClassPathHttpScanner scanner = new ClassPathHttpScanner(context);
 		int result = scanner.scan(ClassPathHttpScannerTests.class.getPackageName());
-		assertEquals(1, result);
+		assertThat(result).isEqualTo(1);
 
-		assertEquals(1, context.getBeanProvider(HttpService.class).stream().count());
+		assertThat(context.getBeanProvider(HttpService.class)).hasSize(1);
 	}
 
 	@Test
@@ -43,9 +43,9 @@ class ClassPathHttpScannerTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ClassPathHttpScanner scanner = new ClassPathHttpScanner(context);
 		int result = scanner.scan(ClassPathHttpScannerTests.class.getPackageName() + ".empty");
-		assertEquals(0, result);
-		assertEquals(0, context.getBeanProvider(HttpService.class).stream().count());
-		assertEquals(0, context.getBeanNamesForType(HttpFactoryBean.class).length);
+		assertThat(result).isEqualTo(0);
+		assertThat(context.getBeanProvider(HttpService.class)).isEmpty();
+		assertThat(context.getBeanNamesForType(HttpFactoryBean.class)).isEmpty();
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/http/HttpServiceRegistrarTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/http/HttpServiceRegistrarTests.java
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -38,7 +38,7 @@ class HttpServiceRegistrarTests {
 		AnnotationMetadata metadata = AnnotationMetadata.introspect(HttpConfig.class);
 		registrar.registerBeanDefinitions(metadata, context);
 
-		assertEquals(1, context.getBeanProvider(HttpService.class).stream().count());
+		assertThat(context.getBeanProvider(HttpService.class)).hasSize(1);
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/http/factory/HttpFactoryBeanTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/http/factory/HttpFactoryBeanTests.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -35,13 +35,13 @@ class HttpFactoryBeanTests {
 	BeanFactory beanFactory;
 
 	@Test
-	void test() throws Exception {
+	void test() {
 		HttpFactoryBean factoryBean = new HttpFactoryBean();
 		factoryBean.setType(HttpService.class);
 		factoryBean.setAdapterFactory(new RestClientAdapterFactory());
 		factoryBean.setBeanFactory(beanFactory);
 		factoryBean.afterPropertiesSet();
-		assertNotNull(factoryBean.getObject());
+		assertThat(factoryBean.getObject()).isNotNull();
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/http/factory/RestClientAdapterFactoryTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/http/factory/RestClientAdapterFactoryTests.java
@@ -22,9 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -39,17 +37,17 @@ class RestClientAdapterFactoryTests {
 
 	@Test
 	void support() {
-		assertTrue(factory.support());
+		assertThat(factory.support()).isTrue();
 	}
 
 	@Test
 	void create() {
-		assertNotNull(factory.create(beanFactory));
+		assertThat(factory.create(beanFactory)).isNotNull();
 	}
 
 	@Test
 	void type() {
-		assertEquals(AdapterType.REST_CLIENT, factory.type());
+		assertThat(factory.type()).isEqualTo(AdapterType.REST_CLIENT);
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/http/factory/WebClientAdapterFactoryTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/http/factory/WebClientAdapterFactoryTests.java
@@ -22,9 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -39,17 +37,17 @@ class WebClientAdapterFactoryTests {
 
 	@Test
 	void support() {
-		assertTrue(factory.support());
+		assertThat(factory.support()).isTrue();
 	}
 
 	@Test
 	void create() {
-		assertNotNull(factory.create(beanFactory));
+		assertThat(factory.create(beanFactory)).isNotNull();
 	}
 
 	@Test
 	void type() {
-		assertEquals(AdapterType.WEB_CLIENT, factory.type());
+		assertThat(factory.type()).isEqualTo(AdapterType.WEB_CLIENT);
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/lock/support/CuratorLockTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/lock/support/CuratorLockTests.java
@@ -43,8 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -80,13 +79,13 @@ class CuratorLockTests {
 	@Test
 	void tryLock() throws ExecutionException, InterruptedException {
 		lock.lock(LockType.LOCK, "tryLock", false);
-		assertFalse(service.submit(() -> lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false)).get());
-		assertFalse(lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false));
-		assertTrue(lock.tryLock(LockType.LOCK, "key", 3, 3, false));
+		assertThat(service.submit(() -> lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false)).get()).isFalse();
+		assertThat(lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false)).isFalse();
+		assertThat(lock.tryLock(LockType.LOCK, "key", 3, 3, false)).isTrue();
 
 		lock.unlock();
 
-		assertTrue(lock.tryLock(LockType.LOCK, "key", 3, 3, false));
+		assertThat(lock.tryLock(LockType.LOCK, "key", 3, 3, false)).isTrue();
 
 		lock.unlock();
 	}

--- a/spring-extension-context/src/test/java/com/livk/context/lock/support/RedissonLockTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/lock/support/RedissonLockTests.java
@@ -43,8 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -79,13 +78,13 @@ class RedissonLockTests {
 	@Test
 	void tryLock() throws ExecutionException, InterruptedException {
 		lock.lock(LockType.LOCK, "tryLock", false);
-		assertFalse(service.submit(() -> lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false)).get());
-		assertTrue(lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false));
-		assertTrue(lock.tryLock(LockType.LOCK, "key", 3, 3, false));
+		assertThat(service.submit(() -> lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false)).get()).isFalse();
+		assertThat(lock.tryLock(LockType.LOCK, "tryLock", 3, 3, false)).isTrue();
+		assertThat(lock.tryLock(LockType.LOCK, "key", 3, 3, false)).isTrue();
 
 		lock.unlock();
 
-		assertTrue(lock.tryLock(LockType.LOCK, "key", 3, 3, false));
+		assertThat(lock.tryLock(LockType.LOCK, "key", 3, 3, false)).isTrue();
 
 		lock.unlock();
 	}

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/GenericMapstructServiceTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/GenericMapstructServiceTests.java
@@ -25,7 +25,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -40,15 +40,15 @@ class GenericMapstructServiceTests {
 	void test() {
 		DoubleConverter converter = new DoubleConverter();
 
-		assertEquals(converter, service.addConverter(converter));
+		assertThat(service.addConverter(converter)).isEqualTo(converter);
 
-		assertEquals(123, service.convert("123", Integer.class));
-		assertEquals(123L, service.convert("123", Long.class));
-		assertEquals(123.1, service.convert("123.1", Double.class));
+		assertThat(service.convert("123", Integer.class)).isEqualTo(123);
+		assertThat(service.convert("123", Long.class)).isEqualTo(123L);
+		assertThat(service.convert("123.1", Double.class)).isEqualTo(123.1);
 
-		assertEquals("123", service.convert(123, String.class));
-		assertEquals("123", service.convert(123L, String.class));
-		assertEquals("123.1", service.convert(123.1, String.class));
+		assertThat(service.convert(123, String.class)).isEqualTo("123");
+		assertThat(service.convert(123L, String.class)).isEqualTo("123");
+		assertThat(service.convert(123.1, String.class)).isEqualTo("123.1");
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/converter/ConverterPairTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/converter/ConverterPairTests.java
@@ -18,8 +18,7 @@ package com.livk.context.mapstruct.converter;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -30,14 +29,14 @@ class ConverterPairTests {
 	void of() {
 		ConverterPair pair = ConverterPair.of(String.class, Object.class);
 
-		assertEquals(String.class, pair.getSourceType());
-		assertEquals(Object.class, pair.getTargetType());
+		assertThat(pair.getSourceType()).isEqualTo(String.class);
+		assertThat(pair.getTargetType()).isEqualTo(Object.class);
 
 		ConverterPair converterPair = ConverterPair.of(new TestConverter());
 
-		assertNotNull(converterPair);
-		assertEquals(String.class, converterPair.getSourceType());
-		assertEquals(Object.class, converterPair.getTargetType());
+		assertThat(converterPair).isNotNull();
+		assertThat(converterPair.getSourceType()).isEqualTo(String.class);
+		assertThat(converterPair.getTargetType()).isEqualTo(Object.class);
 	}
 
 	static class TestConverter implements Converter<String, Object> {

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/InMemoryConverterRepositoryTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/InMemoryConverterRepositoryTests.java
@@ -22,10 +22,7 @@ import com.livk.context.mapstruct.converter.Converter;
 import com.livk.context.mapstruct.converter.ConverterPair;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -41,20 +38,21 @@ class InMemoryConverterRepositoryTests {
 		Converter<Long, String> result = repository.computeIfAbsent(ConverterPair.of(Long.class, String.class),
 				longConverter);
 
-		assertNotNull(result);
+		assertThat(result).isNotNull();
 
-		assertTrue(repository.contains(ConverterPair.of(Integer.class, String.class)));
-		assertTrue(repository.contains(Integer.class, String.class));
-		assertFalse(repository.contains(ConverterPair.of(String.class, Integer.class)));
-		assertFalse(repository.contains(String.class, Integer.class));
+		assertThat(repository.contains(ConverterPair.of(Integer.class, String.class))).isTrue();
+		assertThat(repository.contains(Integer.class, String.class)).isTrue();
+		assertThat(repository.contains(ConverterPair.of(String.class, Integer.class))).isFalse();
+		assertThat(repository.contains(String.class, Integer.class)).isFalse();
 
-		assertTrue(repository.contains(ConverterPair.of(Long.class, String.class)));
-		assertTrue(repository.contains(Long.class, String.class));
-		assertFalse(repository.contains(ConverterPair.of(String.class, Long.class)));
-		assertFalse(repository.contains(String.class, Long.class));
+		assertThat(repository.contains(ConverterPair.of(Long.class, String.class))).isTrue();
+		assertThat(repository.contains(Long.class, String.class)).isTrue();
+		assertThat(repository.contains(ConverterPair.of(String.class, Long.class))).isFalse();
+		assertThat(repository.contains(String.class, Long.class)).isFalse();
 
-		assertEquals(intConverter, repository.<Integer, String>get(ConverterPair.of(Integer.class, String.class)));
-		assertEquals(longConverter, repository.<Long, String>get(ConverterPair.of(Long.class, String.class)));
+		assertThat(repository.<Integer, String>get(ConverterPair.of(Integer.class, String.class)))
+			.isEqualTo(intConverter);
+		assertThat(repository.<Long, String>get(ConverterPair.of(Long.class, String.class))).isEqualTo(longConverter);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/SpringMapstructLocatorTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/SpringMapstructLocatorTests.java
@@ -25,7 +25,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -38,8 +38,8 @@ class SpringMapstructLocatorTests {
 
 	@Test
 	void test() {
-		assertNotNull(mapstructLocator.get(ConverterPair.of(Integer.class, String.class)));
-		assertNotNull(mapstructLocator.get(ConverterPair.of(Long.class, String.class)));
+		assertThat(mapstructLocator.get(ConverterPair.of(Integer.class, String.class))).isNotNull();
+		assertThat(mapstructLocator.get(ConverterPair.of(Long.class, String.class))).isNotNull();
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/mybatis/inject/SqlDataInjectionTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mybatis/inject/SqlDataInjectionTests.java
@@ -50,8 +50,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -78,9 +77,9 @@ class SqlDataInjectionTests {
 		userMapper.insert(user);
 
 		User copy = userMapper.getById(1);
-		assertEquals(user.getUsername(), copy.getUsername());
-		assertNotNull(copy.getInsertTime());
-		assertNotNull(copy.getUpdateTime());
+		assertThat(copy.getUsername()).isEqualTo(user.getUsername());
+		assertThat(copy.getInsertTime()).isNotNull();
+		assertThat(copy.getUpdateTime()).isNotNull();
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/mybatis/type/mysql/MysqlJsonTypeHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mybatis/type/mysql/MysqlJsonTypeHandlerTests.java
@@ -55,7 +55,7 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -99,12 +99,13 @@ class MysqlJsonTypeHandlerTests {
 		user.setPassword("admin");
 		user.setDes(JsonMapperUtils.readTree(json));
 
-		assertEquals(1, userMapper.insert(user));
+		assertThat(userMapper.insert(user)).isEqualTo(1);
+
 		User first = userMapper.selectList().getFirst();
-		assertEquals(user.getUsername(), first.getUsername());
-		assertEquals(user.getPassword(), first.getPassword());
-		assertEquals(user.getDes(), first.getDes());
-		assertEquals("livk", first.getDes().get("mark").asText());
+		assertThat(first.getUsername()).isEqualTo(user.getUsername());
+		assertThat(first.getPassword()).isEqualTo(user.getPassword());
+		assertThat(first.getDes()).isEqualTo(user.getDes());
+		assertThat(first.getDes().get("mark").asText()).isEqualTo("livk");
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/mybatis/type/postgresql/PostgresJsonTypeHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/mybatis/type/postgresql/PostgresJsonTypeHandlerTests.java
@@ -55,7 +55,7 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -99,12 +99,12 @@ class PostgresJsonTypeHandlerTests {
 		user.setPassword("admin");
 		user.setDes(JsonMapperUtils.readTree(json));
 
-		assertEquals(1, userMapper.insert(user));
+		assertThat(userMapper.insert(user)).isEqualTo(1);
 		User first = userMapper.selectList().getFirst();
-		assertEquals(user.getUsername(), first.getUsername());
-		assertEquals(user.getPassword(), first.getPassword());
-		assertEquals(user.getDes(), first.getDes());
-		assertEquals("livk", first.getDes().get("mark").asText());
+		assertThat(first.getUsername()).isEqualTo(user.getUsername());
+		assertThat(first.getPassword()).isEqualTo(user.getPassword());
+		assertThat(first.getDes()).isEqualTo(user.getDes());
+		assertThat(first.getDes().get("mark").asText()).isEqualTo("livk");
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/QrCodeManagerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/QrCodeManagerTests.java
@@ -28,7 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -52,7 +52,7 @@ class QrCodeManagerTests {
 
 		String text = manager.parser(inputStream);
 
-		assertEquals("hello", text);
+		assertThat(text).isEqualTo("hello");
 	}
 
 	@Test
@@ -70,7 +70,7 @@ class QrCodeManagerTests {
 
 		String text = manager.parser(inputStream);
 
-		assertEquals(mapper.writeValueAsString(map), text);
+		assertThat(mapper.writeValueAsString(map)).isEqualTo(text);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/QRCodeMethodReturnValueHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/QRCodeMethodReturnValueHandlerTests.java
@@ -32,8 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -57,7 +56,7 @@ class QRCodeMethodReturnValueHandlerTests {
 
 	@Test
 	void supportsReturnType() {
-		assertTrue(handler.supportsReturnType(parameter));
+		assertThat(handler.supportsReturnType(parameter)).isTrue();
 	}
 
 	@Test
@@ -70,7 +69,7 @@ class QRCodeMethodReturnValueHandlerTests {
 
 		InputStream inputStream = new ByteArrayInputStream(response.getContentAsByteArray());
 
-		assertEquals("code", manager.parser(inputStream));
+		assertThat(manager.parser(inputStream)).isEqualTo("code");
 	}
 
 	@ResponseQrCode

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/QrCodeMethodArgumentResolverTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/QrCodeMethodArgumentResolverTests.java
@@ -29,8 +29,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -51,7 +50,7 @@ class QrCodeMethodArgumentResolverTests {
 
 	@Test
 	void supportsParameter() {
-		assertTrue(resolver.supportsParameter(parameter));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
 	@Test
@@ -64,7 +63,7 @@ class QrCodeMethodArgumentResolverTests {
 
 		Object result = resolver.resolveArgument(parameter, null, webRequest, null);
 
-		assertEquals("QrCode", result);
+		assertThat(result).isEqualTo("QrCode");
 	}
 
 	static class TestController {

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQRCodeMethodReturnValueHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQRCodeMethodReturnValueHandlerTests.java
@@ -33,7 +33,7 @@ import reactor.test.StepVerifier;
 
 import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -58,7 +58,7 @@ class ReactiveQRCodeMethodReturnValueHandlerTests {
 
 	@Test
 	void supports() {
-		assertTrue(handler.supports(result));
+		assertThat(handler.supports(result)).isTrue();
 	}
 
 	@Test

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQrCodeMethodArgumentResolverTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQrCodeMethodArgumentResolverTests.java
@@ -44,8 +44,7 @@ import reactor.test.StepVerifier;
 
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -71,7 +70,7 @@ class ReactiveQrCodeMethodArgumentResolverTests {
 
 	@Test
 	void supportsParameter() {
-		assertTrue(resolver.supportsParameter(parameter));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
 	@Test
@@ -89,7 +88,7 @@ class ReactiveQrCodeMethodArgumentResolverTests {
 
 		MediaType contentType = clientRequest.getHeaders().getContentType();
 		Flux<DataBuffer> body = clientRequest.getBody();
-		assertNotNull(contentType);
+		assertThat(contentType).isNotNull();
 		MockServerHttpRequest serverRequest = MockServerHttpRequest.post("/").contentType(contentType).body(body);
 
 		MockServerWebExchange exchange = MockServerWebExchange.from(serverRequest);

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/support/QrCodeSupportTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/support/QrCodeSupportTests.java
@@ -17,6 +17,7 @@
 package com.livk.context.qrcode.support;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.livk.context.qrcode.PicType;
 import com.livk.context.qrcode.QrCodeEntity;
 import com.livk.context.qrcode.annotation.ResponseQrCode;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,9 +28,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -53,22 +52,21 @@ class QrCodeSupportTests {
 	@Test
 	void createAttributes() {
 		AnnotationAttributes attributes = support.createAttributes(returnValue, parameter);
-		assertEquals(returnValue.width(), attributes.getNumber("width").intValue());
-		assertEquals(returnValue.height(), attributes.getNumber("height").intValue());
-		assertEquals(returnValue.type(), attributes.getEnum("type"));
+		assertThat(attributes.getNumber("width").intValue()).isEqualTo(returnValue.width());
+		assertThat(attributes.getNumber("height").intValue()).isEqualTo(returnValue.height());
+		assertThat(attributes.<PicType>getEnum("type")).isEqualTo(returnValue.type());
 	}
 
 	@Test
 	void toBufferedImage() {
 		BufferedImage bufferedImage = support.toBufferedImage(returnValue, attributes);
-		assertNotNull(bufferedImage);
+		assertThat(bufferedImage).isNotNull();
 	}
 
 	@Test
 	void toByteArray() {
 		byte[] bytes = support.toByteArray(returnValue, attributes);
-		assertNotNull(bytes);
-		assertTrue(bytes.length > 0);
+		assertThat(bytes).isNotNull().isNotEmpty();
 	}
 
 	@Test
@@ -77,8 +75,7 @@ class QrCodeSupportTests {
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
 		support.write(bufferedImage, "PNG", stream);
 		byte[] bytes = stream.toByteArray();
-		assertNotNull(bytes);
-		assertTrue(bytes.length > 0);
+		assertThat(bytes).isNotNull().isNotEmpty();
 	}
 
 	static class Support extends QrCodeSupport {

--- a/spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTests.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -63,7 +63,7 @@ class ReactiveRedisOpsTests {
 			.hashValue(JacksonSerializerUtils.json())
 			.build();
 		ReactiveRedisOps ops = new ReactiveRedisOps(connectionFactory, context);
-		assertEquals("PONG", ops.execute(ReactiveRedisConnection::ping).blockFirst());
+		assertThat(ops.execute(ReactiveRedisConnection::ping).blockFirst()).isEqualTo("PONG");
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTests.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -54,7 +54,7 @@ class RedisOpsTests {
 	@Test
 	void test() {
 		RedisOps ops = new RedisOps(connectionFactory);
-		assertEquals("PONG", ops.execute(RedisConnectionCommands::ping));
+		assertThat(ops.execute(RedisConnectionCommands::ping)).isEqualTo("PONG");
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/FactoryProxySupportTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/FactoryProxySupportTests.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -59,7 +59,7 @@ class FactoryProxySupportTests {
 	@Test
 	void newProxy() {
 		try (StatefulRedisModulesConnection<String, String> connect = factory.connect()) {
-			assertEquals("PONG", connect.sync().ping());
+			assertThat(connect.sync().ping()).isEqualTo("PONG");
 		}
 	}
 

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTests.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -58,8 +58,8 @@ class RediSearchTemplateTests {
 		RediSearchTemplate<String, Object> template = new RediSearchTemplate<>(factory, redisCodec);
 		template.afterPropertiesSet();
 
-		assertEquals("PONG", template.async().ping().get());
-		assertEquals("PONG", template.reactive().ping().block());
+		assertThat(template.async().ping().get()).isEqualTo("PONG");
+		assertThat(template.reactive().ping().block()).isEqualTo("PONG");
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTests.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -53,8 +53,8 @@ class StringRediSearchTemplateTests {
 	void test() throws Exception {
 		StringRediSearchTemplate template = new StringRediSearchTemplate(factory);
 
-		assertEquals("PONG", template.async().ping().get());
-		assertEquals("PONG", template.reactive().ping().block());
+		assertThat(template.async().ping().get()).isEqualTo("PONG");
+		assertThat(template.reactive().ping().block()).isEqualTo("PONG");
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/codec/JacksonRedisCodecTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/codec/JacksonRedisCodecTests.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -39,8 +39,8 @@ class JacksonRedisCodecTests {
 		String key = "redisKey";
 		byte[] bytes = mapper.writeValueAsBytes(key);
 
-		assertEquals(ByteBuffer.wrap(bytes), codec.encodeKey(key));
-		assertEquals(key, codec.decodeKey(ByteBuffer.wrap(bytes)));
+		assertThat(codec.encodeKey(key)).isEqualTo(ByteBuffer.wrap(bytes));
+		assertThat(codec.decodeKey(ByteBuffer.wrap(bytes))).isEqualTo(key);
 	}
 
 	@Test
@@ -48,8 +48,8 @@ class JacksonRedisCodecTests {
 		Map<String, String> map = Map.of("username", "password");
 		byte[] bytes = mapper.writeValueAsBytes(map);
 
-		assertEquals(ByteBuffer.wrap(bytes), codec.encodeValue(map));
-		assertEquals(map, codec.decodeValue(ByteBuffer.wrap(bytes)));
+		assertThat(codec.encodeValue(map)).isEqualTo(ByteBuffer.wrap(bytes));
+		assertThat(codec.decodeValue(ByteBuffer.wrap(bytes))).isEqualTo(map);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/redisearch/codec/JdkRedisCodecTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/redisearch/codec/JdkRedisCodecTests.java
@@ -16,7 +16,6 @@
 
 package com.livk.context.redisearch.codec;
 
-import com.livk.commons.util.ObjectUtils;
 import io.lettuce.core.codec.RedisCodec;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -24,8 +23,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -39,9 +37,9 @@ class JdkRedisCodecTests {
 		String key = "redisKey";
 		byte[] bytes = RedisSerializer.java().serialize(key);
 
-		assertFalse(ObjectUtils.isEmpty(bytes));
-		assertEquals(ByteBuffer.wrap(bytes), codec.encodeKey(key));
-		assertEquals(key, codec.decodeKey(ByteBuffer.wrap(bytes)));
+		assertThat(bytes).isNotEmpty();
+		assertThat(codec.encodeKey(key)).isEqualTo(ByteBuffer.wrap(bytes));
+		assertThat(codec.decodeKey(ByteBuffer.wrap(bytes))).isEqualTo(key);
 	}
 
 	@Test
@@ -49,9 +47,9 @@ class JdkRedisCodecTests {
 		Map<String, String> map = Map.of("username", "password");
 		byte[] bytes = RedisSerializer.java().serialize(map);
 
-		assertFalse(ObjectUtils.isEmpty(bytes));
-		assertEquals(ByteBuffer.wrap(bytes), codec.encodeValue(map));
-		assertEquals(map, codec.decodeValue(ByteBuffer.wrap(bytes)));
+		assertThat(bytes).isNotEmpty();
+		assertThat(codec.encodeValue(map)).isEqualTo(ByteBuffer.wrap(bytes));
+		assertThat(codec.decodeValue(ByteBuffer.wrap(bytes))).isEqualTo(map);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/sequence/SequenceRangeTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/sequence/SequenceRangeTests.java
@@ -18,9 +18,7 @@ package com.livk.context.sequence;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -31,12 +29,12 @@ class SequenceRangeTests {
 	void test() {
 		SequenceRange range = new SequenceRange(1L, 10L);
 		for (int i = 1; i <= 10; i++) {
-			assertFalse(range.isOver());
-			assertEquals(i, range.getAndIncrement());
+			assertThat(range.isOver()).isFalse();
+			assertThat(range.getAndIncrement()).isEqualTo(i);
 		}
 
-		assertEquals(-1, range.getAndIncrement());
-		assertTrue(range.isOver());
+		assertThat(range.getAndIncrement()).isEqualTo(-1);
+		assertThat(range.isOver()).isTrue();
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/sequence/SequenceTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/sequence/SequenceTests.java
@@ -42,9 +42,7 @@ import javax.sql.DataSource;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -82,32 +80,32 @@ class SequenceTests {
 	@Test
 	void testDb() {
 		Sequence sequence = SequenceBuilder.builder(dataSource).bizName("test-sequence").build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 1);
 		}
 	}
 
 	@Test
 	void testRedis() {
 		Sequence sequence = SequenceBuilder.builder(redisClient).bizName("test-sequence").build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 1);
 		}
 	}
 
 	@Test
 	void test() {
 		Sequence sequence = Sequence.snowflake(1, 2);
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		Set<Long> generatedIds = new HashSet<>();
 		for (int i = 0; i < 1000; i++) { // 增加迭代次数以更严格测试
 			Long nextId = sequence.nextValue();
-			assertNotNull(nextId);
-			assertTrue(generatedIds.add(nextId), "ID should be unique");
+			assertThat(nextId).isNotNull();
+			assertThat(generatedIds.add(nextId)).isTrue();
 		}
-		assertEquals(1000, generatedIds.size(), "All generated IDs should be unique");
+		assertThat(generatedIds).hasSize(1000);
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/sequence/builder/DbSequenceBuilderTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/sequence/builder/DbSequenceBuilderTests.java
@@ -26,10 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class DbSequenceBuilderTests {
 
@@ -53,9 +51,9 @@ class DbSequenceBuilderTests {
 	void testBuildSequenceWithAllRequiredParameters() {
 		DbSequenceBuilder builder = new DbSequenceBuilder(dataSource).bizName("test-biz");
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 1);
 		}
 	}
 
@@ -64,7 +62,7 @@ class DbSequenceBuilderTests {
 		int customStep = 123;
 		DbSequenceBuilder builder = new DbSequenceBuilder(dataSource).bizName("step-biz").step(customStep);
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 
 		// Use reflection to access the step value in DbRangeManager
 		Field managerField = sequence.getClass().getDeclaredField("manager");
@@ -73,7 +71,7 @@ class DbSequenceBuilderTests {
 		Field stepField = DbRangeManager.class.getSuperclass().getDeclaredField("step");
 		stepField.setAccessible(true);
 		int actualStep = (int) stepField.get(manager);
-		assertEquals(customStep, actualStep);
+		assertThat(actualStep).isEqualTo(customStep);
 	}
 
 	@Test
@@ -82,7 +80,7 @@ class DbSequenceBuilderTests {
 		DbSequenceBuilder builder = new DbSequenceBuilder(dataSource).bizName("stepStart-biz")
 			.stepStart(customStepStart);
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 
 		// Use reflection to access the stepStart value in DbRangeManager
 		Field managerField = sequence.getClass().getDeclaredField("manager");
@@ -91,21 +89,22 @@ class DbSequenceBuilderTests {
 		Field stepStartField = DbRangeManager.class.getSuperclass().getDeclaredField("stepStart");
 		stepStartField.setAccessible(true);
 		long actualStepStart = (long) stepStartField.get(manager);
-		assertEquals(customStepStart, actualStepStart);
+		assertThat(actualStepStart).isEqualTo(customStepStart);
 	}
 
 	@Test
 	void testBuildThrowsExceptionWhenBizNameMissing() {
 		DbSequenceBuilder builder = new DbSequenceBuilder(dataSource);
-		Exception exception = assertThrows(IllegalArgumentException.class, builder::build);
-		assertTrue(exception.getMessage().contains("name is required"));
+		Throwable exception = catchThrowable(builder::build);
+		assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+		assertThat(exception.getMessage()).contains("name is required");
 	}
 
 	@Test
 	void testNegativeStepValueIgnored() throws Exception {
 		DbSequenceBuilder builder = new DbSequenceBuilder(dataSource).bizName("neg-step-biz").step(-100);
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 
 		// Should still use default step (1000)
 		Field managerField = sequence.getClass().getDeclaredField("manager");
@@ -114,14 +113,14 @@ class DbSequenceBuilderTests {
 		Field stepField = DbRangeManager.class.getSuperclass().getDeclaredField("step");
 		stepField.setAccessible(true);
 		int actualStep = (int) stepField.get(manager);
-		assertEquals(1000, actualStep);
+		assertThat(actualStep).isEqualTo(1000);
 	}
 
 	@Test
 	void testNegativeStepStartValueIgnored() throws Exception {
 		DbSequenceBuilder builder = new DbSequenceBuilder(dataSource).bizName("neg-stepStart-biz").stepStart(-99L);
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 
 		// Should still use default stepStart (0)
 		Field managerField = sequence.getClass().getDeclaredField("manager");
@@ -130,7 +129,7 @@ class DbSequenceBuilderTests {
 		Field stepStartField = DbRangeManager.class.getSuperclass().getDeclaredField("stepStart");
 		stepStartField.setAccessible(true);
 		long actualStepStart = (long) stepStartField.get(manager);
-		assertEquals(0L, actualStepStart);
+		assertThat(actualStepStart).isEqualTo(0);
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/sequence/builder/DefaultRangeSequenceTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/sequence/builder/DefaultRangeSequenceTests.java
@@ -20,7 +20,7 @@ import com.livk.context.sequence.SequenceRange;
 import com.livk.context.sequence.support.RangeManager;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -33,7 +33,7 @@ class DefaultRangeSequenceTests {
 	void nextValue() {
 		DefaultRangeSequence sequence = new DefaultRangeSequence(rangeManager, "test");
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 1);
 		}
 	}
 

--- a/spring-extension-context/src/test/java/com/livk/context/sequence/builder/RedisSequenceBuilderTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/sequence/builder/RedisSequenceBuilderTests.java
@@ -27,10 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 @Testcontainers(disabledWithoutDocker = true, parallel = true)
 class RedisSequenceBuilderTests {
@@ -58,9 +56,9 @@ class RedisSequenceBuilderTests {
 	void testBuildSequenceWithRequiredParameters() {
 		RedisSequenceBuilder builder = new RedisSequenceBuilder(redisClient).bizName("test-sequence");
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 1);
 		}
 	}
 
@@ -70,9 +68,9 @@ class RedisSequenceBuilderTests {
 			.step(10)
 			.stepStart(100);
 		Sequence sequence = builder.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 101, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 101);
 		}
 	}
 
@@ -82,9 +80,9 @@ class RedisSequenceBuilderTests {
 			.bizName("chain-sequence")
 			.stepStart(50)
 			.build();
-		assertNotNull(sequence);
+		assertThat(sequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 51, sequence.nextValue());
+			assertThat(sequence.nextValue()).isEqualTo(i + 51);
 		}
 	}
 
@@ -95,35 +93,36 @@ class RedisSequenceBuilderTests {
 		RedisSequenceBuilder builder = new RedisSequenceBuilder(
 				RedisClient.create("redis://localhost:" + unreachablePort))
 			.bizName("fail-sequence");
-		Exception exception = assertThrows(RedisConnectionException.class, builder::build);
-		assertTrue(exception.getMessage().contains("Unable to connect to localhost/<unresolved>:6399"));
+		Throwable exception = catchThrowable(builder::build);
+		assertThat(exception).isInstanceOf(RedisConnectionException.class);
+		assertThat(exception.getMessage()).contains("Unable to connect to localhost/<unresolved>:6399");
 	}
 
 	@Test
 	void testBuildSequenceWithInvalidStepOrStepStart() {
 		// step = 0 should fallback to default (1000)
 		Sequence zeroStepSequence = new RedisSequenceBuilder(redisClient).bizName("zero-step").step(0).build();
-		assertNotNull(zeroStepSequence);
+		assertThat(zeroStepSequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, zeroStepSequence.nextValue());
+			assertThat(zeroStepSequence.nextValue()).isEqualTo(i + 1);
 		}
 
 		// step < 0 should fallback to default (1000)
 		Sequence negativeStepSequence = new RedisSequenceBuilder(redisClient).bizName("negative-step")
 			.step(-10)
 			.build();
-		assertNotNull(negativeStepSequence);
+		assertThat(negativeStepSequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, negativeStepSequence.nextValue());
+			assertThat(negativeStepSequence.nextValue()).isEqualTo(i + 1);
 		}
 
 		// stepStart < 0 should fallback to default (0)
 		Sequence negativeStepStartSequence = new RedisSequenceBuilder(redisClient).bizName("negative-stepstart")
 			.stepStart(-100)
 			.build();
-		assertNotNull(negativeStepStartSequence);
+		assertThat(negativeStepStartSequence).isNotNull();
 		for (int i = 0; i < 10; i++) {
-			assertEquals(i + 1, negativeStepStartSequence.nextValue());
+			assertThat(negativeStepStartSequence.nextValue()).isEqualTo(i + 1);
 		}
 	}
 

--- a/spring-extension-context/src/test/java/com/livk/context/useragent/UserAgentHelperTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/useragent/UserAgentHelperTests.java
@@ -34,8 +34,7 @@ import org.springframework.http.HttpHeaders;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -55,42 +54,42 @@ class UserAgentHelperTests {
 
 	@Test
 	void convertBrowscap() {
-
 		applicationContext = new AnnotationConfigApplicationContext(BrowscapConfig.class);
 
 		UserAgentHelper helper = new UserAgentHelper();
 		helper.setApplicationContext(applicationContext);
 		UserAgent userAgent = helper.convert(headers);
-		assertNotNull(userAgent);
-		assertEquals(userAgentStr, userAgent.userAgentStr());
-		assertEquals("Chrome", userAgent.browser());
-		assertEquals("Browser", userAgent.browserType());
-		assertEquals("120", userAgent.browserVersion());
-		assertEquals("Win10", userAgent.os());
-		assertEquals("10.0", userAgent.osVersion());
-		assertEquals("Desktop", userAgent.deviceType());
-		assertEquals("Windows Desktop", userAgent.deviceName());
-		assertEquals("Unknown", userAgent.deviceBrand());
+
+		assertThat(userAgent).isNotNull();
+		assertThat(userAgent.userAgentStr()).isEqualTo(userAgentStr);
+		assertThat(userAgent.browser()).isEqualTo("Chrome");
+		assertThat(userAgent.browserType()).isEqualTo("Browser");
+		assertThat(userAgent.browserVersion()).isEqualTo("120");
+		assertThat(userAgent.os()).isEqualTo("Win10");
+		assertThat(userAgent.osVersion()).isEqualTo("10.0");
+		assertThat(userAgent.deviceType()).isEqualTo("Desktop");
+		assertThat(userAgent.deviceName()).isEqualTo("Windows Desktop");
+		assertThat(userAgent.deviceBrand()).isEqualTo("Unknown");
 	}
 
 	@Test
 	void convertYauaa() {
-
 		applicationContext = new AnnotationConfigApplicationContext(YauaaConfig.class);
 
 		UserAgentHelper helper = new UserAgentHelper();
 		helper.setApplicationContext(applicationContext);
 		UserAgent userAgent = helper.convert(headers);
-		assertNotNull(userAgent);
-		assertEquals(userAgentStr, userAgent.userAgentStr());
-		assertEquals("Chrome", userAgent.browser());
-		assertEquals("Browser", userAgent.browserType());
-		assertEquals("120", userAgent.browserVersion());
-		assertEquals("Windows NT", userAgent.os());
-		assertEquals("Windows NT ??", userAgent.osVersion());
-		assertEquals("Desktop", userAgent.deviceType());
-		assertEquals("Desktop", userAgent.deviceName());
-		assertEquals("Unknown", userAgent.deviceBrand());
+
+		assertThat(userAgent).isNotNull();
+		assertThat(userAgent.userAgentStr()).isEqualTo(userAgentStr);
+		assertThat(userAgent.browser()).isEqualTo("Chrome");
+		assertThat(userAgent.browserType()).isEqualTo("Browser");
+		assertThat(userAgent.browserVersion()).isEqualTo("120");
+		assertThat(userAgent.os()).isEqualTo("Windows NT");
+		assertThat(userAgent.osVersion()).isEqualTo("Windows NT ??");
+		assertThat(userAgent.deviceType()).isEqualTo("Desktop");
+		assertThat(userAgent.deviceName()).isEqualTo("Desktop");
+		assertThat(userAgent.deviceBrand()).isEqualTo("Unknown");
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/src/test/java/com/livk/context/useragent/reactive/ReactiveUserAgentResolverTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/useragent/reactive/ReactiveUserAgentResolverTests.java
@@ -43,7 +43,7 @@ import reactor.test.StepVerifier;
 import java.lang.reflect.Method;
 import java.util.function.Function;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -72,7 +72,7 @@ class ReactiveUserAgentResolverTests {
 		Method method = this.getClass().getDeclaredMethod("test", Mono.class);
 		MethodParameter parameter = MethodParameter.forExecutable(method, 0);
 
-		assertTrue(resolver.supportsParameter(parameter));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
 	@Test

--- a/spring-extension-context/src/test/java/com/livk/context/useragent/servlet/UserAgentResolverTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/useragent/servlet/UserAgentResolverTests.java
@@ -37,11 +37,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author livk
@@ -73,34 +69,33 @@ class UserAgentResolverTests {
 		Method method = this.getClass().getDeclaredMethod("test", UserAgent.class);
 		MethodParameter parameter = MethodParameter.forExecutable(method, 0);
 
-		assertTrue(resolver.supportsParameter(parameter));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
 	@Test
 	void resolveArgument() throws Exception {
+		assertThat(UserAgentContextHolder.getUserAgentContext()).isNull();
 
-		assertNull(UserAgentContextHolder.getUserAgentContext());
 		Method method = this.getClass().getDeclaredMethod("test", UserAgent.class);
 		MethodParameter parameter = MethodParameter.forExecutable(method, 0);
 
 		ServletWebRequest webRequest = new ServletWebRequest(request, response);
 		Object result = resolver.resolveArgument(parameter, null, webRequest, null);
 
-		assertInstanceOf(UserAgent.class, result);
+		assertThat(result).isInstanceOf(UserAgent.class).isEqualTo(UserAgentContextHolder.getUserAgentContext());
 
 		UserAgent userAgent = (UserAgent) result;
-		assertNotNull(userAgent);
-		assertEquals(request.getHeader(HttpHeaders.USER_AGENT), userAgent.userAgentStr());
-		assertEquals("Chrome", userAgent.browser());
-		assertEquals("Browser", userAgent.browserType());
-		assertEquals("120", userAgent.browserVersion());
-		assertEquals("Windows NT", userAgent.os());
-		assertEquals("Windows NT ??", userAgent.osVersion());
-		assertEquals("Desktop", userAgent.deviceType());
-		assertEquals("Desktop", userAgent.deviceName());
-		assertEquals("Unknown", userAgent.deviceBrand());
 
-		assertEquals(result, UserAgentContextHolder.getUserAgentContext());
+		assertThat(userAgent).isNotNull();
+		assertThat(userAgent.userAgentStr()).isEqualTo(request.getHeader(HttpHeaders.USER_AGENT));
+		assertThat(userAgent.browser()).isEqualTo("Chrome");
+		assertThat(userAgent.browserType()).isEqualTo("Browser");
+		assertThat(userAgent.browserVersion()).isEqualTo("120");
+		assertThat(userAgent.os()).isEqualTo("Windows NT");
+		assertThat(userAgent.osVersion()).isEqualTo("Windows NT ??");
+		assertThat(userAgent.deviceType()).isEqualTo("Desktop");
+		assertThat(userAgent.deviceName()).isEqualTo("Desktop");
+		assertThat(userAgent.deviceBrand()).isEqualTo("Unknown");
 
 		UserAgentContextHolder.cleanUserAgentContext();
 	}

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -27,7 +27,6 @@
         <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"/>
         <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck"/>
         <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck"/>
-        <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck"/>
         <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedJavaCheck"/>
         <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck"/>
         <property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck"/>


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
• Migrated all test classes from JUnit assertions to AssertJ assertions for improved readability and fluent API
• Replaced traditional JUnit assertions (`assertEquals`, `assertNotNull`, `assertTrue`, etc.) with AssertJ equivalents (`assertThat().isEqualTo()`, `isNotNull()`, `isTrue()`, etc.)
• Enhanced exception testing by replacing `assertThrows` with `assertThatThrownBy` and `catchThrowable` for better error handling
• Improved collection and array assertions using AssertJ methods like `containsExactly()`, `hasSize()`, `containsAllEntriesOf()`
• Enhanced resource management with try-with-resources patterns in some test classes
• Updated imports across all test files to use AssertJ static methods
• Maintained all existing test functionality while improving code consistency and readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JUnit Assertions"] -- "Migration" --> B["AssertJ Assertions"]
  B --> C["Fluent API"]
  B --> D["Better Readability"]
  B --> E["Enhanced Exception Testing"]
  B --> F["Improved Collection Assertions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>65 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonMapperUtilsTests.java</strong><dd><code>Migrate JsonMapperUtilsTests from JUnit to AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonMapperUtilsTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test class<br> • Improved resource management by using try-with-resources <br>for InputStreams and Readers<br> • Removed unused import <br><code>com.google.common.collect.Lists</code><br> • Enhanced readability with more <br>fluent assertion syntax


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-8d02ac944d9594103ecc75e7fb1714ee098bcafd1d70f181ade545a78920c54a">+182/-181</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JacksonSupportTests.java</strong><dd><code>Convert JacksonSupportTests to use AssertJ assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/jackson/support/JacksonSupportTests.java

• Replaced JUnit assertions (<code>assertEquals</code>, <code>assertArrayEquals</code>, <br><code>assertNotNull</code>) with AssertJ assertions<br> • Updated all test methods to <br>use <code>assertThat()</code> with fluent assertion methods<br> • Improved test <br>readability and consistency across the test class


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-e2fc7a052f7997d77fb4133b0ae532de06fbd1cde0ef57cb9acc145c99f79d3b">+125/-107</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenericsByteBuddyTests.java</strong><dd><code>Refactor GenericsByteBuddyTests to use AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/GenericsByteBuddyTests.java

• Migrated from JUnit assertions to AssertJ assertions for better <br>readability<br> • Replaced <code>assertThrows</code> with <code>assertThatThrownBy</code> for <br>exception testing<br> • Updated modifier checks to use more descriptive <br>assertion patterns<br> • Enhanced test assertions with more expressive <br>fluent API


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-b15439c5658f851890104eec1c56510fb37dfaadb135157181af8b8821a18984">+50/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CuratorOperationsTests.java</strong><dd><code>Convert CuratorOperationsTests to AssertJ assertion style</code></dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/curator/CuratorOperationsTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test class<br> • Enhanced assertion messages with descriptive text for <br>better test failure reporting<br> • Updated array equality checks to use <br><code>containsExactly</code> method<br> • Improved test readability with fluent <br>assertion syntax


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-0df32236c3023941b42ddbcc45dcc5358b8792a5f0037bae61d9770d2fa547e7">+43/-40</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StreamUtilsTests.java</strong><dd><code>Update StreamUtilsTests to use AssertJ assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/StreamUtilsTests.java

• Migrated from JUnit assertions to AssertJ assertions for consistency<br> <br>• Removed unused import <code>java.util.Objects</code> and replaced with <br><code>Object::toString</code><br> • Updated stream comparison logic to collect and <br>compare as lists<br> • Enhanced array and collection assertions with more <br>expressive methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-ca81cbea2f4e0ded86f4def23aa7daa4d3ac76865dee938c959fc3f3f542cabb">+19/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TypeFactoryUtilsTests.java</strong><dd><code>Migrate TypeFactoryUtilsTests to AssertJ assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/jackson/TypeFactoryUtilsTests.java

• Replaced JUnit <code>assertEquals</code> assertions with AssertJ <br><code>assertThat().isEqualTo()</code><br> • Maintained all existing test logic while <br>improving assertion readability<br> • Updated all test methods to use <br>consistent AssertJ assertion style


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-f933be77180a264fa6c9baa79ccd7759b015787c6015788f3194c080b7034df3">+26/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SpringContextHolderTests.java</strong><dd><code>Convert SpringContextHolderTests to AssertJ assertion framework</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java

• Converted JUnit assertions to AssertJ assertions for better test <br>readability<br> • Updated bean comparison assertions to use <code>isSameAs</code> for <br>reference equality<br> • Enhanced property and binding assertions with <br>more descriptive methods<br> • Improved overall test consistency with <br>fluent assertion API


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-5333323f6d4d260dabb97a329de2d1c3c44a223a9c8e3a792e7fd9761a575e25">+20/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SpringExpressionResolverTests.java</strong><dd><code>Migrate SpringExpressionResolverTests to AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/expression/spring/SpringExpressionResolverTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test class<br> • Updated boolean and string equality checks to use fluent <br>assertion methods<br> • Enhanced test readability with more expressive <br>assertion syntax<br> • Maintained all existing test functionality while <br>improving code style


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-d0b565578e5c2a33dac0df6783955896e30749143c1ee6133054543bc3a29234">+28/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AviatorExpressionResolverTests.java</strong><dd><code>Update AviatorExpressionResolverTests to use AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/expression/aviator/AviatorExpressionResolverTests.java

• Converted JUnit assertions to AssertJ assertions for consistency<br> • <br>Updated boolean and string equality assertions to use fluent API<br> • <br>Enhanced test readability with more descriptive assertion methods<br> • <br>Maintained all test logic while improving assertion style


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-e7daa04ed2a5efc4173f4a2465b5582bc08ce9ff74e77727eca40cb3e4ed454b">+31/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnnotationUtilsTests.java</strong><dd><code>Convert AnnotationUtilsTests to AssertJ assertion framework</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationUtilsTests.java

• Replaced JUnit assertions with AssertJ assertions for better test <br>expressiveness<br> • Updated null/not-null checks and boolean assertions <br>to use fluent methods<br> • Enhanced array equality checks with <br><code>containsExactly</code> method<br> • Improved overall test readability and <br>consistency


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-6cbe6a9ec46adb94db0a6144eb40bdaa6abc21e2986bc2ba3f2575df6265f98d">+24/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpServletUtilsTests.java</strong><dd><code>Refactor HttpServletUtilsTests to use AssertJ assertions</code>&nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/HttpServletUtilsTests.java

• Migrated from JUnit assertions to AssertJ assertions throughout the <br>test class<br> • Enhanced map and collection assertions with more <br>expressive methods<br> • Updated reference equality checks to use <code>isSameAs</code> <br>method<br> • Improved test readability with fluent assertion syntax


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-d96589b0b65de80ed8825fba55270466f3232495504087951f6c8841bc87f9ed">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SequenceDbHelperTests.java</strong><dd><code>Convert SequenceDbHelperTests to AssertJ assertion style</code>&nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/support/SequenceDbHelperTests.java

• Replaced JUnit assertions with AssertJ assertions for better test <br>expressiveness<br> • Updated exception testing to use <code>assertThatThrownBy</code> <br>instead of <code>assertThrows</code><br> • Enhanced boolean and equality assertions <br>with more descriptive methods<br> • Improved test failure messages and <br>overall readability


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-83617cc24b91a7219a7a620fa6fc5c0a261309e8a9024defafecfc107b11ccb3">+13/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DbSequenceBuilderTests.java</strong><dd><code>Update DbSequenceBuilderTests to use AssertJ assertions</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/builder/DbSequenceBuilderTests.java

• Migrated from JUnit assertions to AssertJ assertions for consistency<br> <br>• Updated exception testing to use <code>catchThrowable</code> instead of <br><code>assertThrows</code><br> • Enhanced equality and null checks with more expressive <br>assertion methods<br> • Improved test readability and error reporting


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-e7f3274494c15adc65490609ad168f1d4b86d4d7b4cc2559a328f6e849656268">+15/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MvelExpressionResolverTests.java</strong><dd><code>Migrate MvelExpressionResolverTests to AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/expression/mvel2/MvelExpressionResolverTests.java

• Converted JUnit assertions to AssertJ assertions throughout the test <br>class<br> • Updated boolean and string equality checks to use fluent <br>assertion methods<br> • Enhanced test readability with more expressive <br>assertion syntax<br> • Maintained all existing test functionality while <br>improving code style


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-fe57f2021da4d4333b6703d669a3d9c7f8367a11d7a5b3c495bd2af815828419">+28/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SqlParserUtilsTests.java</strong><dd><code>Convert SqlParserUtilsTests to AssertJ assertion framework</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/SqlParserUtilsTests.java

• Replaced JUnit assertions with AssertJ assertions for better test <br>expressiveness<br> • Added exception testing using <code>assertThatThrownBy</code> for <br>null/empty input validation<br> • Enhanced collection and equality <br>assertions with more descriptive methods<br> • Improved test coverage and <br>readability with fluent assertion syntax


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-f78921d5e647cbb11b0fb9191eb609f9588cbe84d4ad94582b136919e90e5cfb">+32/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisSequenceBuilderTests.java</strong><dd><code>Replace JUnit assertions with AssertJ in RedisSequenceBuilderTests</code></dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/builder/RedisSequenceBuilderTests.java

• Replaced JUnit assertions with AssertJ assertions using <code>assertThat()</code> <br>instead of <code>assertEquals()</code>, <code>assertNotNull()</code>, etc.<br> • Changed exception <br>testing from <code>assertThrows()</code> to <code>catchThrowable()</code> with <br><code>assertThat().isInstanceOf()</code><br> • Updated imports to use AssertJ static <br>methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-8d73d5f771a92fbbecf6f813051bf51a1c17ec308b027b9ff5eba8d526818234">+17/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DbRangeManagerTests.java</strong><dd><code>Convert JUnit assertions to AssertJ in DbRangeManagerTests</code></dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/support/DbRangeManagerTests.java

• Migrated from JUnit assertions to AssertJ assertions throughout the <br>test class<br> • Changed <code>assertDoesNotThrow()</code> to <br><code>assertThatCode().doesNotThrowAnyException()</code><br> • Updated exception <br>testing to use <code>assertThatThrownBy().isInstanceOf()</code>


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-4bc7fddc36b44a6bc8024838aef81859865dd228e3322c706833cd298268a463">+24/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SnowflakeIdGeneratorTests.java</strong><dd><code>Migrate SnowflakeIdGeneratorTests to AssertJ assertions</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/SnowflakeIdGeneratorTests.java

• Replaced JUnit assertions with AssertJ fluent assertions<br> • <br>Simplified duplicate checking using <br><code>assertThat(list).doesNotHaveDuplicates()</code><br> • Updated assertion messages <br>to use AssertJ's <code>withFailMessage()</code> method


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-43f32849fa3c400cd70b0c5643d5f81dfb71d1d6d351c199688e44d8209eb090">+11/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnnotationPointcutTests.java</strong><dd><code>Switch AnnotationPointcutTests to AssertJ assertion style</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationPointcutTests.java

• Converted JUnit assertions to AssertJ assertions with fluent API<br> • <br>Improved readability by chaining assertions and using more descriptive <br>methods<br> • Updated all <code>assertEquals()</code> and <code>assertTrue()</code> calls to use <br><code>assertThat()</code>


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-ef9bd3401ea0b1bbd542c1b28da7caef0550109c6d41873d4daa4b4ae3ade904">+26/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JexlExpressionResolverTests.java</strong><dd><code>Convert JexlExpressionResolverTests to use AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/expression/jexl3/JexlExpressionResolverTests.java

• Replaced JUnit assertions with AssertJ assertions for better <br>readability<br> • Updated all <code>assertEquals()</code> and <code>assertTrue()</code> calls to use <br><code>assertThat()</code><br> • Maintained the same test logic while improving <br>assertion clarity


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-d22573d6c8aa9e1c9c316c6e02defbfa7060af39aa2aed2c95796ac1b0ebada4">+22/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpReactiveUtilsTests.java</strong><dd><code>Update HttpReactiveUtilsTests with AssertJ and BDD Mockito</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/HttpReactiveUtilsTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Changed <br>Mockito stubbing from <code>when().thenReturn()</code> to <code>given().willReturn()</code><br> • <br>Updated test assertions to use more fluent and readable AssertJ syntax


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-16827137a86297aacbf5c493de29590b4fdc1b066a68410ab38f652e235c41f2">+13/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FreeMarkerExpressionResolverTests.java</strong><dd><code>Convert FreeMarkerExpressionResolverTests to AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolverTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test<br> • Changed exception testing from <code>assertThrowsExactly()</code> to <br><code>assertThatThrownBy().isExactlyInstanceOf()</code><br> • Updated imports to use <br>AssertJ static methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-bb19753d0e81cdf4de2ce1f48a981bfe8a29e7cde2efae627ffdfdf1c1364b07">+22/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NumberJsonSerializerTests.java</strong><dd><code>Update NumberJsonSerializerTests with AssertJ precision assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Added <br>precision-aware assertions using <code>within()</code> for floating-point <br>comparisons<br> • Improved test readability with fluent assertion chains


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-d83e04616f9e8f64458c264c4013c7fecd8399997d2d1b7db52587f27c6ba254">+19/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BeanUtilsTests.java</strong><dd><code>Convert BeanUtilsTests to use AssertJ assertion style</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTests.java

• Replaced JUnit assertions with AssertJ assertions for better <br>readability<br> • Changed exception testing to use <br><code>assertThatThrownBy().isInstanceOf().hasMessage()</code><br> • Updated map <br>assertions to use <code>containsEntry()</code> for cleaner validation


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-8e5e37cad660a91da3bc56201477904a5c2a8cf7469b183d302e80cc92b4bf8c">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PairTests.java</strong><dd><code>Switch PairTests to AssertJ fluent assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/PairTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Updated <br>collection assertions to use <code>containsExactly()</code> and <br><code>containsAllEntriesOf()</code><br> • Improved null checking and equality <br>assertions with fluent API


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-56b4c1c5ee888021536e5e0faaa8afcc550ff42baaf830ac90dad7f292a8a684">+15/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserAgentHelperTests.java</strong><dd><code>Convert UserAgentHelperTests to AssertJ assertion style</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/useragent/UserAgentHelperTests.java

• Replaced JUnit assertions with AssertJ assertions throughout both <br>test methods<br> • Updated all <code>assertEquals()</code> and <code>assertNotNull()</code> calls to <br>use <code>assertThat()</code><br> • Maintained the same test validation logic with <br>improved readability


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-15a54672c28d450dacfec5036032dfdf3b33134ce0be02d7935b14a44207200b">+23/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReflectionUtilsTests.java</strong><dd><code>Update ReflectionUtilsTests with AssertJ collection assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/ReflectionUtilsTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Changed <br><code>assertLinesMatch()</code> to <code>containsExactly()</code> for list comparison<br> • Updated <br>set assertions to use <code>containsExactlyInAnyOrder()</code> for better clarity


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-eb7c64aff8c8e3bf8dec0d1013e5ffc9c03a26a24d8677bf765af449168b3d5a">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisRangeManagerTests.java</strong><dd><code>Convert RedisRangeManagerTests to AssertJ assertion style</code></dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/support/RedisRangeManagerTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test class<br> • Changed <code>assertDoesNotThrow()</code> to <br><code>assertThatCode().doesNotThrowAnyException()</code><br> • Updated exception <br>testing to use <br><code>assertThatThrownBy().isInstanceOf().hasMessageContaining()</code>


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-0a4b6fd77bfdbeffd650600bf6b30de967945396ddb64b7a648d6289c8179cf2">+17/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContextFactoryTests.java</strong><dd><code>Switch ContextFactoryTests to AssertJ fluent assertions</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/expression/ContextFactoryTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Updated <br>collection and map assertions to use fluent API methods like <br><code>hasSize()</code>, <code>containsKey()</code>, <code>containsValue()</code><br> • Improved readability with <br>chained assertions and descriptive methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-57ffb975c9bd05ff18cf20134e0e70dbbca21a5eb9eb15eb10c3cafe53b2d369">+12/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserAgentResolverTests.java</strong><dd><code>Convert UserAgentResolverTests to AssertJ assertion style</code></dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/useragent/servlet/UserAgentResolverTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test<br> • Combined multiple assertion calls into single fluent chains <br>where appropriate<br> • Updated all equality and type checking assertions <br>to use <code>assertThat()</code>


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-05595b081dc2c2fbd613a2e2381220d2b917e8ccc3cb944a0d8cc6376f8ff30b">+15/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnnotationAbstractPointcutAdvisorTests.java</strong><dd><code>Update AnnotationAbstractPointcutAdvisorTests with AssertJ assertions</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisorTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Updated type <br>checking and equality assertions to use fluent API<br> • Improved test <br>readability with chained assertions and descriptive methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-9c413850924f0b7cf01f8bed4be93135bb0b54dfffd7431926de911203cf1a39">+15/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClassUtilsTests.java</strong><dd><code>Convert ClassUtilsTests to use AssertJ assertion style</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test<br> • Changed exception testing from <code>assertThrows()</code> to <br><code>assertThatThrownBy().isInstanceOf().hasMessage()</code><br> • Updated all <br>equality assertions to use <code>assertThat().isEqualTo()</code>


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-2f44f0ce389a62cb258d67e2153c7a473ba126d86190f10d99506bfe9f116fb0">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserAgentAutoConfigurationTests.java</strong><dd><code>Standardize UserAgentAutoConfigurationTests to AssertJ assertions</code></dd></summary>
<hr>

spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/useragent/UserAgentAutoConfigurationTests.java

• Replaced <code>assertNotNull()</code> calls with <code>assertThat().isNotNull()</code><br> • <br>Maintained existing AssertJ usage while ensuring consistency<br> • Updated <br>field validation assertions to use AssertJ style


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-8fe6465739f30f3c420e6c2b914ead8c973292ae93c905659eb38f8669520ff8">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BeanLambdaTests.java</strong><dd><code>Convert BeanLambdaTests to AssertJ assertion style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Updated all <br><code>assertEquals()</code> calls to use <code>assertThat().isEqualTo()</code><br> • Maintained the <br>same test logic with improved assertion readability


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-874b3da8a8c43b2f7750949f09a6dcf8f0c6686b7d07035bebcdc9d29a4ac888">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedissonPropertyEditorRegistrarTests.java</strong><dd><code>Update RedissonPropertyEditorRegistrarTests with AssertJ assertions</code></dd></summary>
<hr>

spring-boot-extension-autoconfigure/src/test/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrarTests.java

• Replaced JUnit assertions with AssertJ assertions<br> • Combined null <br>checking and type checking into fluent assertion chains<br> • Added <code>@Slf4j</code> <br>annotation for logging support


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-dbea6cdddf6fbb517e0354e7db88d683d96fa03ff11bfda771344d8d7b4660e5">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RequestWrapperTests.java</strong><dd><code>Convert RequestWrapperTests to AssertJ assertion style</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Updated <br>collection assertions to use <code>containsExactly()</code> and <code>hasSize()</code><br> • <br>Improved readability with fluent assertion chains


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-b2645cb9317610acf0605e604820f51c1c3368dc6629e9ea341ac98023588b77">+11/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FileUtilsTests.java</strong><dd><code>Switch FileUtilsTests to AssertJ assertion style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/io/FileUtilsTests.java

• Replaced JUnit assertions with AssertJ assertions throughout the <br>test<br> • Updated boolean assertions to use <code>isTrue()</code> and file existence <br>checks<br> • Improved test readability with fluent assertion chains


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-b912ae3fccf9223727753efb1e13c074e15b1a7308894c6446ebb92c3cbe5107">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CuratorTemplateTests.java</strong><dd><code>Convert CuratorTemplateTests to AssertJ assertion style</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/curator/CuratorTemplateTests.java

• Migrated from JUnit assertions to AssertJ assertions<br> • Updated array <br>comparison to use <code>containsExactly()</code> for better readability<br> • Changed <br>boolean and class type assertions to use fluent API


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-27d4de22796a9d2181aa2db249fb59a564ad739819e9ad5afea36905e3a86d3f">+10/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TypeElementsTests.java</strong><dd><code>Update TypeElementsTests with AssertJ fluent assertions</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTests.java

• Replaced JUnit assertions with AssertJ assertions<br> • Updated optional <br>and collection assertions to use fluent API with lambda expressions<br> • <br>Improved test readability with chained assertions and descriptive <br>methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-5292d5a5f47850132b7048d705a67bb0d67b9e904066e4ebfe9dbe9575479b01">+12/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DateUtilsTests.java</strong><dd><code>Convert DateUtilsTests to AssertJ assertion style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/DateUtilsTests.java

• Replaced all <code>assertNotNull()</code> calls with <code>assertThat().isNotNull()</code><br> • <br>Maintained the same test logic while using consistent AssertJ <br>assertions<br> • Updated imports to use AssertJ static methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-b36123687d0f54420f0a76c2bee26200719e39f7435e07a899447ede59517c9c">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AutoImportSelectorTests.java</strong><dd><code>Switch from JUnit to AssertJ assertions for array comparison</code></dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/spring/AutoImportSelectorTests.java

• Replaced JUnit <code>assertArrayEquals</code> with AssertJ <br><code>assertThat().containsExactly()</code><br> • Updated import statement from JUnit <br>to AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-167f209f9ecb9e650f677c60f94f20f9b250b9248238655bae3f80cff0fcbdfa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpParametersTests.java</strong><dd><code>Migrate HTTP parameters test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/web/HttpParametersTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <br><code>assertThat().containsExactly()</code> and <code>isEqualTo()</code><br> • Removed unused <code>List</code> <br>import<br> • Added blank lines for better code formatting


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-0e6dcb1435f8d0e9f2a29f8974f4cd2e4685d84d94a2d4d110f362d6e2c93f43">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExcelMethodArgumentResolverTests.java</strong><dd><code>Convert Excel resolver test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/fastexcel/resolver/ExcelMethodArgumentResolverTests.java

• Replaced JUnit assertions (<code>assertTrue</code>, <code>assertInstanceOf</code>, <br><code>assertEquals</code>) with AssertJ equivalents<br> • Updated to use <code>isTrue()</code>, <br><code>isInstanceOf()</code>, and <code>hasSize()</code> methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-fdb844739ea816777fc406580aebe06982f45eacc70425fc7c1ef8bc2a18fc12">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DefaultExcelMapReadListenerTests.java</strong><dd><code>Migrate Excel listener test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/fastexcel/listener/DefaultExcelMapReadListenerTests.java

• Replaced JUnit assertions with AssertJ fluent assertions<br> • Removed <br>unused <code>Set</code> import<br> • Updated to use <code>isNotEmpty()</code>, <code>hasSize()</code>, <br><code>containsKey()</code>, and <code>isEqualTo()</code>


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-154237d9b809dc10394ab464eb2c846996534b1460c6851562a9ea90229fae55">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReactiveQrCodeMethodArgumentResolverTests.java</strong><dd><code>Convert reactive QR code resolver assertions to AssertJ</code>&nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQrCodeMethodArgumentResolverTests.java

• Replaced JUnit <code>assertNotNull</code> and <code>assertTrue</code> with AssertJ <code>isNotNull()</code> <br>and <code>isTrue()</code><br> • Updated import statements to use AssertJ


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-bbc736257f4b9a2a0a39fb90e01471059b1c613f7860ae3d572df453c5323a92">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SequenceRangeTests.java</strong><dd><code>Migrate sequence range test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/SequenceRangeTests.java

• Replaced JUnit assertions (<code>assertEquals</code>, <code>assertFalse</code>, <code>assertTrue</code>) <br>with AssertJ equivalents<br> • Updated to use <code>isFalse()</code>, <code>isEqualTo()</code>, and <br><code>isTrue()</code> methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-37979213b6add927cd5a2318f8cdea1afd02de5d95cb3625dabbb63bf26e7658">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestClientAdapterFactoryTests.java</strong><dd><code>Convert REST client adapter factory tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/http/factory/RestClientAdapterFactoryTests.java

• Replaced JUnit assertions with AssertJ fluent assertions<br> • Updated <br>to use <code>isTrue()</code>, <code>isNotNull()</code>, and <code>isEqualTo()</code> methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-508d9d723cb57b9fb0dbff58b0a6e936db3aab7157046b7daf0e803148dd28fd">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebClientAdapterFactoryTests.java</strong><dd><code>Convert web client adapter factory tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/http/factory/WebClientAdapterFactoryTests.java

• Replaced JUnit assertions with AssertJ fluent assertions<br> • Updated <br>to use <code>isTrue()</code>, <code>isNotNull()</code>, and <code>isEqualTo()</code> methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-9790d0eb61ba1a7e24395c43a2dfa5739c5339d7dfa567e7099ffdfc7d8850c7">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QrCodeMethodArgumentResolverTests.java</strong><dd><code>Migrate QR code method argument resolver tests to AssertJ</code></dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/QrCodeMethodArgumentResolverTests.java

• Replaced JUnit <code>assertEquals</code> and <code>assertTrue</code> with AssertJ <code>isEqualTo()</code> <br>and <code>isTrue()</code><br> • Updated import statements to use AssertJ


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-3ad5802483d1f2d0973c23cf3bc4d9cd6aa8644d65fc109b19d829a2806cab8a">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>YamlUtilsTests.java</strong><dd><code>Convert YAML utilities test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/YamlUtilsTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement from JUnit to AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-4734f28face2cd25968c3fb005a743c3a256cdb38475fb2e576fc2f7f4190144">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QRCodeMethodReturnValueHandlerTests.java</strong><dd><code>Migrate QR code return value handler tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/QRCodeMethodReturnValueHandlerTests.java

• Replaced JUnit assertions with AssertJ equivalents<br> • Updated to use <br><code>isTrue()</code> and <code>isEqualTo()</code> methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-e7e68d096e568b6c9a355148be626483b5a425c445b16804caff9b703cc6b495">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TreeNodeTests.java</strong><dd><code>Convert tree node test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-commons/src/test/java/com/livk/commons/util/TreeNodeTests.java

• Replaced JUnit <code>assertNotNull</code> with AssertJ <code>isNotNull()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-2aaf165ae37f9f94aca928a8a19ce087ac0cfeec590c9376ab275b5e98e2a7c6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpFactoryBeanTests.java</strong><dd><code>Migrate HTTP factory bean test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/http/factory/HttpFactoryBeanTests.java

• Replaced JUnit <code>assertNotNull</code> with AssertJ <code>isNotNull()</code><br> • Removed <br><code>throws Exception</code> from test method signature


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-452bf2d1f97b83c77123b2a4c0285d93b411c83237c49aada123fd1f60ca53ce">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SpringMapstructLocatorTests.java</strong><dd><code>Convert MapStruct locator test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/mapstruct/repository/SpringMapstructLocatorTests.java

• Replaced JUnit <code>assertNotNull</code> with AssertJ <code>isNotNull()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-018ba40be981f244374aeac0e108666827c715e8381b788eb22206de21f6761d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SqlDataInjectionTests.java</strong><dd><code>Migrate MyBatis SQL injection test assertions to AssertJ</code>&nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/mybatis/inject/SqlDataInjectionTests.java

• Replaced JUnit assertions (<code>assertEquals</code>, <code>assertNotNull</code>) with AssertJ <br>equivalents<br> • Updated to use <code>isEqualTo()</code> and <code>isNotNull()</code> methods


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-0590bd6d6c82bbdd010e4c5dd508e2215d89c31c468371ea59340de19da50b1e">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RediSearchTemplateTests.java</strong><dd><code>Convert RediSearch template test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/redisearch/RediSearchTemplateTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-98ae1ced92fdd9c45ea469c15d18a693722247590c87996c0088d6af7602a71f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StringRediSearchTemplateTests.java</strong><dd><code>Migrate string RediSearch template tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/redisearch/StringRediSearchTemplateTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-bbcfa82cb7242d812b1279531d77eed407353d7be9e67abe836517d5824922df">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QrCodeManagerTests.java</strong><dd><code>Convert QR code manager test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/qrcode/QrCodeManagerTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-fd6585c439cf5a96a64d8875ceebe333c48ced03daa6b74ef97ce55f4af0a45c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DisruptorEventWrapperTests.java</strong><dd><code>Migrate disruptor event wrapper tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/disruptor/support/DisruptorEventWrapperTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-cb324d5f21bfd32c8bb244daa70dc5a70091bae4ab4e4cc60282011fe804820c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DisruptorScanRegistrarTests.java</strong><dd><code>Convert disruptor scan registrar tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/disruptor/DisruptorScanRegistrarTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>hasSize()</code><br> • Updated import <br>statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-3535f0e024d078ec4930c48fa99a3cbf1b1ed531afff8884797a5775c4be0e91">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReactiveRedisOpsTests.java</strong><dd><code>Migrate reactive Redis operations tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/redis/ReactiveRedisOpsTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-fc191d5fe3e4f45d7c253e3db9b27b97697448435520b54ca0d34336ae85bdb7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DefaultRangeSequenceTests.java</strong><dd><code>Convert default range sequence tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/sequence/builder/DefaultRangeSequenceTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-a42e740c5ccff03269036e8bb973cbf0cf8b3b274d6e3492374d275b4a542f98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HttpServiceRegistrarTests.java</strong><dd><code>Migrate HTTP service registrar tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/http/HttpServiceRegistrarTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>hasSize()</code><br> • Updated import <br>statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-16f6af1c5d32bb44d8288f1d94be610a7d0f344119cbdb8e08d4236339ff3994">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisOpsTests.java</strong><dd><code>Convert Redis operations test assertions to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/redis/RedisOpsTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-c45607c334dd4b9d476a602d099a51452f8eb9072ac0f7d9c015b84882f9abfa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FactoryProxySupportTests.java</strong><dd><code>Migrate factory proxy support tests to AssertJ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spring-extension-context/src/test/java/com/livk/context/redisearch/FactoryProxySupportTests.java

• Replaced JUnit <code>assertEquals</code> with AssertJ <code>isEqualTo()</code><br> • Updated <br>import statement to use AssertJ assertions


</details>


  </td>
  <td><a href="https://github.com/livk-cloud/spring-boot-extension/pull/822/files#diff-6cd7a8a93c7292c7b1dda43001da379a9a1755b9850e46e7c0ccce73b1b34b22">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

