### PR TITLE
Refactor Jackson configuration and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
         run: ./gradlew build
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.java }} == '21'
+        if: ${{ matrix.java == 21 }}
         uses: codecov/codecov-action@v5.4.3
         env:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.java }} == '21'
+        if: ${{ matrix.java == 21 }}
         uses: codecov/test-results-action@v1.1.1
         env:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/samples/spring-admin/spring-admin-server/src/main/java/com/livk/admin/server/config/AdminRedisConfig.java
+++ b/samples/spring-admin/spring-admin-server/src/main/java/com/livk/admin/server/config/AdminRedisConfig.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.livk.commons.jackson.TypeFactoryUtils;
 import com.livk.context.redis.JacksonSerializerUtils;
 import com.livk.context.redis.ReactiveRedisOps;
-import de.codecentric.boot.admin.server.config.AdminServerProperties;
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.utils.jackson.AdminServerModule;
@@ -42,12 +41,9 @@ import java.util.List;
 public class AdminRedisConfig {
 
 	@Bean
-	public ReactiveRedisOps reactiveRedisOps(AdminServerProperties adminServerProperties,
+	public ReactiveRedisOps reactiveRedisOps(AdminServerModule adminJacksonModule,
 			ReactiveRedisConnectionFactory redisConnectionFactory) {
-		JsonMapper mapper = JsonMapper.builder()
-			.addModule(new AdminServerModule(adminServerProperties.getMetadataKeysToSanitize()))
-			.addModule(new JavaTimeModule())
-			.build();
+		JsonMapper mapper = JsonMapper.builder().addModule(adminJacksonModule).addModule(new JavaTimeModule()).build();
 		Jackson2JsonRedisSerializer<InstanceId> hashKeySerializer = new Jackson2JsonRedisSerializer<>(mapper,
 				InstanceId.class);
 		CollectionType collectionType = TypeFactoryUtils.listType(InstanceEvent.class);

--- a/samples/spring-admin/spring-admin-server/src/main/java/com/livk/admin/server/converter/RegistrationHttpMessageConverters.java
+++ b/samples/spring-admin/spring-admin-server/src/main/java/com/livk/admin/server/converter/RegistrationHttpMessageConverters.java
@@ -16,7 +16,6 @@
 
 package com.livk.admin.server.converter;
 
-import de.codecentric.boot.admin.server.config.AdminServerProperties;
 import de.codecentric.boot.admin.server.utils.jackson.AdminServerModule;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -29,14 +28,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class RegistrationHttpMessageConverters extends HttpMessageConverters {
 
-	public RegistrationHttpMessageConverters(AdminServerProperties adminServerProperties) {
-		super(jacksonHttpMessageConverter(adminServerProperties));
+	public RegistrationHttpMessageConverters(AdminServerModule adminJacksonModule) {
+		super(jacksonHttpMessageConverter(adminJacksonModule));
 	}
 
-	private static HttpMessageConverter<?> jacksonHttpMessageConverter(AdminServerProperties adminServerProperties) {
+	private static HttpMessageConverter<?> jacksonHttpMessageConverter(AdminServerModule adminJacksonModule) {
 		MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
-		converter.getObjectMapper()
-			.registerModule(new AdminServerModule(adminServerProperties.getMetadataKeysToSanitize()));
+		converter.getObjectMapper().registerModule(adminJacksonModule);
 		return converter;
 	}
 


### PR DESCRIPTION
```chinese
## Sourcery 总结

重构 HTTP 消息转换器和 Redis 配置，使其使用注入的 AdminServerModule 进行 Jackson 配置，并纠正 Codecov 上传的 CI 工作流条件语法

增强功能:
- 将 RegistrationHttpMessageConverters 中基于 AdminServerProperties 的模块实例化替换为注入的 AdminServerModule
- 重构 reactiveRedisOps bean，使其使用 AdminServerModule 进行 JSON 序列化配置

CI:
- 修复 GitHub Actions 中 matrix.java 条件语法，用于 Codecov 上传步骤
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor HTTP message converters and Redis configuration to use an injected AdminServerModule for Jackson setup, and correct the CI workflow condition syntax for Codecov uploads

Enhancements:
- Replace AdminServerProperties-based module instantiation with injected AdminServerModule in RegistrationHttpMessageConverters
- Refactor reactiveRedisOps bean to use AdminServerModule for JSON serialization setup

CI:
- Fix GitHub Actions matrix.java conditional syntax for Codecov upload steps

</details>