### PR TITLE
Refactor generic type resolution and enhance package scanning

### DIFF
--- a/samples/spring-authorization-server/server-commons/src/main/java/com/livk/auth/server/common/provider/OAuth2BaseAuthenticationProvider.java
+++ b/samples/spring-authorization-server/server-commons/src/main/java/com/livk/auth/server/common/provider/OAuth2BaseAuthenticationProvider.java
@@ -22,9 +22,9 @@ import com.livk.auth.server.common.token.OAuth2BaseAuthenticationToken;
 import com.livk.auth.server.common.util.MessageSourceUtils;
 import com.livk.auth.server.common.util.OAuth2AuthenticationProviderUtils;
 import com.livk.auth.server.common.util.OAuth2ErrorCodesExpand;
+import com.livk.commons.util.ClassUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.MessageSourceAccessor;
-import org.springframework.core.GenericTypeResolver;
 import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -119,9 +119,7 @@ public abstract class OAuth2BaseAuthenticationProvider<T extends OAuth2BaseAuthe
 	 */
 	@Override
 	public boolean supports(Class<?> authentication) {
-		@SuppressWarnings("unchecked")
-		Class<T> childType = (Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(),
-				OAuth2BaseAuthenticationProvider.class);
+		Class<T> childType = ClassUtils.resolveTypeArgument(this.getClass(), OAuth2BaseAuthenticationProvider.class);
 		Assert.notNull(childType, "child Type is null");
 		return childType.isAssignableFrom(authentication);
 	}

--- a/samples/spring-fastexcel/spring-fastexcel-batch/src/main/java/com/livk/excel/batch/support/FastExcelItemReader.java
+++ b/samples/spring-fastexcel/spring-fastexcel-batch/src/main/java/com/livk/excel/batch/support/FastExcelItemReader.java
@@ -17,9 +17,9 @@
 package com.livk.excel.batch.support;
 
 import cn.idev.excel.FastExcel;
+import com.livk.commons.util.ClassUtils;
 import com.livk.context.fastexcel.listener.ExcelMapReadListener;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.core.GenericTypeResolver;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -33,9 +33,7 @@ public class FastExcelItemReader<T> implements ItemReader<T> {
 	private final List<T> data;
 
 	public FastExcelItemReader(InputStream inputStream, ExcelMapReadListener<T> excelReadListener) {
-		@SuppressWarnings("unchecked")
-		Class<T> targetClass = (Class<T>) GenericTypeResolver.resolveTypeArgument(excelReadListener.getClass(),
-				ExcelMapReadListener.class);
+		Class<T> targetClass = ClassUtils.resolveTypeArgument(excelReadListener.getClass(), ExcelMapReadListener.class);
 		FastExcel.read(inputStream, targetClass, excelReadListener).sheet().doRead();
 		data = new ArrayList<>(excelReadListener.getCollectionData());
 	}

--- a/samples/spring-redis/redis-consumer/src/main/java/com/livk/redis/config/RedisConfig.java
+++ b/samples/spring-redis/redis-consumer/src/main/java/com/livk/redis/config/RedisConfig.java
@@ -16,7 +16,9 @@
 
 package com.livk.redis.config;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.livk.common.redis.domain.LivkMessage;
+import com.livk.commons.jackson.TypeFactoryUtils;
 import com.livk.context.redis.JacksonSerializerUtils;
 import com.livk.redis.listener.KeyExpiredListener;
 import lombok.extern.slf4j.Slf4j;
@@ -47,8 +49,8 @@ public class RedisConfig {
 	public ReactiveRedisMessageListenerContainer reactiveRedisMessageListenerContainer(
 			ReactiveRedisConnectionFactory connectionFactory) {
 		ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(connectionFactory);
-		@SuppressWarnings("rawtypes")
-		RedisSerializer<LivkMessage> serializer = JacksonSerializerUtils.json(LivkMessage.class);
+		JavaType javaType = TypeFactoryUtils.javaType(LivkMessage.class, Object.class);
+		RedisSerializer<LivkMessage<Object>> serializer = JacksonSerializerUtils.json(javaType);
 		container
 			.receive(List.of(PatternTopic.of(LivkMessage.CHANNEL)),
 					RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.string()),

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
@@ -17,6 +17,7 @@
 package com.livk.autoconfigure.redisson;
 
 import com.livk.commons.util.BeanUtils;
+import com.livk.commons.util.ClassUtils;
 import io.netty.channel.EventLoopGroup;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -62,10 +63,8 @@ import org.springframework.boot.context.properties.bind.PlaceholdersResolver;
 import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
-import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.util.Assert;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -504,9 +503,7 @@ public class RedissonProperties {
 		 * @return the t
 		 */
 		public T convert() {
-			@SuppressWarnings("unchecked")
-			Class<T> type = (Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(), Base.class);
-			Assert.notNull(type, "type must not be null");
+			Class<T> type = ClassUtils.resolveTypeArgument(this.getClass(), Base.class);
 			return BeanUtils.copy(this, type);
 		}
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisor.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisor.java
@@ -16,13 +16,13 @@
 
 package com.livk.commons.aop;
 
+import com.livk.commons.util.ClassUtils;
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.NonNull;
 import org.springframework.aop.IntroductionInterceptor;
 import org.springframework.aop.support.AbstractPointcutAdvisor;
-import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.Ordered;
-import org.jspecify.annotations.NonNull;
 import org.springframework.util.Assert;
 
 import java.lang.annotation.Annotation;
@@ -40,8 +40,7 @@ public abstract class AnnotationAbstractPointcutAdvisor<A extends Annotation> ex
 	/**
 	 * 切点注解类型
 	 */
-	@SuppressWarnings("unchecked")
-	protected final Class<A> annotationType = (Class<A>) GenericTypeResolver.resolveTypeArgument(this.getClass(),
+	protected final Class<A> annotationType = ClassUtils.resolveTypeArgument(this.getClass(),
 			AnnotationAbstractPointcutAdvisor.class);
 
 	@NonNull

--- a/spring-extension-commons/src/main/java/com/livk/commons/spring/AnnotationBasePackageSupport.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/spring/AnnotationBasePackageSupport.java
@@ -46,25 +46,29 @@ public class AnnotationBasePackageSupport {
 	 * @return 去重后的基础包路径数组
 	 */
 	public String[] getBasePackages(AnnotationMetadata metadata, Class<? extends Annotation> annotationClass) {
+		Set<String> packagesToScan = new LinkedHashSet<>();
 		AnnotationAttributes attributes = AnnotationUtils.attributesFor(metadata, annotationClass);
-		if (CollectionUtils.isEmpty(attributes)) {
-			return new String[0];
-		}
-		String[] basePackages = attributes.getStringArray("basePackages");
-		Set<String> packagesToScan = new LinkedHashSet<>(Arrays.asList(basePackages));
-		log.debug("Loaded basePackages from annotation: {}", packagesToScan);
-		Class<?>[] basePackageClasses = attributes.getClassArray("basePackageClasses");
-		for (Class<?> basePackageClass : basePackageClasses) {
-			if (basePackageClass != null) {
-				String packageName = ClassUtils.getPackageName(basePackageClass);
-				packagesToScan.add(packageName);
-				log.debug("Added package from basePackageClasses: {}", packageName);
+		if (!CollectionUtils.isEmpty(attributes)) {
+			if (attributes.containsKey("basePackages")) {
+				String[] basePackages = attributes.getStringArray("basePackages");
+				packagesToScan.addAll(Arrays.asList(basePackages));
+				log.debug("Loaded basePackages from annotation: {}", packagesToScan);
 			}
-		}
-		if (packagesToScan.isEmpty() && metadata != null && StringUtils.hasText(metadata.getClassName())) {
-			String defaultPackage = ClassUtils.getPackageName(metadata.getClassName());
-			packagesToScan.add(defaultPackage);
-			log.debug("Using default package: {}", defaultPackage);
+			if (attributes.containsKey("basePackageClasses")) {
+				Class<?>[] basePackageClasses = attributes.getClassArray("basePackageClasses");
+				for (Class<?> basePackageClass : basePackageClasses) {
+					if (basePackageClass != null) {
+						String packageName = ClassUtils.getPackageName(basePackageClass);
+						packagesToScan.add(packageName);
+						log.debug("Added package from basePackageClasses: {}", packageName);
+					}
+				}
+			}
+			if (packagesToScan.isEmpty() && metadata != null && StringUtils.hasText(metadata.getClassName())) {
+				String defaultPackage = ClassUtils.getPackageName(metadata.getClassName());
+				packagesToScan.add(defaultPackage);
+				log.debug("Using default package: {}", defaultPackage);
+			}
 		}
 		return StringUtils.toStringArray(packagesToScan);
 	}

--- a/spring-extension-commons/src/main/java/com/livk/commons/spring/AnnotationBeanDefinitionScanner.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/spring/AnnotationBeanDefinitionScanner.java
@@ -17,6 +17,7 @@
 package com.livk.commons.spring;
 
 import com.livk.commons.util.AnnotationUtils;
+import com.livk.commons.util.ClassUtils;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -25,14 +26,12 @@ import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
 import org.springframework.context.annotation.ScannedGenericBeanDefinition;
-import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.Assert;
 
 import java.lang.annotation.Annotation;
 import java.util.LinkedHashSet;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -40,9 +39,8 @@ import java.util.Set;
  */
 public abstract class AnnotationBeanDefinitionScanner<T extends Annotation> extends ClassPathBeanDefinitionScanner {
 
-	@SuppressWarnings("unchecked")
-	protected final Class<T> annotationClass = Objects.requireNonNull(
-			(Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(), AnnotationBeanDefinitionScanner.class));
+	protected final Class<T> annotationClass = ClassUtils.resolveTypeArgument(this.getClass(),
+			AnnotationBeanDefinitionScanner.class);
 
 	protected final BeanNameGenerator beanNameGenerator;
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/spring/SpringAbstractImportSelector.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/spring/SpringAbstractImportSelector.java
@@ -16,6 +16,7 @@
 
 package com.livk.commons.spring;
 
+import com.livk.commons.util.ClassUtils;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationImportSelector;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -23,7 +24,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.context.annotation.ImportCandidates;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DeferredImportSelector;
-import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.Assert;
@@ -53,10 +53,8 @@ public abstract class SpringAbstractImportSelector<A extends Annotation> extends
 	 */
 	private final Class<A> annotationClass;
 
-	@SuppressWarnings("unchecked")
 	protected SpringAbstractImportSelector() {
-		this.annotationClass = (Class<A>) GenericTypeResolver.resolveTypeArgument(this.getClass(),
-				SpringAbstractImportSelector.class);
+		this.annotationClass = ClassUtils.resolveTypeArgument(this.getClass(), SpringAbstractImportSelector.class);
 	}
 
 	@Override
@@ -66,7 +64,6 @@ public abstract class SpringAbstractImportSelector<A extends Annotation> extends
 
 	@Override
 	protected List<String> getCandidateConfigurations(AnnotationMetadata metadata, AnnotationAttributes attributes) {
-		Assert.notNull(annotationClass, "annotation Class not be null");
 		List<String> configurations = ImportCandidates.load(annotationClass, getBeanClassLoader()).getCandidates();
 		Assert.notEmpty(configurations,
 				"No auto configuration classes found in META-INF/spring/" + annotationClass.getName()

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/ClassUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/ClassUtils.java
@@ -17,6 +17,8 @@
 package com.livk.commons.util;
 
 import lombok.experimental.UtilityClass;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
@@ -34,6 +36,16 @@ import java.lang.reflect.WildcardType;
  */
 @UtilityClass
 public class ClassUtils extends org.springframework.util.ClassUtils {
+
+	public static <T> Class<T> resolveTypeArgument(Class<?> clazz, Class<?> genericType) {
+		ResolvableType resolvableType = ResolvableType.forClass(clazz).as(genericType);
+		if (!resolvableType.hasGenerics()) {
+			throw new IllegalArgumentException("No type arguments found on generic interface [" + resolvableType + "]");
+		}
+		Assert.isTrue(resolvableType.getGenerics().length == 1, () -> "Expected 1 type argument on generic interface ["
+				+ resolvableType + "] but found " + resolvableType.getGenerics().length);
+		return toClass(resolvableType.getGeneric().resolve());
+	}
 
 	/**
 	 * 将Type安全的转成Class

--- a/spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java
@@ -105,12 +105,13 @@ class SpringContextHolderTests {
 		});
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	void registerBean() {
 		contextRunner.run(ctx -> {
 			SpringContextHolder.registerBean(bean, "test1");
-			RootBeanDefinition beanDefinition = new RootBeanDefinition((Class<BeanTest>) bean.getClass(), () -> bean);
+			RootBeanDefinition beanDefinition = new RootBeanDefinition();
+			beanDefinition.setBeanClass(bean.getClass());
+			beanDefinition.setInstanceSupplier(() -> bean);
 			SpringContextHolder.registerBean(beanDefinition, "test2");
 			assertThat(SpringContextHolder.getBeansOfType(BeanTest.class))
 				.isEqualTo(Map.of("test1", bean, "test2", bean));

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java
@@ -24,6 +24,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +53,26 @@ class ClassUtilsTests {
 
 		assertThatThrownBy(() -> ClassUtils.toClass(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Type cannot be null");
+	}
+
+	@Test
+	void resolveTypeArgument() {
+		assertThatThrownBy(() -> ClassUtils.resolveTypeArgument(NumberWildcardType.class, WildcardType.class))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("No type arguments found on generic interface [" + WildcardType.class.getName() + "]");
+
+		assertThat(ClassUtils.resolveTypeArgument(IntGeneric.class, MyGeneric.class)).isEqualTo(Integer.class);
+
+		assertThatThrownBy(() -> ClassUtils.resolveTypeArgument(TypeMap.class, HashMap.class))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	static class TypeMap extends HashMap<String, Type> {
+
+	}
+
+	static class IntGeneric extends MyGeneric<Integer> {
+
 	}
 
 	static class NumberWildcardType implements WildcardType {

--- a/spring-extension-context/src/main/java/com/livk/context/mybatis/handler/InjectHandle.java
+++ b/spring-extension-context/src/main/java/com/livk/context/mybatis/handler/InjectHandle.java
@@ -16,7 +16,7 @@
 
 package com.livk.context.mybatis.handler;
 
-import org.springframework.core.GenericTypeResolver;
+import com.livk.commons.util.ClassUtils;
 
 /**
  * @param <T> the type parameter
@@ -34,9 +34,8 @@ public interface InjectHandle<T> {
 	 * Gets type.
 	 * @return the type
 	 */
-	@SuppressWarnings("unchecked")
 	default Class<T> getType() {
-		return (Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(), InjectHandle.class);
+		return ClassUtils.resolveTypeArgument(this.getClass(), InjectHandle.class);
 	}
 
 }


### PR DESCRIPTION
## Sourcery 总结

引入 ClassUtils.resolveTypeArgument 以实现更安全的泛型类型解析，并重构代码以使用它，增强注解包扫描行为，并更新相关测试

新功能：
- 添加 ClassUtils.resolveTypeArgument 工具，用于提取单个泛型类型参数并进行验证
- 为 resolveTypeArgument 添加单元测试，覆盖正常和错误场景

改进：
- 在多个模块中用 ClassUtils.resolveTypeArgument 替换 GenericTypeResolver.resolveTypeArgument 调用
- 优化 AnnotationBasePackageSupport.getBasePackages，以更健壮地处理属性存在和默认包
- 简化 SpringContextHolder.registerBean 测试中的 RootBeanDefinition 创建
- 使用 JacksonSerializerUtils.json 和 JavaType 进行 Redis 序列化器配置

测试：
- 在 ClassUtilsTests 中添加 resolveTypeArgument 测试，以验证泛型解析和异常路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce ClassUtils.resolveTypeArgument for safer generic type resolution and refactor code to use it, enhance annotation package scanning behavior, and update related tests

New Features:
- Add ClassUtils.resolveTypeArgument utility to extract a single generic type argument with validation
- Add unit tests for resolveTypeArgument covering normal and error scenarios

Enhancements:
- Replace GenericTypeResolver.resolveTypeArgument calls with ClassUtils.resolveTypeArgument across multiple modules
- Refine AnnotationBasePackageSupport.getBasePackages to handle attribute presence and default package more robustly
- Simplify RootBeanDefinition creation in SpringContextHolder.registerBean test
- Use JacksonSerializerUtils.json with JavaType for Redis serializer configuration

Tests:
- Add resolveTypeArgument tests in ClassUtilsTests to verify generic resolution and exception paths

</details>