### PR TITLE
ci: 添加travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+
+jdk:
+  - openjdk21
+  - openjdk24
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+script:
+  - ./gradlew build


### PR DESCRIPTION
## Sourcery 总结

添加针对 Java 项目的 Travis CI 配置

CI:
- 添加 .travis.yml 以在 openjdk21 和 openjdk24 上运行构建
- 缓存 Gradle 目录以加快构建速度
- 通过 `./gradlew build` 执行构建

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Travis CI configuration for Java project

CI:
- Add .travis.yml to run builds on openjdk21 and openjdk24
- Cache Gradle directories to speed up builds
- Execute build via ./gradlew build

</details>