### PR TITLE
ci: 添加appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: 1.0.{build}
+
+image: Ubuntu2004
+
+build:
+  verbosity: minimal
+
+environment:
+  JAVA_VERSION:
+    - 21
+    - 24
+
+cache:
+  - $HOME/.gradle/wrapper
+  - $HOME/.gradle/caches
+
+build_script:
+  - sudo service docker start
+  - docker version
+
+  - echo "Install Temurin JDK $env:JAVA_VERSION"
+  - sudo apt-get update
+  - sudo apt-get install -y wget
+  - wget https://github.com/adoptium/temurin${env:JAVA_VERSION}-binaries/releases/latest/download/OpenJDK${env:JAVA_VERSION}U-jdk_x64_linux_hotspot.tar.gz
+  - tar -xzf OpenJDK${env:JAVA_VERSION}U-jdk_x64_linux_hotspot.tar.gz
+  - export JAVA_HOME=$PWD/jdk-${env:JAVA_VERSION}*
+  - export PATH=$JAVA_HOME/bin:$PATH
+  - java -version
+  - ./gradlew build --no-daemon -Dorg.gradle.workers.max=1 -Dorg.gradle.jvmargs="-Xmx2g -XX:+UseG1GC -Dfile.encoding=UTF-8"


### PR DESCRIPTION
## Sourcery 总结

CI:
- 配置 AppVeyor CI，使用 Java 21 和 24 矩阵、Gradle 缓存、Docker 启动、Temurin JDK 安装以及 Gradle 构建脚本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Configure AppVeyor CI with a Java 21 and 24 matrix, Gradle caching, Docker startup, Temurin JDK installation, and Gradle build script

</details>