### PR TITLE
Refactor service processor and unify resource I/O

### DIFF
--- a/buildSrc/src/main/java/com/livk/boot/maven/MavenPortalPublishPlugin.kt
+++ b/buildSrc/src/main/java/com/livk/boot/maven/MavenPortalPublishPlugin.kt
@@ -22,12 +22,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 /**
- * <p>
- * MavenPortalPublishPlugin
- * </p>
- *
  * @author livk
- * @date 2025/4/28
  */
 abstract class MavenPortalPublishPlugin : Plugin<Project> {
 

--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/AotFactoriesProcessor.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/AotFactoriesProcessor.java
@@ -28,8 +28,6 @@ import java.lang.annotation.Annotation;
 @AutoService(Processor.class)
 public class AotFactoriesProcessor extends AbstractFactoriesProcessor {
 
-	private static final Class<AotFactories> SUPPORT_CLASS = AotFactories.class;
-
 	static final String AOT_LOCATION = "META-INF/spring/aot.factories";
 
 	public AotFactoriesProcessor() {
@@ -38,7 +36,7 @@ public class AotFactoriesProcessor extends AbstractFactoriesProcessor {
 
 	@Override
 	protected Class<? extends Annotation> getSupportedAnnotation() {
-		return SUPPORT_CLASS;
+		return AotFactories.class;
 	}
 
 }

--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/SpringFactoriesProcessor.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/SpringFactoriesProcessor.java
@@ -28,8 +28,6 @@ import java.lang.annotation.Annotation;
 @AutoService(Processor.class)
 public class SpringFactoriesProcessor extends AbstractFactoriesProcessor {
 
-	private static final Class<SpringFactories> SUPPORT_CLASS = SpringFactories.class;
-
 	static final String SPRING_LOCATION = "META-INF/spring.factories";
 
 	public SpringFactoriesProcessor() {
@@ -38,7 +36,7 @@ public class SpringFactoriesProcessor extends AbstractFactoriesProcessor {
 
 	@Override
 	protected Class<? extends Annotation> getSupportedAnnotation() {
-		return SUPPORT_CLASS;
+		return SpringFactories.class;
 	}
 
 }

--- a/spring-extension-context/src/test/java/com/livk/context/storage/StorageOperationsTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/storage/StorageOperationsTests.java
@@ -44,12 +44,7 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * <p>
- * StorageOperationsTests
- * </p>
- *
  * @author livk
- * @date 2025/8/11
  */
 @SpringJUnitConfig(StorageOperationsTests.Config.class)
 @Testcontainers(disabledWithoutDocker = true, parallel = true)

--- a/spring-extension-context/src/test/java/com/livk/context/storage/StorageTemplateTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/storage/StorageTemplateTests.java
@@ -46,12 +46,7 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * <p>
- * StorageTemplateTests
- * </p>
- *
  * @author livk
- * @date 2025/8/11
  */
 @SpringJUnitConfig(StorageTemplateTests.Config.class)
 @Testcontainers(disabledWithoutDocker = true, parallel = true)


### PR DESCRIPTION
```markdown
## Sourcery 总结

通过在 CustomizeAbstractProcessor 中用一个共享的 processorMap 替换每个处理器独立的存储映射来集中和简化服务处理器逻辑，统一资源读写方法，重命名配置字段，移除废弃的存储方法和静态字段，并引入对资源操作的可选调试日志支持。

改进：
- 在 CustomizeAbstractProcessor 中用一个共享的 processorMap 替换单独的 importsMap 和 factoriesMap 字段
- 引入 readFromResource 和 统一的 writeFile 方法，以简化配置文件 I/O 并替换旧的读写逻辑
- 将 "out" 字段重命名为 resourcesPath，并移除抽象存储方法，转而直接填充 processorMap
- 为资源操作添加调试模式日志输出，并在读取失败时发出警告
- 移除 AotFactoriesProcessor 和 SpringFactoriesProcessor 中冗余的 SUPPORT_CLASS 常量，并清理构建插件注释

杂项：
- 在 spring-extension-context 测试中删除未使用的 StorageOperationsTests 和 StorageTemplateTests 存根
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and simplify service processor logic by replacing per-processor storage maps with a shared processorMap in CustomizeAbstractProcessor, unify resource reading and writing methods, rename configuration fields, remove obsolete storage methods and static fields, and introduce optional debug logging support for resource operations.

Enhancements:
- Replace individual importsMap and factoriesMap fields with a shared processorMap in CustomizeAbstractProcessor
- Introduce readFromResource and unified writeFile methods to streamline config file I/O and replace old read/write logic
- Rename "out" field to resourcesPath and remove abstract storage method in favor of directly populating processorMap
- Add debug-mode log output for resource operations and warnings on read failures
- Remove redundant SUPPORT_CLASS constants in AotFactoriesProcessor and SpringFactoriesProcessor and clean up build plugin comments

Chores:
- Eliminate unused StorageOperationsTests and StorageTemplateTests stubs in spring-extension-context tests

</details>