### PR TITLE
Refactor FastExcelSupport, enhance template loading, and adjust handlers

### DIFF
--- a/spring-extension-context/src/main/java/com/livk/context/fastexcel/resolver/ExcelMethodReturnValueHandler.java
+++ b/spring-extension-context/src/main/java/com/livk/context/fastexcel/resolver/ExcelMethodReturnValueHandler.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /**
  * @author livk
  */
-public class ExcelMethodReturnValueHandler implements AsyncHandlerMethodReturnValueHandler {
+public class ExcelMethodReturnValueHandler extends FastExcelSupport implements AsyncHandlerMethodReturnValueHandler {
 
 	/**
 	 * The constant UTF8.
@@ -71,7 +71,7 @@ public class ExcelMethodReturnValueHandler implements AsyncHandlerMethodReturnVa
 			try (ServletServerHttpResponse httpResponse = new ServletServerHttpResponse(response)) {
 				if (returnValue instanceof Collection) {
 					Class<?> excelModelClass = ResolvableType.forMethodParameter(returnType).resolveGeneric(0);
-					FastExcelSupport.write(httpResponse.getBody(), excelModelClass, responseExcel.template(),
+					super.write(httpResponse.getBody(), excelModelClass, responseExcel.template(),
 							Map.of("sheet", (Collection<?>) returnValue));
 				}
 				else if (returnValue instanceof Map) {
@@ -80,7 +80,7 @@ public class ExcelMethodReturnValueHandler implements AsyncHandlerMethodReturnVa
 					Class<?> excelModelClass = ResolvableType.forMethodParameter(returnType)
 						.getGeneric(1)
 						.resolveGeneric(0);
-					FastExcelSupport.write(httpResponse.getBody(), excelModelClass, responseExcel.template(), result);
+					super.write(httpResponse.getBody(), excelModelClass, responseExcel.template(), result);
 				}
 			}
 		}

--- a/spring-extension-context/src/main/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodReturnValueHandler.java
+++ b/spring-extension-context/src/main/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodReturnValueHandler.java
@@ -144,7 +144,7 @@ public class ReactiveExcelMethodReturnValueHandler extends FastExcelSupport impl
 		else {
 			type = elementType.resolve();
 		}
-		return Collection.class.isAssignableFrom(type) || Map.class.isAssignableFrom(type);
+		return type != null && (Collection.class.isAssignableFrom(type) || Map.class.isAssignableFrom(type));
 	}
 
 }

--- a/spring-extension-context/src/main/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodReturnValueHandler.java
+++ b/spring-extension-context/src/main/java/com/livk/context/fastexcel/resolver/ReactiveExcelMethodReturnValueHandler.java
@@ -50,7 +50,7 @@ import java.util.function.Function;
 /**
  * @author livk
  */
-public class ReactiveExcelMethodReturnValueHandler implements HandlerResultHandler, Ordered {
+public class ReactiveExcelMethodReturnValueHandler extends FastExcelSupport implements HandlerResultHandler, Ordered {
 
 	/**
 	 * The constant EXCEL_MEDIA_TYPE.
@@ -110,7 +110,7 @@ public class ReactiveExcelMethodReturnValueHandler implements HandlerResultHandl
 			Mono<Map<String, Collection<?>>> result) {
 		return result.flatMap(r -> {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			FastExcelSupport.write(outputStream, excelModelClass, excelReturn.template(), r);
+			super.write(outputStream, excelModelClass, excelReturn.template(), r);
 			Flux<DataBuffer> bufferFlux = DataBufferUtils.transform(outputStream.toByteArray());
 			return message.writeWith(bufferFlux);
 		});

--- a/spring-extension-context/src/test/java/com/livk/context/fastexcel/FastExcelSupportTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/fastexcel/FastExcelSupportTests.java
@@ -32,12 +32,13 @@ class FastExcelSupportTests {
 
 	@Test
 	void write() {
+		CustomFastExcelSupport support = new CustomFastExcelSupport();
 		Map<String, List<Info>> data = Map.of("0", List.of(new Info("123456789"), new Info("987654321")));
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
 		assertThat(stream.toByteArray()).isEmpty();
 
-		FastExcelSupport.write(stream, Info.class, null, data);
+		support.write(stream, Info.class, null, data);
 
 		assertThat(stream.toByteArray()).isNotEmpty();
 	}
@@ -53,6 +54,10 @@ class FastExcelSupportTests {
 
 	@ResponseExcel(fileName = "outFile", suffix = ResponseExcel.Suffix.XLS)
 	void fileNameResponse() {
+
+	}
+
+	static class CustomFastExcelSupport extends FastExcelSupport {
 
 	}
 


### PR DESCRIPTION
## Sourcery 总结

将 FastExcelSupport 重构为抽象类，通过 Resource 改进模板加载，提取工作表处理器类，调整处理器以继承写入逻辑，并在响应式处理器中添加空值检查。

Bug 修复:
- 在 ReactiveExcelMethodReturnValueHandler.canWrite 中添加空值检查以防止 NullPointerException
- 拓宽模板加载时的异常处理范围以捕获 IOException

增强功能:
- 将 FastExcelSupport 从静态工具类转换为带有受保护写入方法的抽象类
- 通过 Resource InputStreams 而非 Files 加载 Excel 模板
- 将 TemplateSheetWriteHandler 提取到其自己的私有类中用于工作表命名
- 更新 ExcelMethodReturnValueHandler 和 ReactiveExcelMethodReturnValueHandler 以继承 FastExcelSupport 并使用实例方法

测试:
- 更新测试以使用 CustomFastExcelSupport 子类进行写入调用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor FastExcelSupport to an abstract class, improve template loading via Resource, extract sheet handler class, adjust handlers to inherit write logic, and add null check in reactive handler.

Bug Fixes:
- Add null check in ReactiveExcelMethodReturnValueHandler.canWrite to prevent NullPointerException
- Broaden exception handling when loading templates to catch IOException

Enhancements:
- Convert FastExcelSupport from a static utility to an abstract class with protected write methods
- Load Excel templates via Resource InputStreams instead of Files
- Extract TemplateSheetWriteHandler into its own private class for sheet naming
- Update ExcelMethodReturnValueHandler and ReactiveExcelMethodReturnValueHandler to extend FastExcelSupport and use instance methods

Tests:
- Update tests to use a CustomFastExcelSupport subclass for write invocation

</details>