### PR TITLE
Update CircleCI image, switch to Adoptium Temurin, and upgrade JDK 23 to 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - run: |
           sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https
-          wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
-          echo "deb https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+          sudo apt-get install -y wget gnupg apt-transport-https
+          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
+            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
+          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
+            sudo tee /etc/apt/sources.list.d/adoptium.list
           sudo apt-get update
           sudo apt-get install -y temurin-21-jdk
       - checkout
@@ -28,9 +30,11 @@ jobs:
     steps:
       - run: |
           sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https
-          wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
-          echo "deb https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+          sudo apt-get install -y wget gnupg apt-transport-https
+          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
+            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
+          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
+            sudo tee /etc/apt/sources.list.d/adoptium.list
           sudo apt-get update
           sudo apt-get install -y temurin-24-jdk
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       JVM_OPTS: -Xmx3200m
       TERM: dumb
     machine:
-      image: ubuntu-2404:2024.11.1
+      image: ubuntu-2404:2025.09.1
       docker_layer_caching: true
     resource_class: arm.large
 
@@ -14,15 +14,25 @@ jobs:
   jdk21:
     executor: ubuntu
     steps:
-      - run: sudo apt-get update
-      - run: sudo apt install openjdk-21-jdk
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y wget apt-transport-https
+          wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+          echo "deb https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+          sudo apt-get update
+          sudo apt-get install -y temurin-21-jdk
       - checkout
       - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
-  jdk23:
+  jdk24:
     executor: ubuntu
     steps:
-      - run: sudo apt-get update
-      - run: sudo apt install openjdk-23-jdk
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y wget apt-transport-https
+          wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+          echo "deb https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+          sudo apt-get update
+          sudo apt-get install -y temurin-24-jdk
       - checkout
       - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
 
@@ -30,4 +40,4 @@ workflows:
   gradle-build:
     jobs:
       - jdk21
-      - jdk23
+      - jdk24


### PR DESCRIPTION
## Sourcery 总结

更新 CircleCI 配置以使用最新的 Ubuntu 机器镜像，将 JDK 安装切换到 Adoptium Temurin 包，并将次要的 JDK 任务从版本 23 提升到 24。

改进:
- 将 CircleCI 机器镜像提升到 ubuntu-2404:2025.09.1
- 将 OpenJDK apt 安装替换为 Adoptium Temurin 仓库，并安装 temurin-21 和 temurin-24 JDK
- 将 CI 任务从 jdk23 重命名为 jdk24，并相应地更新工作流

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CircleCI config to use the latest Ubuntu machine image, switch JDK installs to Adoptium Temurin packages, and bump the secondary JDK job from version 23 to 24

Enhancements:
- Bump CircleCI machine image to ubuntu-2404:2025.09.1
- Replace OpenJDK apt installs with Adoptium Temurin repositories and install temurin-21 and temurin-24 JDKs
- Rename CI job from jdk23 to jdk24 and update workflow accordingly

</details>