### PR TITLE
Upgrade CI to Temurin JDK 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y temurin-21-jdk
       - checkout
       - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
-  jdk24:
+  jdk25:
     executor: ubuntu
     steps:
       - run: |
@@ -36,7 +36,7 @@ jobs:
           echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
             sudo tee /etc/apt/sources.list.d/adoptium.list
           sudo apt-get update
-          sudo apt-get install -y temurin-24-jdk
+          sudo apt-get install -y temurin-25-jdk
       - checkout
       - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
 
@@ -44,4 +44,4 @@ workflows:
   gradle-build:
     jobs:
       - jdk21
-      - jdk24
+      - jdk25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java: [ 21 ,24 ]
+        java: [ 21 ,25 ]
 
     name: JDK ${{ matrix.java }}
 


### PR DESCRIPTION
## Sourcery 总结

升级 CI 流水线以使用 Temurin JDK 25

CI:
- 更新 CircleCI 作业以安装 temurin-25-jdk，并将作业从 jdk24 重命名为 jdk25
- 更新 GitHub Actions 工作流以在构建矩阵中包含 Java 25，而不是 Java 24

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade CI pipelines to use Temurin JDK 25

CI:
- Update CircleCI job to install temurin-25-jdk and rename the job from jdk24 to jdk25
- Update GitHub Actions workflow to include Java 25 in the build matrix instead of Java 24

</details>