### PR TITLE
Simplify Redisson auto-config: use @NestedConfigurationProperty and refactor mixins

### DIFF
--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonProperties.java
@@ -16,49 +16,17 @@
 
 package com.livk.autoconfigure.redisson;
 
-import com.livk.commons.util.BeanUtils;
-import com.livk.commons.util.ClassUtils;
-import io.netty.channel.EventLoopGroup;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import org.redisson.api.NameMapper;
-import org.redisson.api.NatMapper;
-import org.redisson.client.DefaultCredentialsResolver;
-import org.redisson.client.FailedConnectionDetector;
-import org.redisson.client.FailedNodeDetector;
-import org.redisson.client.NettyHook;
-import org.redisson.client.codec.Codec;
-import org.redisson.config.BaseConfig;
-import org.redisson.config.BaseMasterSlaveServersConfig;
 import org.redisson.config.ClusterServersConfig;
-import org.redisson.config.CommandMapper;
 import org.redisson.config.Config;
-import org.redisson.config.CredentialsResolver;
-import org.redisson.config.DelayStrategy;
-import org.redisson.config.EqualJitterDelay;
 import org.redisson.config.MasterSlaveServersConfig;
-import org.redisson.config.Protocol;
-import org.redisson.config.ReadMode;
 import org.redisson.config.ReplicatedServersConfig;
 import org.redisson.config.SentinelServersConfig;
-import org.redisson.config.ShardedSubscriptionMode;
 import org.redisson.config.SingleServerConfig;
-import org.redisson.config.SslProvider;
-import org.redisson.config.SslVerificationMode;
-import org.redisson.config.SubscriptionMode;
-import org.redisson.config.TransportMode;
-import org.redisson.config.ValkeyCapability;
-import org.redisson.connection.AddressResolverGroupFactory;
-import org.redisson.connection.ConnectionListener;
-import org.redisson.connection.balancer.LoadBalancer;
-import org.redisson.connection.balancer.RoundRobinLoadBalancer;
 import org.springframework.beans.PropertyEditorRegistry;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.boot.context.properties.bind.ConstructorBinding;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.context.properties.bind.PlaceholdersResolver;
 import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
@@ -66,15 +34,6 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.TrustManagerFactory;
-import java.net.URL;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 /**
@@ -91,7 +50,7 @@ public class RedissonProperties {
 	 */
 	public static final String PREFIX = "spring.redisson";
 
-	private RedissonConfig config;
+	private RedissonConfig config = new RedissonConfig();
 
 	public static RedissonProperties load(ConfigurableEnvironment environment) {
 		Iterable<ConfigurationPropertySource> sources = ConfigurationPropertySources.get(environment);
@@ -103,408 +62,71 @@ public class RedissonProperties {
 		return binder.bind(RedissonProperties.PREFIX, RedissonProperties.class).orElse(new RedissonProperties());
 	}
 
-	/**
-	 * The type Redisson config.
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	@NoArgsConstructor
 	public static class RedissonConfig extends Config {
 
-		/**
-		 * Instantiates a new Redisson config.
-		 */
-		@ConstructorBinding
-		public RedissonConfig(SentinelServers sentinelServersConfig, MasterSlaveServers masterSlaveServersConfig,
-				SingleServer singleServerConfig, ClusterServers clusterServersConfig,
-				ReplicatedServers replicatedServersConfig, @DefaultValue("16") Integer threads,
-				@DefaultValue("32") Integer nettyThreads, Executor nettyExecutor, Codec codec, ExecutorService executor,
-				@DefaultValue("true") Boolean referenceEnabled, @DefaultValue("NIO") TransportMode transportMode,
-				EventLoopGroup eventLoopGroup, @DefaultValue("30000") Long lockWatchdogTimeout,
-				@DefaultValue("100") Integer lockWatchdogBatchSize, @DefaultValue("300000") Integer fairLockWaitTimeout,
-				@DefaultValue("true") Boolean checkLockSyncedSlaves, @DefaultValue("1000") Long slavesSyncTimeout,
-				@DefaultValue("600000") Long reliableTopicWatchdogTimeout,
-				@DefaultValue("true") Boolean keepPubSubOrder, @DefaultValue("true") Boolean useScriptCache,
-				@DefaultValue("5") Integer minCleanUpDelay, @DefaultValue("1800") Integer maxCleanUpDelay,
-				@DefaultValue("100") Integer cleanUpKeysAmount,
-				@DefaultValue("!<org.redisson.client.DefaultNettyHook> {}") NettyHook nettyHook,
-				ConnectionListener connectionListener, @DefaultValue("true") Boolean useThreadClassLoader,
-				@DefaultValue("!<org.redisson.connection.SequentialDnsAddressResolverFactory> {}") AddressResolverGroupFactory addressResolverGroupFactory,
-				Boolean lazyInitialization, @DefaultValue("RESP2") Protocol protocol,
-				Set<ValkeyCapability> valkeyCapabilities) {
-			PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
-
-			mapper.from(sentinelServersConfig).as(Base::convert).to(this::setSentinelServersConfig);
-			mapper.from(masterSlaveServersConfig).as(Base::convert).to(this::setMasterSlaveServersConfig);
-			mapper.from(singleServerConfig).as(Base::convert).to(this::setSingleServerConfig);
-			mapper.from(clusterServersConfig).as(Base::convert).to(this::setClusterServersConfig);
-			mapper.from(replicatedServersConfig).as(Base::convert).to(this::setReplicatedServersConfig);
-			setThreads(threads);
-			setNettyThreads(nettyThreads);
-			mapper.from(nettyExecutor).to(this::setNettyExecutor);
-			mapper.from(codec).to(this::setCodec);
-			mapper.from(executor).to(this::setExecutor);
-			setReferenceEnabled(referenceEnabled);
-			setTransportMode(transportMode);
-			mapper.from(eventLoopGroup).to(this::setEventLoopGroup);
-			setLockWatchdogTimeout(lockWatchdogTimeout);
-			setLockWatchdogBatchSize(lockWatchdogBatchSize);
-			setFairLockWaitTimeout(fairLockWaitTimeout);
-			setCheckLockSyncedSlaves(checkLockSyncedSlaves);
-			setSlavesSyncTimeout(slavesSyncTimeout);
-			setReliableTopicWatchdogTimeout(reliableTopicWatchdogTimeout);
-			setKeepPubSubOrder(keepPubSubOrder);
-			setUseScriptCache(useScriptCache);
-			setMinCleanUpDelay(minCleanUpDelay);
-			setMaxCleanUpDelay(maxCleanUpDelay);
-			setCleanUpKeysAmount(cleanUpKeysAmount);
-			setNettyHook(nettyHook);
-			mapper.from(connectionListener).to(this::setConnectionListener);
-			setUseThreadClassLoader(useThreadClassLoader);
-			setAddressResolverGroupFactory(addressResolverGroupFactory);
-			mapper.from(lazyInitialization).to(this::setLazyInitialization);
-			setProtocol(protocol);
-			mapper.from(valkeyCapabilities).to(this::setValkeyCapabilities);
+		@Override
+		@NestedConfigurationProperty
+		public void setSingleServerConfig(SingleServerConfig singleServerConfig) {
+			super.setSingleServerConfig(singleServerConfig);
 		}
 
-	}
-
-	/**
-	 * The type Cluster servers.
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	public static class ClusterServers extends BaseMasterSlaveServers<ClusterServersConfig> {
-
-		private NatMapper natMapper = NatMapper.direct();
-
-		/**
-		 * Redis cluster node urls list
-		 */
-
-		private List<String> nodeAddresses = new ArrayList<>();
-
-		/**
-		 * Redis cluster scan interval in milliseconds
-		 */
-
-		private int scanInterval = 5000;
-
-		private boolean checkSlotsCoverage = true;
-
-		private ShardedSubscriptionMode shardedSubscriptionMode = ShardedSubscriptionMode.AUTO;
-
-	}
-
-	/**
-	 * The type Master slave servers.
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	public static class MasterSlaveServers extends BaseMasterSlaveServers<MasterSlaveServersConfig> {
-
-		private NatMapper natMapper = NatMapper.direct();
-
-		/**
-		 * Redis cluster node urls list
-		 */
-
-		private List<String> nodeAddresses = new ArrayList<>();
-
-		/**
-		 * Redis cluster scan interval in milliseconds
-		 */
-
-		private int scanInterval = 5000;
-
-	}
-
-	/**
-	 * The type Replicated servers.
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	public static class ReplicatedServers extends BaseMasterSlaveServers<ReplicatedServersConfig> {
-
-		/**
-		 * Replication group node urls list
-		 */
-
-		private List<String> nodeAddresses = new ArrayList<>();
-
-		/**
-		 * Replication group scan interval in milliseconds
-		 */
-
-		private int scanInterval = 1000;
-
-		/**
-		 * Database index used for Redis connection
-		 */
-
-		private int database = 0;
-
-		private boolean monitorIPChanges = false;
-
-	}
-
-	/**
-	 * The type Sentinel servers.
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	public static class SentinelServers extends BaseMasterSlaveServers<SentinelServersConfig> {
-
-		private List<String> sentinelAddresses = new ArrayList<>();
-
-		private NatMapper natMapper = NatMapper.direct();
-
-		private String masterName;
-
-		private String sentinelUsername;
-
-		private String sentinelPassword;
-
-		/**
-		 * Database index used for Redis connection
-		 */
-
-		private int database = 0;
-
-		/**
-		 * Sentinel scan interval in milliseconds
-		 */
-
-		private int scanInterval = 1000;
-
-		private boolean checkSentinelsList = true;
-
-		private boolean checkSlaveStatusWithSyncing = true;
-
-		private boolean sentinelsDiscovery = true;
-
-	}
-
-	/**
-	 * The type Single server.
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	public static class SingleServer extends Base<SingleServerConfig> {
-
-		/**
-		 * Redis server address
-		 */
-
-		private String address;
-
-		/**
-		 * Minimum idle subscription connection amount
-		 */
-
-		private int subscriptionConnectionMinimumIdleSize = 1;
-
-		/**
-		 * Redis subscription connection maximum pool size
-		 */
-
-		private int subscriptionConnectionPoolSize = 50;
-
-		/**
-		 * Minimum idle Redis connection amount
-		 */
-
-		private int connectionMinimumIdleSize = 24;
-
-		/**
-		 * Redis connection maximum pool size
-		 */
-
-		private int connectionPoolSize = 64;
-
-		/**
-		 * Database index used for Redis connection
-		 */
-
-		private int database = 0;
-
-		/**
-		 * Interval in milliseconds to check DNS
-		 */
-
-		private long dnsMonitoringInterval = 5000;
-
-	}
-
-	/**
-	 * The type Base master slave servers.
-	 *
-	 * @param <T> the type parameter
-	 */
-	@EqualsAndHashCode(callSuper = true)
-	@Data
-	public abstract static class BaseMasterSlaveServers<T extends BaseMasterSlaveServersConfig<T>> extends Base<T> {
-
-		private LoadBalancer loadBalancer = new RoundRobinLoadBalancer();
-
-		/**
-		 * Redis 'slave' node minimum idle connection amount for <b>each</b> slave node
-		 */
-
-		private int slaveConnectionMinimumIdleSize = 24;
-
-		/**
-		 * Redis 'slave' node maximum connection pool size for <b>each</b> slave node
-		 */
-
-		private int slaveConnectionPoolSize = 64;
-
-		private int failedSlaveReconnectionInterval = 3000;
-
-		/**
-		 * Redis 'master' node minimum idle connection amount for <b>each</b> slave node
-		 */
-
-		private int masterConnectionMinimumIdleSize = 24;
-
-		/**
-		 * Redis 'master' node maximum connection pool size
-		 */
-
-		private int masterConnectionPoolSize = 64;
-
-		private ReadMode readMode = ReadMode.SLAVE;
-
-		private SubscriptionMode subscriptionMode = SubscriptionMode.MASTER;
-
-		/**
-		 * Redis 'slave' node minimum idle subscription (pub/sub) connection amount for
-		 * <b>each</b> slave node
-		 */
-
-		private int subscriptionConnectionMinimumIdleSize = 1;
-
-		/**
-		 * Redis 'slave' node maximum subscription (pub/sub) connection pool size for
-		 * <b>each</b> slave node
-		 */
-
-		private int subscriptionConnectionPoolSize = 50;
-
-		private long dnsMonitoringInterval = 5000;
-
-		private FailedNodeDetector failedSlaveNodeDetector = new FailedConnectionDetector();
-
-	}
-
-	/**
-	 * The type Base.
-	 *
-	 * @param <T> the type parameter
-	 */
-	@Data
-	public abstract static class Base<T extends BaseConfig<T>> {
-
-		/**
-		 * If pooled connection not used for a <code>timeout</code> time and current
-		 * connections amount bigger than minimum idle connections pool size, then it will
-		 * close and removed from pool. Value in milliseconds.
-		 */
-
-		private int idleConnectionTimeout = 10000;
-
-		/**
-		 * Timeout during connecting to any Redis server. Value in milliseconds.
-		 */
-
-		private int connectTimeout = 10000;
-
-		/**
-		 * Redis server response timeout. Starts to countdown when Redis command was
-		 * successfully sent. Value in milliseconds.
-		 */
-
-		private int timeout = 3000;
-
-		private int subscriptionTimeout = 7500;
-
-		private int retryAttempts = 4;
-
-		private DelayStrategy retryDelay = new EqualJitterDelay(Duration.ofMillis(1000), Duration.ofSeconds(2));
-
-		private DelayStrategy reconnectionDelay = new EqualJitterDelay(Duration.ofMillis(100), Duration.ofSeconds(10));
-
-		/**
-		 * Password for Redis authentication. Should be null if not needed
-		 */
-
-		private String password;
-
-		private String username;
-
-		private CredentialsResolver credentialsResolver = new DefaultCredentialsResolver();
-
-		private int credentialsReapplyInterval = 0;
-
-		/**
-		 * Subscriptions per Redis connection limit
-		 */
-
-		private int subscriptionsPerConnection = 5;
-
-		/**
-		 * Name of client connection
-		 */
-
-		private String clientName;
-
-		private SslVerificationMode sslVerificationMode = SslVerificationMode.STRICT;
-
-		private String sslKeystoreType;
-
-		private SslProvider sslProvider = SslProvider.JDK;
-
-		private URL sslTruststore;
-
-		private String sslTruststorePassword;
-
-		private URL sslKeystore;
-
-		private String sslKeystorePassword;
-
-		private String[] sslProtocols;
-
-		private String[] sslCiphers;
-
-		private TrustManagerFactory sslTrustManagerFactory;
-
-		private KeyManagerFactory sslKeyManagerFactory;
-
-		private int pingConnectionInterval = 30000;
-
-		private boolean keepAlive;
-
-		private int tcpKeepAliveCount;
-
-		private int tcpKeepAliveIdle;
-
-		private int tcpKeepAliveInterval;
-
-		private int tcpUserTimeout;
-
-		private boolean tcpNoDelay = true;
-
-		private NameMapper nameMapper = NameMapper.direct();
-
-		private CommandMapper commandMapper = CommandMapper.direct();
-
-		/**
-		 * Convert t.
-		 * @return the t
-		 */
-		public T convert() {
-			Class<T> type = ClassUtils.resolveTypeArgument(this.getClass(), Base.class);
-			return BeanUtils.copy(this, type);
+		@Override
+		@NestedConfigurationProperty
+		public void setMasterSlaveServersConfig(MasterSlaveServersConfig masterSlaveServersConfig) {
+			super.setMasterSlaveServersConfig(masterSlaveServersConfig);
+		}
+
+		@Override
+		@NestedConfigurationProperty
+		public void setClusterServersConfig(ClusterServersConfig clusterServersConfig) {
+			super.setClusterServersConfig(clusterServersConfig);
+		}
+
+		@Override
+		@NestedConfigurationProperty
+		public void setReplicatedServersConfig(ReplicatedServersConfig replicatedServersConfig) {
+			super.setReplicatedServersConfig(replicatedServersConfig);
+		}
+
+		@Override
+		@NestedConfigurationProperty
+		public void setSentinelServersConfig(SentinelServersConfig sentinelServersConfig) {
+			super.setSentinelServersConfig(sentinelServersConfig);
+		}
+
+		@Override
+		@NestedConfigurationProperty
+
+		public SingleServerConfig getSingleServerConfig() {
+			return super.getSingleServerConfig();
+		}
+
+		@Override
+		@NestedConfigurationProperty
+
+		public MasterSlaveServersConfig getMasterSlaveServersConfig() {
+			return super.getMasterSlaveServersConfig();
+		}
+
+		@Override
+		@NestedConfigurationProperty
+
+		public ClusterServersConfig getClusterServersConfig() {
+			return super.getClusterServersConfig();
+		}
+
+		@Override
+		@NestedConfigurationProperty
+
+		public ReplicatedServersConfig getReplicatedServersConfig() {
+			return super.getReplicatedServersConfig();
+		}
+
+		@Override
+		@NestedConfigurationProperty
+
+		public SentinelServersConfig getSentinelServersConfig() {
+			return super.getSentinelServersConfig();
 		}
 
 	}


### PR DESCRIPTION
## Sourcery 摘要

通过默认初始化配置对象、使用 Spring Boot 的 `@NestedConfigurationProperty` setter 方法替换自定义的嵌套配置类，以及简化属性编辑器注册器中的 JSON mixin 定义，来简化 Redisson 的自动配置。

增强功能：
- 使用默认实例初始化 RedissonConfig 字段，以避免在绑定时进行空值检查
- 为 RedissonProperties.RedissonConfig 中的服务器配置 setter 方法添加 `@NestedConfigurationProperty` 注解，并移除冗余的嵌套配置类
- 将 RedissonPropertyEditorRegistrar 中冗长的 mixin 映射替换为简洁的内部 mixin 类，并相应地更新 JSON 注解

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify Redisson auto-configuration by default-initializing the config object, replacing custom nested config classes with Spring Boot's @NestedConfigurationProperty setters, and streamlining JSON mixin definitions in the property editor registrar.

Enhancements:
- Initialize RedissonConfig field with a default instance to avoid null checks during binding
- Annotate server config setters in RedissonProperties.RedissonConfig with @NestedConfigurationProperty and remove redundant nested config classes
- Replace verbose mixin mappings in RedissonPropertyEditorRegistrar with concise inner mixin classes and update JSON annotations accordingly

</details>