### PR TITLE
feat: checkstyle升级调整

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,10 @@ configure(module) {
 	afterEvaluate {
 		dependencies {
 			compileOnly(libs.spotbugs.annotations)
+			checkstyle(libs.spring.javaformat.checkstyle) {
+				exclude(group = "com.puppycrawl.tools", module = "checkstyle")
+			}
+			checkstyle(libs.checkstyle)
 		}
 	}
 }

--- a/buildSrc/src/main/groovy/com/livk/boot/CorePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/livk/boot/CorePlugin.groovy
@@ -23,6 +23,9 @@ import com.livk.boot.info.ManifestPlugin
 import com.livk.boot.tasks.DeleteExpand
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.quality.CheckstyleExtension
+import org.gradle.api.plugins.quality.CheckstylePlugin
 
 /**
  * @author livk
@@ -36,6 +39,19 @@ class CorePlugin implements Plugin<Project> {
 		project.pluginManager.apply(OptionalPlugin)
 		project.pluginManager.apply(AptCompilePlugin)
 		project.pluginManager.apply(ManifestPlugin)
+		project.pluginManager.apply(CheckstylePlugin)
+
+		project.extensions.getByType(CheckstyleExtension).with {
+			def checkstyleVersion = project.rootProject
+				.extensions
+				.getByType(VersionCatalogsExtension)
+				.named('libs')
+				.findVersion('checkstyle')
+				.get()
+				.displayName
+			toolVersion = checkstyleVersion
+			configFile = new File("${project.rootDir.path}/src/checkstyle/checkstyle.xml")
+		}
 	}
 }
 

--- a/buildSrc/src/main/groovy/com/livk/boot/ModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/livk/boot/ModulePlugin.groovy
@@ -21,11 +21,7 @@ import com.livk.boot.info.ExtractResources
 import io.spring.javaformat.gradle.SpringJavaFormatPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.quality.CheckstyleExtension
-import org.gradle.api.plugins.quality.CheckstylePlugin
 import org.gradle.api.tasks.bundling.Jar
-
 /**
  * @author livk
  */
@@ -36,22 +32,6 @@ class ModulePlugin implements Plugin<Project> {
 		project.pluginManager.apply(CompileArgsPlugin)
 		project.pluginManager.apply(CorePlugin)
 		project.pluginManager.apply(SpringJavaFormatPlugin)
-		project.pluginManager.apply(CheckstylePlugin)
-
-		project.extensions.getByType(CheckstyleExtension).with {
-			toolVersion = '9.3'
-			configFile = new File("${project.rootDir.path}/src/checkstyle/checkstyle.xml")
-		}
-
-		def version = project.rootProject
-			.extensions
-			.getByType(VersionCatalogsExtension)
-			.named('libs')
-			.findVersion('spring-javaformat')
-			.get()
-			.displayName
-
-		project.dependencies.add('checkstyle', "io.spring.javaformat:spring-javaformat-checkstyle:${version}")
 
 		project.tasks.register('checkstyle') { checkstyle ->
 			checkstyle.group = 'other'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ spring-javaformat = "0.0.47"
 okhttp = "5.3.1"
 spotbugs-annotations = "4.9.8"
 maven-publish-plugins = "0.35.0"
+checkstyle = "12.1.2"
 
 [libraries]
 okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp" }
@@ -65,6 +66,8 @@ mvel2 = { group = "org.mvel", name = "mvel2", version.ref = "mvel2" }
 disruptor = { group = "com.lmax", name = "disruptor", version.ref = "disruptor" }
 spring-asciidoctor = { group = "io.spring.asciidoctor.backends", name = "spring-asciidoctor-backends", version.ref = "spring-asciidoctor" }
 spotbugs-annotations = { group = "com.github.spotbugs", name = "spotbugs-annotations", version.ref = "spotbugs-annotations" }
+spring-javaformat-checkstyle = { group = "io.spring.javaformat", name = "spring-javaformat-checkstyle", version.ref = "spring-javaformat" }
+checkstyle = { group = "com.puppycrawl.tools", name = "checkstyle", version.ref = "checkstyle" }
 
 #plugin
 spring-boot-plugin = { group = "org.springframework.boot", name = "spring-boot-gradle-plugin", version.ref = "spring-boot" }

--- a/spring-auto-service/src/main/java/com/livk/auto/service/processor/TypeElements.java
+++ b/spring-auto-service/src/main/java/com/livk/auto/service/processor/TypeElements.java
@@ -87,7 +87,8 @@ class TypeElements {
 		throw new IllegalArgumentException(element + " not has annotation:" + targetClass);
 	}
 
-	private static class SimpleAnnotationValueVisitor extends SimpleAnnotationValueVisitor14<Set<TypeElement>, Void> {
+	private static final class SimpleAnnotationValueVisitor
+			extends SimpleAnnotationValueVisitor14<Set<TypeElement>, Void> {
 
 		@Override
 		public Set<TypeElement> visitType(TypeMirror t, Void v) {

--- a/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrar.java
+++ b/spring-boot-extension-autoconfigure/src/main/java/com/livk/autoconfigure/redisson/RedissonPropertyEditorRegistrar.java
@@ -113,7 +113,7 @@ final class RedissonPropertyEditorRegistrar implements PropertyEditorRegistrar {
 	}
 
 	@RequiredArgsConstructor
-	private static class RedissonTypePropertyEditor extends PropertyEditorSupport {
+	private static final class RedissonTypePropertyEditor extends PropertyEditorSupport {
 
 		private final Class<?> type;
 
@@ -125,22 +125,22 @@ final class RedissonPropertyEditorRegistrar implements PropertyEditorRegistrar {
 	}
 
 	@JsonIgnoreType
-	private static class IgnoreMixIn {
+	private static final class IgnoreMixIn {
 
 	}
 
 	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 	@JsonFilter("classFilter")
-	public static class ClassMixIn {
+	public static final class ClassMixIn {
 
 	}
 
 	@JsonIgnoreProperties({ "slaveNotUsed" })
-	private static class ConfigPropsMixIn {
+	private static final class ConfigPropsMixIn {
 
 	}
 
-	private static class DelayMixin {
+	private static final class DelayMixin {
 
 		@JsonCreator
 		DelayMixin(@JsonProperty("baseDelay") Duration baseDelay, @JsonProperty("maxDelay") Duration maxDelay) {
@@ -149,7 +149,7 @@ final class RedissonPropertyEditorRegistrar implements PropertyEditorRegistrar {
 	}
 
 	@JsonIgnoreProperties({ "clusterConfig", "sentinelConfig", "singleConfig" })
-	private static class ConfigMixIn {
+	private static final class ConfigMixIn {
 
 		@JsonProperty
 		SentinelServersConfig sentinelServersConfig;

--- a/spring-extension-commons/src/main/java/com/livk/commons/SpringContextHolder.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/SpringContextHolder.java
@@ -257,7 +257,7 @@ public class SpringContextHolder implements BeanFactoryAware, ApplicationContext
 		SpringContextHolder.IOC.clear();
 	}
 
-	private static class SpringIoC implements GenericWrapper<ApplicationContext> {
+	private static final class SpringIoC implements GenericWrapper<ApplicationContext> {
 
 		private volatile ApplicationContext context;
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/expression/Context.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/expression/Context.java
@@ -61,7 +61,7 @@ public sealed interface Context permits Context.ContextImpl {
 
 	Map<String, Object> asMap();
 
-	non-sealed class ContextImpl implements Context {
+	final class ContextImpl implements Context {
 
 		private final Map<String, Object> variables;
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/http/support/OkHttpClientHttpRequest.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/http/support/OkHttpClientHttpRequest.java
@@ -110,7 +110,7 @@ class OkHttpClientHttpRequest extends AbstractClientHttpRequest implements Strea
 	}
 
 	@RequiredArgsConstructor
-	private static class BodyRequestBody extends RequestBody {
+	private static final class BodyRequestBody extends RequestBody {
 
 		private final HttpHeaders headers;
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/web/ResponseWrapper.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/web/ResponseWrapper.java
@@ -143,7 +143,7 @@ public class ResponseWrapper extends HttpServletResponseWrapper {
 	}
 
 	@RequiredArgsConstructor
-	private static class WrapperOutputStream extends ServletOutputStream {
+	private static final class WrapperOutputStream extends ServletOutputStream {
 
 		private final ByteArrayOutputStream outputStream;
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java
@@ -63,7 +63,7 @@ class NumberJsonSerializerTests {
 	}
 
 	@Getter
-	private static class Big {
+	private static final class Big {
 
 		@NumberJsonFormat(pattern = "0000")
 		private long l;

--- a/spring-extension-context/src/main/java/com/livk/context/curator/lock/ZkLockType.java
+++ b/spring-extension-context/src/main/java/com/livk/context/curator/lock/ZkLockType.java
@@ -60,7 +60,7 @@ public enum ZkLockType implements LockProcess {
 		return new InterProcessMultiLock(locks);
 	}
 
-	private static class ReentrantLockProcess implements LockProcess {
+	private static final class ReentrantLockProcess implements LockProcess {
 
 		@Override
 		public InterProcessLock getLock(CuratorFramework framework, String path) {
@@ -69,7 +69,7 @@ public enum ZkLockType implements LockProcess {
 
 	}
 
-	private static class NonReentrantLockProcess implements LockProcess {
+	private static final class NonReentrantLockProcess implements LockProcess {
 
 		@Override
 		public InterProcessLock getLock(CuratorFramework framework, String path) {
@@ -78,7 +78,7 @@ public enum ZkLockType implements LockProcess {
 
 	}
 
-	private static class ReadLockProcess implements LockProcess {
+	private static final class ReadLockProcess implements LockProcess {
 
 		@Override
 		public InterProcessLock getLock(CuratorFramework framework, String path) {
@@ -87,7 +87,7 @@ public enum ZkLockType implements LockProcess {
 
 	}
 
-	private static class WriteLockProcess implements LockProcess {
+	private static final class WriteLockProcess implements LockProcess {
 
 		@Override
 		public InterProcessLock getLock(CuratorFramework framework, String path) {

--- a/spring-extension-context/src/main/java/com/livk/context/disruptor/factory/DisruptorFactoryBean.java
+++ b/spring-extension-context/src/main/java/com/livk/context/disruptor/factory/DisruptorFactoryBean.java
@@ -131,7 +131,7 @@ public class DisruptorFactoryBean<T>
 		disruptor.shutdown();
 	}
 
-	private static class SpringEventFactory<T> implements EventFactory<DisruptorEventWrapper<T>> {
+	private static final class SpringEventFactory<T> implements EventFactory<DisruptorEventWrapper<T>> {
 
 		public DisruptorEventWrapper<T> newInstance() {
 			return new DisruptorEventWrapper<>();
@@ -168,7 +168,7 @@ public class DisruptorFactoryBean<T>
 	}
 
 	@RequiredArgsConstructor
-	private static class VirtualThreadFactory implements ThreadFactory {
+	private static final class VirtualThreadFactory implements ThreadFactory {
 
 		private final ThreadFactory delegate;
 

--- a/spring-extension-context/src/main/java/com/livk/context/fastexcel/FastExcelSupport.java
+++ b/spring-extension-context/src/main/java/com/livk/context/fastexcel/FastExcelSupport.java
@@ -118,7 +118,7 @@ public abstract class FastExcelSupport {
 	}
 
 	@RequiredArgsConstructor
-	private static class TemplateSheetWriteHandler implements SheetWriteHandler {
+	private static final class TemplateSheetWriteHandler implements SheetWriteHandler {
 
 		private final Integer sheetIndex;
 

--- a/spring-extension-context/src/main/java/com/livk/context/mapstruct/AbstractMapstructService.java
+++ b/spring-extension-context/src/main/java/com/livk/context/mapstruct/AbstractMapstructService.java
@@ -75,7 +75,7 @@ abstract class AbstractMapstructService implements MapstructService, MapstructRe
 		mapstructLocators.orderedStream().filter(MATCH.negate()).forEach(mapstructLocator::add);
 	}
 
-	private static class PrioritizedMapstructLocator implements MapstructLocator {
+	private static final class PrioritizedMapstructLocator implements MapstructLocator {
 
 		private final List<MapstructLocator> mapstructLocators = new ArrayList<>();
 

--- a/spring-extension-context/src/main/java/com/livk/context/redisearch/FactoryProxySupport.java
+++ b/spring-extension-context/src/main/java/com/livk/context/redisearch/FactoryProxySupport.java
@@ -81,7 +81,7 @@ final class FactoryProxySupport {
 		}
 	}
 
-	private static class ConnectWithCodecInterceptor {
+	private static final class ConnectWithCodecInterceptor {
 
 		@SuppressWarnings({ "unchecked", "unused" })
 		@RuntimeType
@@ -93,7 +93,7 @@ final class FactoryProxySupport {
 
 	}
 
-	private static class CloseInterceptor {
+	private static final class CloseInterceptor {
 
 		@SuppressWarnings("unused")
 		@RuntimeType

--- a/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQRCodeMethodReturnValueHandlerTests.java
+++ b/spring-extension-context/src/test/java/com/livk/context/qrcode/resolver/ReactiveQRCodeMethodReturnValueHandlerTests.java
@@ -72,7 +72,7 @@ class ReactiveQRCodeMethodReturnValueHandlerTests {
 	}
 
 	@RestController
-	private static class TestController {
+	private static final class TestController {
 
 		@ResponseQrCode
 		String qrcode() {


### PR DESCRIPTION
## Sourcery 摘要

将 Checkstyle 集成升级并集中到 12.1.2 版本，简化构建配置，并对内部类强制使用 static final。

增强:
- 将 CheckstylePlugin 的应用和配置整合到 CorePlugin 中，移除 ModulePlugin 中冗余的设置
- 在版本目录中添加 checkstyle 和 spring-javaformat-checkstyle 条目，并将它们作为依赖项包含在 build.gradle.kts 中
- 重构多个模块中的内部辅助类，使其明确地为 static final 以保持一致性

构建:
- 通过版本目录将 Checkstyle 工具版本升级到 12.1.2
- 在模块构建脚本中包含 spring-javaformat-checkstyle 和 Checkstyle 依赖项，并排除重复的传递性工件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade and centralize Checkstyle integration to version 12.1.2, streamline build configuration, and enforce static final on inner classes

Enhancements:
- Consolidate CheckstylePlugin application and configuration into CorePlugin, removing redundant setup from ModulePlugin
- Add checkstyle and spring-javaformat-checkstyle entries in version catalogs and include them as dependencies in build.gradle.kts
- Refactor numerous inner helper classes across modules to be explicitly static final for consistency

Build:
- Upgrade Checkstyle tool version to 12.1.2 via version catalogs
- Include spring-javaformat-checkstyle and Checkstyle dependencies in module build script, excluding duplicate transitive artifacts

</details>