### PR TITLE
Refine Redis search proxy and commons utilities for caching and validation

### DIFF
--- a/spring-extension-commons/src/main/java/com/livk/commons/util/BeanLambdaDescriptor.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/BeanLambdaDescriptor.java
@@ -17,7 +17,6 @@
 package com.livk.commons.util;
 
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.springframework.util.Assert;
 
 import java.beans.PropertyDescriptor;
@@ -35,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Getter
 final class BeanLambdaDescriptor {
 
-	private static final Map<Method, BeanLambdaDescriptor> cache = new ConcurrentHashMap<>(128);
+	private static final Map<String, BeanLambdaDescriptor> cache = new ConcurrentHashMap<>(128);
 
 	private final Method method;
 
@@ -60,16 +59,29 @@ final class BeanLambdaDescriptor {
 	 * @param function beanLambdaFunc表达式
 	 * @return beanLambdaDescriptor
 	 */
-	@SneakyThrows
 	public static <T> BeanLambdaDescriptor create(BeanLambda<T> function) {
-		Method writeReplace = function.getClass().getDeclaredMethod("writeReplace");
-		writeReplace.setAccessible(true);
-		SerializedLambda serializedLambda = (SerializedLambda) writeReplace.invoke(function);
+		SerializedLambda serializedLambda = resolveSerializedLambda(function);
+		String key = serializedLambda.getImplClass() + "#" + serializedLambda.getImplMethodName();
+		return cache.computeIfAbsent(key, k -> doCreate(serializedLambda));
+	}
+
+	private static SerializedLambda resolveSerializedLambda(BeanLambda<?> function) {
+		try {
+			Method writeReplace = function.getClass().getDeclaredMethod("writeReplace");
+			writeReplace.setAccessible(true);
+			return (SerializedLambda) writeReplace.invoke(function);
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException("Failed to resolve lambda: " + function, ex);
+		}
+	}
+
+	private static BeanLambdaDescriptor doCreate(SerializedLambda serializedLambda) {
 		String className = ClassUtils.convertResourcePathToClassName(serializedLambda.getImplClass());
 		Class<?> type = ClassUtils.resolveClassName(className, ClassUtils.getDefaultClassLoader());
 		Method method = ReflectionUtils.findMethod(type, serializedLambda.getImplMethodName());
-		Assert.notNull(method, "method must not be null");
-		return cache.computeIfAbsent(method, BeanLambdaDescriptor::new);
+		Assert.notNull(method, "Cannot find method: " + serializedLambda.getImplMethodName() + " on " + className);
+		return new BeanLambdaDescriptor(method);
 	}
 
 	public String getFieldName() {

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/HttpServletUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/HttpServletUtils.java
@@ -136,7 +136,7 @@ public class HttpServletUtils {
 			String headerIp = request.getHeader(header);
 			if (headerIp != null && !headerIp.isBlank() && !"unknown".equalsIgnoreCase(headerIp)) {
 				// 处理多IP的情况（只取第一个IP）
-				Splitter.on(",").splitToList(headerIp).getFirst();
+				return Splitter.on(",").splitToList(headerIp).getFirst();
 			}
 		}
 		return request.getRemoteAddr();

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/SnowflakeIdGenerator.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/SnowflakeIdGenerator.java
@@ -65,9 +65,9 @@ public class SnowflakeIdGenerator {
 	 * @param machineId 机器 ID
 	 */
 	public SnowflakeIdGenerator(long dataCenterId, long machineId) {
-		Assert.isTrue(dataCenterId <= MAX_DATA_CENTER_ID && dataCenterId > 0,
+		Assert.isTrue(dataCenterId <= MAX_DATA_CENTER_ID && dataCenterId >= 0,
 				"DataCenter ID exceeds range: 0-" + MAX_DATA_CENTER_ID);
-		Assert.isTrue(machineId <= MAX_MACHINE_ID & machineId > 0, "Machine ID exceeds range: 0-" + MAX_MACHINE_ID);
+		Assert.isTrue(machineId <= MAX_MACHINE_ID && machineId >= 0, "Machine ID exceeds range: 0-" + MAX_MACHINE_ID);
 		this.dataCenterId = dataCenterId;
 		this.machineId = machineId;
 	}

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/TreeNode.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/TreeNode.java
@@ -26,6 +26,8 @@ import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -89,10 +91,17 @@ public class TreeNode<I, T> {
 	 * @param nodes treeNode List
 	 */
 	public void setChildren(List<TreeNode<I, T>> nodes) {
-		List<TreeNode<I, T>> treeNodeList = nodes.stream().filter(node -> id.equals(node.pid)).toList();
-		if (!CollectionUtils.isEmpty(treeNodeList)) {
-			children = new ArrayList<>(treeNodeList);
-			children.forEach(child -> child.setChildren(nodes));
+		Map<I, List<TreeNode<I, T>>> grouped = nodes.stream()
+			.filter(n -> n.pid != null)
+			.collect(Collectors.groupingBy(n -> n.pid));
+		setChildrenFromMap(grouped);
+	}
+
+	private void setChildrenFromMap(Map<I, List<TreeNode<I, T>>> grouped) {
+		List<TreeNode<I, T>> childList = grouped.get(this.id);
+		if (childList != null && !childList.isEmpty()) {
+			this.children = new ArrayList<>(childList);
+			this.children.forEach(child -> child.setChildrenFromMap(grouped));
 		}
 	}
 

--- a/spring-extension-context/spring-extension-redisearch/src/main/java/com/livk/context/redisearch/FactoryProxySupport.java
+++ b/spring-extension-context/spring-extension-redisearch/src/main/java/com/livk/context/redisearch/FactoryProxySupport.java
@@ -33,6 +33,7 @@ import net.bytebuddy.implementation.bind.annotation.FieldValue;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.matcher.ElementMatchers;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
@@ -43,18 +44,48 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 final class FactoryProxySupport {
 
-	private static final Map<Class<? extends AbstractRedisClient>, Class<? extends RediSearchConnectionFactory>> FACTORY_CACHE = new ConcurrentHashMap<>();
+	private static final Map<Class<? extends AbstractRedisClient>, Constructor<? extends RediSearchConnectionFactory>> CONSTRUCTOR_CACHE = new ConcurrentHashMap<>();
+
+	private static final Map<Class<?>, Method> CONNECT_METHOD_CACHE = new ConcurrentHashMap<>();
+
+	private static final Constructor<Object> OBJECT_CONSTRUCTOR;
+
+	static {
+		try {
+			OBJECT_CONSTRUCTOR = Object.class.getConstructor();
+		}
+		catch (NoSuchMethodException ex) {
+			throw new ExceptionInInitializerError(ex);
+		}
+	}
 
 	@SuppressWarnings("unchecked")
 	public static <T extends AbstractRedisClient, S extends RediSearchConnectionFactory> S newProxy(T client) {
 		Class<T> clientType = (Class<T>) client.getClass();
-		Class<S> type = (Class<S>) FACTORY_CACHE.computeIfAbsent(clientType, FactoryProxySupport::createFactoryClass);
+		Constructor<S> constructor = (Constructor<S>) CONSTRUCTOR_CACHE.computeIfAbsent(clientType,
+				FactoryProxySupport::createFactoryAndCacheConstructor);
 		try {
-			return type.getConstructor(clientType).newInstance(client);
+			return constructor.newInstance(client);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException(ex);
 		}
+	}
+
+	private static Constructor<? extends RediSearchConnectionFactory> createFactoryAndCacheConstructor(
+			Class<? extends AbstractRedisClient> clientType) {
+		Class<? extends RediSearchConnectionFactory> factoryClass = createFactoryClass(clientType);
+		try {
+			return factoryClass.getConstructor(clientType);
+		}
+		catch (NoSuchMethodException ex) {
+			throw new IllegalArgumentException(ex);
+		}
+	}
+
+	static Method resolveConnectMethod(Class<?> clientType) {
+		return CONNECT_METHOD_CACHE.computeIfAbsent(clientType,
+				type -> ClassUtils.getMethod(type, "connect", RedisCodec.class));
 	}
 
 	private static <S extends RediSearchConnectionFactory> Class<? extends S> createFactoryClass(
@@ -66,8 +97,7 @@ final class FactoryProxySupport {
 			.defineField("client", clientType, Modifier.PRIVATE | Modifier.FINAL)
 			.defineConstructor(Modifier.PUBLIC)
 			.withParameters(clientType)
-			.intercept(MethodCall.invoke(Object.class.getConstructor())
-				.andThen(FieldAccessor.ofField("client").setsArgumentAt(0)))
+			.intercept(MethodCall.invoke(OBJECT_CONSTRUCTOR).andThen(FieldAccessor.ofField("client").setsArgumentAt(0)))
 			.method(ElementMatchers.named("connect").and(ElementMatchers.takesArguments(1)))
 			.intercept(MethodDelegation.to(ConnectWithCodecInterceptor.class))
 			.method(ElementMatchers.named("close"))
@@ -75,9 +105,6 @@ final class FactoryProxySupport {
 			.make()) {
 			return unloaded.load(ClassUtils.getDefaultClassLoader(), ClassLoadingStrategy.Default.INJECTION)
 				.getLoaded();
-		}
-		catch (NoSuchMethodException ex) {
-			throw new IllegalArgumentException(ex);
 		}
 	}
 
@@ -87,7 +114,7 @@ final class FactoryProxySupport {
 		@RuntimeType
 		public static <K, V> StatefulRedisModulesConnection<K, V> connect(@FieldValue("client") Object client,
 				@Argument(0) RedisCodec<K, V> codec) {
-			Method connect = ClassUtils.getMethod(client.getClass(), "connect", RedisCodec.class);
+			Method connect = resolveConnectMethod(client.getClass());
 			return (StatefulRedisModulesConnection<K, V>) ReflectionUtils.invokeMethod(connect, client, codec);
 		}
 


### PR DESCRIPTION
## Summary by Sourcery

优化工具类和代理支持类，在 Redis 搜索、lambda、树结构、ID 生成、HTTP 和流式辅助类中提升缓存效率、方法解析能力以及数据校验能力。

增强内容：
- 在创建代理时，改为缓存 Redis 搜索工厂的构造函数和连接方法，而不是整个类，以减少反射开销。
- 通过以 lambda 实现签名作为键进行缓存，并改进序列化 lambda 解析时的错误处理，优化 Bean lambda 描述符缓存机制。
- 重构树节点子节点构建逻辑，通过按父节点 ID 对节点分组，从而更高效地组装层级结构。
- 在 Snowflake ID 生成器中允许数据中心 ID 和机器 ID 取 0，并修正相关校验逻辑。
- 修复 HTTP 实际 IP 解析逻辑，对多值头部时返回第一个 IP。
- 在按键去重的流式工具中使用非并发 Map，以简化单线程谓词场景下的状态跟踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine utility and proxy support classes to improve caching efficiency, method resolution, and data validation across Redis search, lambda, tree, ID generation, HTTP, and stream helpers.

Enhancements:
- Cache Redis search factory constructors and connect methods instead of classes to reduce reflection overhead during proxy creation.
- Optimize bean lambda descriptor caching by keying on lambda implementation signatures and improving error handling when resolving serialized lambdas.
- Refactor tree node children construction to group nodes by parent ID for more efficient hierarchical assembly.
- Allow zero-valued data center and machine IDs in the Snowflake ID generator and correct the validation logic.
- Fix HTTP real IP resolution to return the first IP from multi-value headers.
- Use a non-concurrent map in the distinct-by-key stream utility to simplify state tracking within a single-threaded predicate context.

</details>