### PR TITLE
Add JDK 26 CI coverage in CircleCI and GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,53 +10,43 @@ executors:
       docker_layer_caching: true
     resource_class: arm.large
 
+commands:
+  install-jdk:
+    parameters:
+      version:
+        type: string
+    steps:
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg apt-transport-https
+          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
+            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
+          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
+            sudo tee /etc/apt/sources.list.d/adoptium.list
+          sudo apt-get update
+          sudo apt-get install -y temurin-<< parameters.version >>-jdk
+
 jobs:
-  jdk21:
+  build:
     executor: ubuntu
+    parameters:
+      jdk:
+        type: string
     steps:
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y wget gnupg apt-transport-https
-          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
-            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
-          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
-            sudo tee /etc/apt/sources.list.d/adoptium.list
-          sudo apt-get update
-          sudo apt-get install -y temurin-21-jdk
       - checkout
-      - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
-  jdk25:
-    executor: ubuntu
-    steps:
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y wget gnupg apt-transport-https
-          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
-            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
-          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
-            sudo tee /etc/apt/sources.list.d/adoptium.list
-          sudo apt-get update
-          sudo apt-get install -y temurin-25-jdk
-      - checkout
-      - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
-  jdk26:
-    executor: ubuntu
-    steps:
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y wget gnupg apt-transport-https
-          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
-            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
-          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
-            sudo tee /etc/apt/sources.list.d/adoptium.list
-          sudo apt-get update
-          sudo apt-get install -y temurin-26-jdk
-      - checkout
+      - install-jdk:
+          version: << parameters.jdk >>
       - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
 
 workflows:
   gradle-build:
     jobs:
-      - jdk21
-      - jdk25
-      - jdk26
+      - build:
+          name: jdk21
+          jdk: "21"
+      - build:
+          name: jdk25
+          jdk: "25"
+      - build:
+          name: jdk26
+          jdk: "26"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,24 @@ jobs:
           sudo apt-get install -y temurin-25-jdk
       - checkout
       - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
+  jdk26:
+    executor: ubuntu
+    steps:
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg apt-transport-https
+          wget -O- https://packages.adoptium.net/artifactory/api/gpg/key/public | \
+            sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
+          echo "deb [signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -sc) main" | \
+            sudo tee /etc/apt/sources.list.d/adoptium.list
+          sudo apt-get update
+          sudo apt-get install -y temurin-26-jdk
+      - checkout
+      - run: ./gradlew build --no-daemon -Dorg.gradle.workers.max=2
 
 workflows:
   gradle-build:
     jobs:
       - jdk21
       - jdk25
+      - jdk26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java: [ 21 ,25 ]
+        java: [ 21 ,25 ,26 ]
 
     name: JDK ${{ matrix.java }}
 


### PR DESCRIPTION
## Summary by Sourcery

为各个 CI 提供商添加使用 JDK 26 进行构建和测试的持续集成覆盖。

CI：
- 新增一个 CircleCI 任务，使用 Temurin JDK 26 构建项目。
- 扩展 GitHub Actions 的 Java 矩阵，在现有版本之外增加使用 JDK 26 运行 CI。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add continuous integration coverage for building and testing with JDK 26 across CI providers.

CI:
- Add a new CircleCI job to build the project using Temurin JDK 26.
- Extend the GitHub Actions Java matrix to run CI with JDK 26 alongside existing versions.

</details>