### PR TITLE
refactor: optimize spring-extension-commons tests and fix realIp bug

### DIFF
--- a/spring-extension-commons/src/main/java/com/livk/commons/util/HttpServletUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/HttpServletUtils.java
@@ -136,7 +136,7 @@ public class HttpServletUtils {
 			String headerIp = request.getHeader(header);
 			if (headerIp != null && !headerIp.isBlank() && !"unknown".equalsIgnoreCase(headerIp)) {
 				// 处理多IP的情况（只取第一个IP）
-				return Splitter.on(",").splitToList(headerIp).getFirst();
+				return Splitter.on(",").trimResults().splitToList(headerIp).getFirst();
 			}
 		}
 		return request.getRemoteAddr();

--- a/spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/SpringContextHolderTests.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.ResolvableType;
 
 import java.util.Map;
@@ -38,42 +37,34 @@ class SpringContextHolderTests {
 		.withPropertyValues("spring.data.redis.host=livk.com")
 		.withBean(SpringContextHolder.class, SpringContextHolder::new);
 
-	final BeanTest bean = new BeanTest();
-
 	@Test
 	void getBean() {
 		contextRunner.run(ctx -> {
+			BeanTest bean = new BeanTest();
 			SpringContextHolder.registerBean(bean, "test");
 			assertThat(SpringContextHolder.<BeanTest>getBean("test")).isSameAs(bean);
 			assertThat(SpringContextHolder.getBean(BeanTest.class)).isSameAs(bean);
 			assertThat(SpringContextHolder.getBean("test", BeanTest.class)).isSameAs(bean);
-			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
-				context.removeBeanDefinition("test");
-			}
 		});
 	}
 
 	@Test
 	void getBeanProvider() {
 		contextRunner.run(ctx -> {
+			BeanTest bean = new BeanTest();
 			SpringContextHolder.registerBean(bean, "test");
 			ResolvableType resolvableType = ResolvableType.forClass(BeanTest.class);
 			assertThat(SpringContextHolder.getBeanProvider(BeanTest.class).getIfAvailable()).isSameAs(bean);
 			assertThat(SpringContextHolder.getBeanProvider(resolvableType).getIfAvailable()).isSameAs(bean);
-			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
-				context.removeBeanDefinition("test");
-			}
 		});
 	}
 
 	@Test
 	void getBeansOfType() {
 		contextRunner.run(ctx -> {
+			BeanTest bean = new BeanTest();
 			SpringContextHolder.registerBean(bean, "test");
 			assertThat(SpringContextHolder.getBeansOfType(BeanTest.class)).isEqualTo(Map.of("test", bean));
-			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
-				context.removeBeanDefinition("test");
-			}
 		});
 	}
 
@@ -108,6 +99,7 @@ class SpringContextHolderTests {
 	@Test
 	void registerBean() {
 		contextRunner.run(ctx -> {
+			BeanTest bean = new BeanTest();
 			SpringContextHolder.registerBean(bean, "test1");
 			RootBeanDefinition beanDefinition = new RootBeanDefinition();
 			beanDefinition.setBeanClass(bean.getClass());
@@ -115,10 +107,6 @@ class SpringContextHolderTests {
 			SpringContextHolder.registerBean(beanDefinition, "test2");
 			assertThat(SpringContextHolder.getBeansOfType(BeanTest.class))
 				.isEqualTo(Map.of("test1", bean, "test2", bean));
-			if (SpringContextHolder.fetch() instanceof GenericApplicationContext context) {
-				context.removeBeanDefinition("test1");
-				context.removeBeanDefinition("test2");
-			}
 		});
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/annotation/AnnotationBasePackageSupportTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/annotation/AnnotationBasePackageSupportTests.java
@@ -36,24 +36,80 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AnnotationBasePackageSupportTests {
 
+	static final String CURRENT_PACKAGE = AnnotationBasePackageSupportTests.class.getPackageName();
+
 	final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withUserConfiguration(Config.class);
 
 	@Test
-	void getBasePackages() {
+	void getBasePackagesFromBasePackageClasses() {
 		AnnotationMetadata metadata = AnnotationMetadata.introspect(Config.class);
 		String[] basePackages = AnnotationBasePackageSupport.getBasePackages(metadata, AnnotationScan.class);
-		assertThat(basePackages).containsExactly(AnnotationBasePackageSupportTests.class.getPackageName());
+		assertThat(basePackages).containsExactly(CURRENT_PACKAGE);
+	}
 
+	@Test
+	void getBasePackagesFromBasePackagesAttribute() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(ExplicitPackageConfig.class);
+		String[] basePackages = AnnotationBasePackageSupport.getBasePackages(metadata, AnnotationScan.class);
+		assertThat(basePackages).containsExactly("com.livk.custom");
+	}
+
+	@Test
+	void getBasePackagesFallsBackToDeclaringClassPackage() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(EmptyAnnotationConfig.class);
+		String[] basePackages = AnnotationBasePackageSupport.getBasePackages(metadata, AnnotationScan.class);
+		assertThat(basePackages).containsExactly(CURRENT_PACKAGE);
+	}
+
+	@Test
+	void getBasePackagesMergesBothAttributes() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(CombinedConfig.class);
+		String[] basePackages = AnnotationBasePackageSupport.getBasePackages(metadata, AnnotationScan.class);
+		assertThat(basePackages).containsExactlyInAnyOrder("com.livk.explicit", CURRENT_PACKAGE);
+	}
+
+	@Test
+	void getBasePackagesFromBeanFactory() {
 		contextRunner.run(context -> {
 			String[] packages = AnnotationBasePackageSupport.getBasePackages(context);
-			assertThat(packages).containsExactly(AnnotationBasePackageSupportTests.class.getPackageName());
+			assertThat(packages).containsExactly(CURRENT_PACKAGE);
 		});
+	}
+
+	@Test
+	void getBasePackagesFromBeanFactoryWithoutAutoConfigurationReturnsEmpty() {
+		new ApplicationContextRunner().run(context -> {
+			String[] packages = AnnotationBasePackageSupport.getBasePackages(context);
+			assertThat(packages).isEmpty();
+		});
+	}
+
+	@Test
+	void getBasePackagesWithUnrelatedAnnotationReturnsEmpty() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(Config.class);
+		String[] basePackages = AnnotationBasePackageSupport.getBasePackages(metadata, Override.class);
+		assertThat(basePackages).isEmpty();
 	}
 
 	@TestConfiguration
 	@AnnotationScan(basePackageClasses = Config.class)
 	@AutoConfigurationPackage
 	static class Config {
+
+	}
+
+	@AnnotationScan(basePackages = "com.livk.custom")
+	static class ExplicitPackageConfig {
+
+	}
+
+	@AnnotationScan
+	static class EmptyAnnotationConfig {
+
+	}
+
+	@AnnotationScan(basePackages = "com.livk.explicit", basePackageClasses = CombinedConfig.class)
+	static class CombinedConfig {
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/annotation/AnnotationBeanDefinitionScannerTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/annotation/AnnotationBeanDefinitionScannerTests.java
@@ -20,8 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
-import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
+import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.core.annotation.AnnotationAttributes;
 
 import java.lang.annotation.ElementType;
@@ -36,12 +37,65 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AnnotationBeanDefinitionScannerTests {
 
+	static final String CURRENT_PACKAGE = AnnotationBeanDefinitionScannerTests.class.getPackageName();
+
 	@Test
-	void test() {
+	void scanRegistersAnnotatedBeanDefinition() {
 		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
-		ClassPathBeanDefinitionScanner scanner = new MyAnnotationBeanDefinitionScanner(registry);
-		scanner.scan(AnnotationBeanDefinitionScannerTests.class.getPackageName());
+		MyAnnotationBeanDefinitionScanner scanner = new MyAnnotationBeanDefinitionScanner(registry);
+		scanner.scan(CURRENT_PACKAGE);
+
 		assertThat(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config")).isTrue();
+	}
+
+	@Test
+	void scanOnlyRegistersAnnotatedClasses() {
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		MyAnnotationBeanDefinitionScanner scanner = new MyAnnotationBeanDefinitionScanner(registry);
+		scanner.scan(CURRENT_PACKAGE);
+
+		// Only Config is annotated with @MyAnnotationScanner, not UnannotatedClass
+		assertThat(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config")).isTrue();
+		for (String name : registry.getBeanDefinitionNames()) {
+			assertThat(name).doesNotContainIgnoringCase("unannotated");
+		}
+	}
+
+	@Test
+	void scanWithUnrelatedPackageRegistersNothing() {
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		MyAnnotationBeanDefinitionScanner scanner = new MyAnnotationBeanDefinitionScanner(registry);
+		scanner.scan("com.livk.nonexistent");
+
+		assertThat(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config")).isFalse();
+	}
+
+	@Test
+	void generateHolderReturningNullSkipsRegistration() {
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		NullHolderScanner scanner = new NullHolderScanner(registry);
+		scanner.scan(CURRENT_PACKAGE);
+
+		assertThat(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config")).isFalse();
+	}
+
+	@Test
+	void scanWithCustomBeanNameGenerator() {
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		BeanNameGenerator customGenerator = new AnnotationBeanNameGenerator();
+		MyAnnotationBeanDefinitionScanner scanner = new MyAnnotationBeanDefinitionScanner(registry, customGenerator);
+		scanner.scan(CURRENT_PACKAGE);
+
+		assertThat(registry.containsBeanDefinition("annotationBeanDefinitionScannerTests.Config")).isTrue();
+	}
+
+	@Test
+	void generateHolderReceivesAnnotationAttributes() {
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		AttributeCapturingScanner scanner = new AttributeCapturingScanner(registry);
+		scanner.scan(CURRENT_PACKAGE);
+
+		assertThat(scanner.capturedAttributes).isNotNull();
 	}
 
 	static class MyAnnotationBeanDefinitionScanner extends AnnotationBeanDefinitionScanner<MyAnnotationScanner> {
@@ -50,9 +104,45 @@ class AnnotationBeanDefinitionScannerTests {
 			super(registry);
 		}
 
+		MyAnnotationBeanDefinitionScanner(BeanDefinitionRegistry registry, BeanNameGenerator beanNameGenerator) {
+			super(registry, beanNameGenerator);
+		}
+
 		@Override
 		protected BeanDefinitionHolder generateHolder(AnnotationAttributes attributes,
 				BeanDefinition candidateComponent, BeanDefinitionRegistry registry) {
+			String beanName = beanNameGenerator.generateBeanName(candidateComponent, registry);
+			return new BeanDefinitionHolder(candidateComponent, beanName);
+		}
+
+	}
+
+	static class NullHolderScanner extends AnnotationBeanDefinitionScanner<MyAnnotationScanner> {
+
+		NullHolderScanner(BeanDefinitionRegistry registry) {
+			super(registry);
+		}
+
+		@Override
+		protected BeanDefinitionHolder generateHolder(AnnotationAttributes attributes,
+				BeanDefinition candidateComponent, BeanDefinitionRegistry registry) {
+			return null;
+		}
+
+	}
+
+	static class AttributeCapturingScanner extends AnnotationBeanDefinitionScanner<MyAnnotationScanner> {
+
+		AnnotationAttributes capturedAttributes;
+
+		AttributeCapturingScanner(BeanDefinitionRegistry registry) {
+			super(registry);
+		}
+
+		@Override
+		protected BeanDefinitionHolder generateHolder(AnnotationAttributes attributes,
+				BeanDefinition candidateComponent, BeanDefinitionRegistry registry) {
+			this.capturedAttributes = attributes;
 			String beanName = beanNameGenerator.generateBeanName(candidateComponent, registry);
 			return new BeanDefinitionHolder(candidateComponent, beanName);
 		}
@@ -67,6 +157,11 @@ class AnnotationBeanDefinitionScannerTests {
 
 	@MyAnnotationScanner
 	static class Config {
+
+	}
+
+	@SuppressWarnings("unused")
+	static class UnannotatedClass {
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/annotation/AutoImportSelectorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/annotation/AutoImportSelectorTests.java
@@ -26,6 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -35,16 +36,33 @@ class AutoImportSelectorTests {
 	final AutoImportSelector importSelector = new AutoImportSelector();
 
 	@Test
-	void test() {
+	void selectImportsWithAutoImportAnnotation() {
 		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(Config.class));
-		String[] result = new String[] { ImportConfig.class.getName() };
-		assertThat(imports).containsExactly(result);
+		assertThat(imports).containsExactly(ImportConfig.class.getName());
+	}
+
+	@Test
+	void selectImportsWithoutAutoImportAnnotationThrows() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(PlainConfig.class);
+		assertThatThrownBy(() -> importSelector.selectImports(metadata)).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void selectImportsIgnoresNonAutoImportAnnotations() {
+		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(MixedConfig.class));
+		assertThat(imports).containsExactly(ImportConfig.class.getName());
 	}
 
 	@AutoImport
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface AutoServiceImport {
+
+	}
+
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface NonAutoImportAnnotation {
 
 	}
 
@@ -55,6 +73,16 @@ class AutoImportSelectorTests {
 
 	@AutoServiceImport
 	static class Config {
+
+	}
+
+	static class PlainConfig {
+
+	}
+
+	@AutoServiceImport
+	@NonAutoImportAnnotation
+	static class MixedConfig {
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/annotation/SpringAbstractImportSelectorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/annotation/SpringAbstractImportSelectorTests.java
@@ -32,14 +32,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class SpringAbstractImportSelectorTests {
 
-	@Test
-	void testFindAnnotation() {
-		MyAnnotationImportSelector selector = new MyAnnotationImportSelector();
-		assertThat(selector.getAnnotationClass()).isEqualTo(MyAnnotation.class);
+	final MyAnnotationImportSelector selector = new MyAnnotationImportSelector();
 
+	@Test
+	void resolvesAnnotationClassFromGenericTypeArgument() {
+		assertThat(selector.getAnnotationClass()).isEqualTo(MyAnnotation.class);
+	}
+
+	@Test
+	void selectImportsReturnsCandidateConfigurations() {
 		String[] imports = selector.selectImports(AnnotationMetadata.introspect(Config.class));
-		String[] result = new String[] { MyAnnotationConfig.class.getName() };
-		assertThat(imports).containsExactly(result);
+		assertThat(imports).containsExactly(MyAnnotationConfig.class.getName());
 	}
 
 	@Target(ElementType.TYPE)

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutAdvisorTests.java
@@ -35,25 +35,40 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AnnotationAbstractPointcutAdvisorTests {
 
+	final MyAnnotationAbstractPointcutAdvisor advisor = new MyAnnotationAbstractPointcutAdvisor();
+
 	@Test
-	void test() throws NoSuchMethodException {
-		MyAnnotationAbstractPointcutAdvisor advisor = new MyAnnotationAbstractPointcutAdvisor();
-
+	void resolvesAnnotationTypeFromGenericArgument() {
 		assertThat(advisor.annotationType).isEqualTo(MyAnnotation.class);
+	}
 
+	@Test
+	void implementsIntroductionInterceptor() {
 		assertThat(advisor.implementsInterface(IntroductionInterceptor.class)).isTrue();
+	}
 
+	@Test
+	void pointcutIsComposablePointcut() {
 		assertThat(advisor.getPointcut()).isInstanceOf(ComposablePointcut.class);
+	}
 
-		assertThat(advisor.getPointcut())
-			.isEqualTo(AnnotationPointcut.forTypeOrMethod().getPointcut(MyAnnotation.class));
-
+	@Test
+	void classFilterMatchesAnnotatedClass() {
 		assertThat(advisor.getPointcut().getClassFilter().matches(AopProxyClass.class)).isTrue();
+	}
 
+	@Test
+	void methodMatcherMatchesAnnotatedMethod() throws NoSuchMethodException {
 		assertThat(advisor.getPointcut()
 			.getMethodMatcher()
 			.matches(AopProxyClass.class.getDeclaredMethod("testAop"), AopProxyClass.class)).isTrue();
+	}
 
+	@Test
+	void methodMatcherDoesNotMatchUnannotatedMethod() throws NoSuchMethodException {
+		assertThat(advisor.getPointcut()
+			.getMethodMatcher()
+			.matches(UnannotatedClass.class.getDeclaredMethod("noAnnotation"), UnannotatedClass.class)).isFalse();
 	}
 
 	@MyAnnotation
@@ -61,6 +76,13 @@ class AnnotationAbstractPointcutAdvisorTests {
 
 		@MyAnnotation
 		void testAop() {
+		}
+
+	}
+
+	static class UnannotatedClass {
+
+		void noAnnotation() {
 		}
 
 	}

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutTypeAdvisorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationAbstractPointcutTypeAdvisorTests.java
@@ -32,20 +32,33 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AnnotationAbstractPointcutTypeAdvisorTests {
 
+	final MyAnnotationAbstractPointcutTypeAdvisor advisor = new MyAnnotationAbstractPointcutTypeAdvisor();
+
 	@Test
-	void test() {
-		MyAnnotationAbstractPointcutTypeAdvisor advisor = new MyAnnotationAbstractPointcutTypeAdvisor();
-
+	void pointcutIsAnnotationMatchingPointcut() {
 		assertThat(advisor.getPointcut()).isInstanceOf(AnnotationMatchingPointcut.class);
+	}
 
+	@Test
+	void pointcutMatchesForClassAnnotation() {
 		assertThat(advisor.getPointcut()).isEqualTo(AnnotationMatchingPointcut.forClassAnnotation(MyAnnotation.class));
+	}
 
+	@Test
+	void classFilterMatchesAnnotatedClass() {
 		assertThat(advisor.getPointcut().getClassFilter().matches(AopProxyClass.class)).isTrue();
+	}
 
+	@Test
+	void classFilterDoesNotMatchDifferentAnnotatedClass() {
 		assertThat(advisor.getPointcut()
 			.getClassFilter()
 			.matches(AnnotationAbstractPointcutAdvisorTests.AopProxyClass.class)).isFalse();
+	}
 
+	@Test
+	void classFilterDoesNotMatchUnannotatedClass() {
+		assertThat(advisor.getPointcut().getClassFilter().matches(UnannotatedClass.class)).isFalse();
 	}
 
 	@MyAnnotation
@@ -54,6 +67,10 @@ class AnnotationAbstractPointcutTypeAdvisorTests {
 		@SuppressWarnings("unused")
 		void testAop() {
 		}
+
+	}
+
+	static class UnannotatedClass {
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/ContextFactoryTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/ContextFactoryTests.java
@@ -19,17 +19,15 @@ package com.livk.commons.expression;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
  */
 class ContextFactoryTests {
-
-	private final Map<String, String> map = Map.of("username", "livk");
 
 	private final Method method = ParseMethod.class.getDeclaredMethod("parseMethod", String.class);
 
@@ -39,28 +37,58 @@ class ContextFactoryTests {
 	}
 
 	@Test
-	void testContextCreationFromFactory() {
+	void createFromMethodAndArgs() {
 		Context context = contextFactory.create(method, new String[] { "livk" });
-
-		assertThat(context.asMap()).hasSize(map.size());
-		assertThat(context.asMap().keySet()).isEqualTo(map.keySet());
-		assertThat(context.asMap().entrySet()).isEqualTo(map.entrySet());
+		assertThat(context.asMap()).containsExactlyInAnyOrderEntriesOf(Map.of("username", "livk"));
 	}
 
 	@Test
-	void testContextCreationFromMap() {
-		HashMap<String, Object> contextMap = new HashMap<>(
-				contextFactory.create(method, new String[] { "root" }).asMap());
-		contextMap.putAll(map);
-		Context context = Context.create(contextMap);
+	void createWithNullArgsReturnsEmptyContext() {
+		Context context = contextFactory.create(method, null);
+		assertThat(context.asMap()).isEmpty();
+	}
 
-		assertThat(context.asMap()).hasSize(1);
-		assertThat(context.asMap().keySet()).isEqualTo(contextMap.keySet());
-		assertThat(context.asMap().entrySet()).isEqualTo(contextMap.entrySet());
-		assertThat(context.asMap()).containsKey("username");
-		assertThat(context.asMap()).doesNotContainValue("root");
-		assertThat(context.asMap()).containsValue("livk");
-		assertThat(context.asMap().get("username")).isEqualTo("livk");
+	@Test
+	void createWithMismatchedArgsLengthReturnsEmptyContext() {
+		Context context = contextFactory.create(method, new Object[] { "a", "b" });
+		assertThat(context.asMap()).isEmpty();
+	}
+
+	@Test
+	void createEmptyContext() {
+		Context context = Context.create();
+		assertThat(context.asMap()).isEmpty();
+	}
+
+	@Test
+	void createFromMap() {
+		Context context = Context.create(Map.of("key", "value"));
+		assertThat(context.asMap()).containsExactlyInAnyOrderEntriesOf(Map.of("key", "value"));
+	}
+
+	@Test
+	void putAddsEntry() {
+		Context context = Context.create().put("username", "livk").put("password", "123456");
+		assertThat(context.asMap()).containsEntry("username", "livk").containsEntry("password", "123456").hasSize(2);
+	}
+
+	@Test
+	void putAllMergesEntries() {
+		Context context = Context.create().put("username", "root").putAll(Map.of("username", "livk", "extra", "val"));
+		assertThat(context.asMap()).containsEntry("username", "livk").containsEntry("extra", "val").hasSize(2);
+	}
+
+	@Test
+	void asMapReturnsUnmodifiableMap() {
+		Context context = Context.create(Map.of("key", "value"));
+		assertThatThrownBy(() -> context.asMap().put("new", "entry")).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	@Test
+	void defaultFactoryConstantIsNotNull() {
+		assertThat(ContextFactory.DEFAULT_FACTORY).isNotNull();
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, new String[] { "livk" });
+		assertThat(context.asMap()).containsEntry("username", "livk");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/aviator/AviatorExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/aviator/AviatorExpressionResolverTests.java
@@ -54,49 +54,61 @@ class AviatorExpressionResolverTests {
 		.withUserConfiguration(SpringConfig.class);
 
 	@Test
-	void evaluate() {
-		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
+	void evaluateEqualityWithMethodArgs() {
 		assertThat(resolver.evaluate("'livk'==#username", method, args, Boolean.class)).isTrue();
+	}
 
+	@Test
+	void evaluateVariableWithMethodArgs() {
 		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateEqualityWithMap() {
 		assertThat(resolver.evaluate("'livk'==#username", map, Boolean.class)).isTrue();
+	}
 
+	@Test
+	void evaluateVariableWithMap() {
 		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateConcatenationWithMethodArgs() {
 		assertThat(resolver.evaluate("'root:'+#username", method, args)).isEqualTo("root:livk");
+	}
 
+	@Test
+	void evaluateConcatenationWithContext() {
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
 		assertThat(resolver.evaluate("'root:'+#username+':'+#password", context)).isEqualTo("root:livk:123456");
-
-		assertThat(resolver.evaluate("'root:'+#username", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("#username+':'+System.getProperty(\"user.dir\")", map))
-			.isEqualTo("livk:" + System.getProperty("user.dir"));
-
-		assertThat(resolver.evaluate("'root:'+#username", method, args)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("'root:'+#username+':'+#password", context)).isEqualTo("root:livk:123456");
-
 		assertThat(resolver.evaluate("#username+#password", context)).isEqualTo("livk123456");
+	}
 
-		assertThat(resolver.evaluate("'root:'+#username", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
-
+	@Test
+	void evaluateWithSystemProperty() {
 		assertThat(resolver.evaluate("#username+':'+System.getProperty(\"user.dir\")", map))
 			.isEqualTo("livk:" + System.getProperty("user.dir"));
+	}
 
+	@Test
+	void evaluatePlainStringPassesThrough() {
+		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
+	}
+
+	@Test
+	void evaluateWithSpringContextCustomFunction() {
 		contextRunner.run(ctx -> {
 			assertThat(resolver.evaluate("add(x,y)", Map.of("x", "livk", "y", "123"))).isEqualTo("livk123");
+		});
+	}
 
+	@Test
+	void evaluateWithSpringContextIfElseFunction() {
+		contextRunner.run(ctx -> {
 			assertThat(resolver.evaluate("ifElse(a==c,b,d)", Map.of("a", 1, "b", 2, "c", 3, "d", 4), Integer.class))
 				.isEqualTo(4);
 		});
-
 	}
 
 	@TestConfiguration

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/freemarker/FreeMarkerExpressionResolverTests.java
@@ -46,35 +46,41 @@ class FreeMarkerExpressionResolverTests {
 	}
 
 	@Test
-	void evaluate() {
+	void evaluateWithMethodArgs() {
+		assertThat(resolver.evaluate("${username}", method, args)).isEqualTo("livk");
+	}
+
+	@Test
+	void evaluateWithMap() {
+		assertThat(resolver.evaluate("${username}", map)).isEqualTo("livk");
+	}
+
+	@Test
+	void evaluateTemplateWithMethodArgs() {
+		assertThat(resolver.evaluate("root:${username}", method, args)).isEqualTo("root:livk");
+	}
+
+	@Test
+	void evaluateTemplateWithContext() {
 		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
-		assertThat(resolver.evaluate("${username}", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("${username}", map)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("root:${username}", method, args)).isEqualTo("root:livk");
-
 		assertThat(resolver.evaluate("root:${username}:${password}", context)).isEqualTo("root:livk:123456");
+	}
 
-		assertThat(resolver.evaluate("root:${username}", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("root:${username}", method, args)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("${username}", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("livk", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("root:${username}:${password}", context)).isEqualTo("root:livk:123456");
-
+	@Test
+	void evaluateConcatenationWithContext() {
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
 		assertThat(resolver.evaluate("${username}${password}", context)).isEqualTo("livk123456");
+	}
 
-		assertThat(resolver.evaluate("root:${username}", map)).isEqualTo("root:livk");
+	@Test
+	void evaluatePlainStringPassesThrough() {
+		assertThat(resolver.evaluate("livk", method, args)).isEqualTo("livk");
+	}
 
-		assertThat(resolver.evaluate("${username}", map)).isEqualTo("livk");
-
+	@Test
+	void evaluateWithNonStringReturnTypeThrows() {
 		assertThatThrownBy(() -> resolver.evaluate("${username}", map, Integer.class))
 			.isExactlyInstanceOf(ExpressionException.class);
-
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/jexl3/JexlExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/jexl3/JexlExpressionResolverTests.java
@@ -44,36 +44,40 @@ class JexlExpressionResolverTests {
 	}
 
 	@Test
-	void evaluate() {
-		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
+	void evaluateEqualityWithMethodArgs() {
 		assertThat(resolver.evaluate("'livk'==username", method, args, Boolean.class)).isTrue();
+	}
 
+	@Test
+	void evaluateVariableWithMethodArgs() {
 		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateEqualityWithMap() {
 		assertThat(resolver.evaluate("'livk'==username", map, Boolean.class)).isTrue();
+	}
 
+	@Test
+	void evaluateVariableWithMap() {
 		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateConcatenationWithMethodArgs() {
 		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
+	}
 
+	@Test
+	void evaluateConcatenationWithContext() {
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
 		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
-
-		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
-
 		assertThat(resolver.evaluate("username+password", context)).isEqualTo("livk123456");
+	}
 
-		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
-
+	@Test
+	void evaluatePlainStringPassesThrough() {
+		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/mvel2/MvelExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/mvel2/MvelExpressionResolverTests.java
@@ -44,42 +44,46 @@ class MvelExpressionResolverTests {
 	}
 
 	@Test
-	void evaluate() {
-		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
+	void evaluateEqualityWithMethodArgs() {
 		assertThat(resolver.evaluate("'livk'==username", method, args, Boolean.class)).isTrue();
+	}
 
+	@Test
+	void evaluateVariableWithMethodArgs() {
 		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateEqualityWithMap() {
 		assertThat(resolver.evaluate("'livk'==username", map, Boolean.class)).isTrue();
+	}
 
+	@Test
+	void evaluateVariableWithMap() {
 		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateConcatenationWithMethodArgs() {
 		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
+	}
 
+	@Test
+	void evaluateConcatenationWithContext() {
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
 		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
-
-		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("username+':'+System.getProperty(\"user.dir\")", map))
-			.isEqualTo("livk:" + System.getProperty("user.dir"));
-
-		assertThat(resolver.evaluate("'root:'+username", method, args)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("username", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
-
-		assertThat(resolver.evaluate("'root:'+username+':'+password", context)).isEqualTo("root:livk:123456");
-
 		assertThat(resolver.evaluate("username+password", context)).isEqualTo("livk123456");
+	}
 
-		assertThat(resolver.evaluate("'root:'+username", map)).isEqualTo("root:livk");
-
-		assertThat(resolver.evaluate("username", map)).isEqualTo("livk");
-
+	@Test
+	void evaluateWithSystemProperty() {
 		assertThat(resolver.evaluate("username+':'+System.getProperty(\"user.dir\")", map))
 			.isEqualTo("livk:" + System.getProperty("user.dir"));
+	}
 
+	@Test
+	void evaluatePlainStringPassesThrough() {
+		assertThat(resolver.evaluate("'livk'", method, args)).isEqualTo("livk");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/expression/spring/SpringExpressionResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/expression/spring/SpringExpressionResolverTests.java
@@ -53,50 +53,68 @@ class SpringExpressionResolverTests {
 	}
 
 	@Test
-	void evaluate() {
-		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
+	void evaluateWithMethodArgs() {
 		assertThat(resolver.evaluate("'livk'==#username", method, args, Boolean.class)).isTrue();
 		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateWithMap() {
 		assertThat(resolver.evaluate("'livk'==#username", map, Boolean.class)).isTrue();
 		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
+	}
 
+	@Test
+	void evaluateTemplateExpressionWithMethodArgs() {
 		assertThat(resolver.evaluate("root:#{#username}", method, args)).isEqualTo("root:livk");
-		assertThat(resolver.evaluate("root:#{#username}:#{#password}", context)).isEqualTo("root:livk:123456");
+	}
 
+	@Test
+	void evaluateTemplateExpressionWithContext() {
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
+		assertThat(resolver.evaluate("root:#{#username}:#{#password}", context)).isEqualTo("root:livk:123456");
+	}
+
+	@Test
+	void evaluateTemplateExpressionWithMap() {
 		assertThat(resolver.evaluate("root:#{#username}", map)).isEqualTo("root:livk");
+	}
+
+	@Test
+	void evaluateWithTypeInvocation() {
 		assertThat(resolver.evaluate("#{#username}:#{T(java.lang.System).getProperty(\"user.dir\")}", map))
 			.isEqualTo("livk:" + System.getProperty("user.dir"));
+	}
 
-		assertThat(resolver.evaluate("root:#{#username}", method, args)).isEqualTo("root:livk");
-		assertThat(resolver.evaluate("#username", method, args)).isEqualTo("livk");
+	@Test
+	void evaluatePlainStringPassesThrough() {
 		assertThat(resolver.evaluate("livk", method, args)).isEqualTo("livk");
+	}
 
-		assertThat(resolver.evaluate("root:#{#username}:#{#password}", context)).isEqualTo("root:livk:123456");
+	@Test
+	void evaluateConcatenationWithContext() {
+		Context context = ContextFactory.DEFAULT_FACTORY.create(method, args).putAll(Map.of("password", "123456"));
 		assertThat(resolver.evaluate("#username+#password", context)).isEqualTo("livk123456");
+	}
 
-		assertThat(resolver.evaluate("root:#{#username}", map)).isEqualTo("root:livk");
-		assertThat(resolver.evaluate("#username", map)).isEqualTo("livk");
-		assertThat(resolver.evaluate("#{#username}:#{T(java.lang.System).getProperty(\"user.dir\")}", map))
-			.isEqualTo("livk:" + System.getProperty("user.dir"));
-
+	@Test
+	void evaluateWithSpringContextHolder() {
 		contextRunner.run(ctx -> {
 			assertThat(resolver.evaluate(
 					"#{#username}:#{T(" + springContextHolderName + ").getProperty(\"spring.application.root.name\")}",
 					map))
 				.isEqualTo("livk:livk");
+		});
+	}
 
-			assertThat(resolver.evaluate(
-					"#{#username}:#{T(" + springContextHolderName + ").getProperty(\"spring.application.root.name\")}",
-					map))
-				.isEqualTo("livk:livk");
-
+	@Test
+	void evaluateWithEnvironmentBean() {
+		contextRunner.run(ctx -> {
 			Map<String, Object> envMap = Map.of("username", "livk", "env",
 					SpringContextHolder.getBean(Environment.class));
 			assertThat(resolver.evaluate("#{#username}:#{#env.getProperty(\"spring.application.root.name\")}", envMap))
 				.isEqualTo("livk:livk");
 		});
-
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/HttpClientImportSelectorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/HttpClientImportSelectorTests.java
@@ -31,27 +31,48 @@ class HttpClientImportSelectorTests {
 	final HttpClientImportSelector importSelector = new HttpClientImportSelector();
 
 	@Test
-	void testSelectImportsForTwoConfig() {
-		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(TwoConfig.class));
-		String[] expected = new String[] { WebClientConfiguration.class.getName(),
-				RestClientConfiguration.class.getName() };
-		assertThat(imports).containsExactly(expected);
+	void selectImportsWithWebClientOnly() {
+		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(WebClientOnlyConfig.class));
+		assertThat(imports).containsExactly(WebClientConfiguration.class.getName());
 	}
 
 	@Test
-	void testSelectImportsForOneConfig() {
-		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(OneConfig.class));
-		String[] expected = new String[] { WebClientConfiguration.class.getName() };
-		assertThat(imports).containsExactly(expected);
+	void selectImportsWithRestClientOnly() {
+		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(RestClientOnlyConfig.class));
+		assertThat(imports).containsExactly(RestClientConfiguration.class.getName());
+	}
+
+	@Test
+	void selectImportsWithBothClientsPreservesOrder() {
+		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(BothClientsConfig.class));
+		assertThat(imports).containsExactly(WebClientConfiguration.class.getName(),
+				RestClientConfiguration.class.getName());
+	}
+
+	@Test
+	void selectImportsWithReversedOrderPreservesAnnotationOrder() {
+		String[] imports = importSelector.selectImports(AnnotationMetadata.introspect(ReversedOrderConfig.class));
+		assertThat(imports).containsExactly(RestClientConfiguration.class.getName(),
+				WebClientConfiguration.class.getName());
+	}
+
+	@EnableHttpClient(HttpClientType.WEB_CLIENT)
+	static class WebClientOnlyConfig {
+
+	}
+
+	@EnableHttpClient(HttpClientType.REST_CLIENT)
+	static class RestClientOnlyConfig {
+
 	}
 
 	@EnableHttpClient({ HttpClientType.WEB_CLIENT, HttpClientType.REST_CLIENT })
-	static class TwoConfig {
+	static class BothClientsConfig {
 
 	}
 
-	@EnableHttpClient({ HttpClientType.WEB_CLIENT })
-	static class OneConfig {
+	@EnableHttpClient({ HttpClientType.REST_CLIENT, HttpClientType.WEB_CLIENT })
+	static class ReversedOrderConfig {
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/OkHttpClientConfigurationTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/OkHttpClientConfigurationTests.java
@@ -32,9 +32,12 @@ class OkHttpClientConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(OkHttpClientConfiguration.class));
 
 	@Test
-	void test() {
+	void defaultOkHttpClientHttpRequestFactoryIsRegistered() {
 		contextRunner.run(context -> assertThat(context).hasBean("defaultOkHttpClientHttpRequestFactory"));
+	}
 
+	@Test
+	void customOkHttpClientUsesCustomFactory() {
 		contextRunner.withBean("okHttpClient", OkHttpClient.class, OkHttpClient::new)
 			.run(context -> assertThat(context).hasBean("okHttpClientHttpRequestFactory"));
 	}

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/RestClientConfigurationTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/RestClientConfigurationTests.java
@@ -35,7 +35,7 @@ class RestClientConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(RestClientConfiguration.class, RestClientAutoConfiguration.class));
 
 	@Test
-	void test() {
+	void restClientBeansAreRegistered() {
 		contextRunner.run(context -> {
 			assertThat(context).hasSingleBean(RestClient.class);
 			assertThat(context).hasBean("restClientCustomizer");

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/WebClientConfigurationTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/WebClientConfigurationTests.java
@@ -36,7 +36,7 @@ class WebClientConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(WebClientConfiguration.class, WebClientAutoConfiguration.class));
 
 	@Test
-	void test() {
+	void webClientBeansAreRegistered() {
 		contextRunner.run(context -> {
 			assertThat(context).hasSingleBean(WebClient.class);
 			assertThat(context).hasSingleBean(WebClientCustomizer.class);

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/annotation/HttpClientTypeTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/annotation/HttpClientTypeTests.java
@@ -26,10 +26,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HttpClientTypeTests {
 
 	@Test
-	void annotationType() {
-		assertThat(HttpClientType.REST_CLIENT.annotationType()).isEqualTo(EnableRestClient.class);
+	void webClientAnnotationType() {
 		assertThat(HttpClientType.WEB_CLIENT.annotationType()).isEqualTo(EnableWebClient.class);
+		assertThat(HttpClientType.WEB_CLIENT.annotationType()).isAnnotation();
+	}
 
+	@Test
+	void restClientAnnotationType() {
+		assertThat(HttpClientType.REST_CLIENT.annotationType()).isEqualTo(EnableRestClient.class);
+		assertThat(HttpClientType.REST_CLIENT.annotationType()).isAnnotation();
+	}
+
+	@Test
+	void allEnumValuesHaveAnnotationType() {
+		for (HttpClientType type : HttpClientType.values()) {
+			assertThat(type.annotationType()).isNotNull().isAnnotation();
+		}
+	}
+
+	@Test
+	void enumValuesCount() {
+		assertThat(HttpClientType.values()).hasSize(2);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/http/support/ReactorClientCustomizerTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/http/support/ReactorClientCustomizerTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.commons.http.support;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.timeout.IdleStateHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.http.client.reactive.ReactorClientHttpConnectorBuilder;
+import org.springframework.http.client.ReactorResourceFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class ReactorClientCustomizerTests {
+
+	final ReactorResourceFactory resourceFactory = new ReactorResourceFactory();
+
+	{
+		resourceFactory.setUseGlobalResources(false);
+		resourceFactory.afterPropertiesSet();
+	}
+
+	// --- fluent configuration ---
+
+	@Test
+	void withConnectTimeoutReturnsSameInstance() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		assertThat(customizer.withConnectTimeout(5000)).isSameAs(customizer);
+	}
+
+	@Test
+	void withResponseTimeoutReturnsSameInstance() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		assertThat(customizer.withResponseTimeout(30)).isSameAs(customizer);
+	}
+
+	@Test
+	void withReadTimeoutReturnsSameInstance() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		assertThat(customizer.withReadTimeout(10)).isSameAs(customizer);
+	}
+
+	@Test
+	void withWriteTimeoutReturnsSameInstance() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		assertThat(customizer.withWriteTimeout(10)).isSameAs(customizer);
+	}
+
+	// --- addChannelHandler ---
+
+	@Test
+	void addChannelHandlerReturnsSameInstance() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		ChannelHandler handler = new IdleStateHandler(0, 0, 60);
+		assertThat(customizer.addChannelHandler(handler)).isSameAs(customizer);
+	}
+
+	@Test
+	void addChannelHandlerIgnoresNull() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		customizer.addChannelHandler((ChannelHandler) null);
+		// should not throw, null is silently ignored
+	}
+
+	@Test
+	void addChannelHandlerIgnoresDuplicate() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		ChannelHandler handler = new IdleStateHandler(0, 0, 60);
+		customizer.addChannelHandler(handler);
+		customizer.addChannelHandler(handler);
+		// duplicate is silently ignored
+	}
+
+	// --- customize ---
+
+	@Test
+	void customizeReturnsNonNullBuilder() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory);
+		ReactorClientHttpConnectorBuilder result = customizer
+			.customize(org.springframework.boot.http.client.reactive.ClientHttpConnectorBuilder.reactor());
+		assertThat(result).isNotNull();
+	}
+
+	@Test
+	void customizeWithAllOptionsDoesNotThrow() {
+		ReactorClientCustomizer customizer = new ReactorClientCustomizer(resourceFactory).withConnectTimeout(3000)
+			.withResponseTimeout(15)
+			.withReadTimeout(20)
+			.withWriteTimeout(20);
+		ReactorClientHttpConnectorBuilder result = customizer
+			.customize(org.springframework.boot.http.client.reactive.ClientHttpConnectorBuilder.reactor());
+		assertThat(result).isNotNull();
+	}
+
+}

--- a/spring-extension-commons/src/test/java/com/livk/commons/io/FileUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/io/FileUtilsTests.java
@@ -18,6 +18,7 @@ package com.livk.commons.io;
 
 import com.livk.commons.jackson.JsonMapperUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.ByteArrayInputStream;
@@ -26,6 +27,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,20 +37,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class FileUtilsTests {
 
+	@TempDir
+	Path tempDir;
+
 	@Test
 	void download() throws IOException {
 		InputStream inputStream = new ByteArrayInputStream("livk".getBytes());
-		FileUtils.download(inputStream, "./username.txt");
-		File file = new File("./username.txt");
-		assertThat(file.exists()).isTrue();
-		assertThat(file.delete()).isTrue();
+		String filePath = tempDir.resolve("username.txt").toString();
+		FileUtils.download(inputStream, filePath);
+		File file = new File(filePath);
+		assertThat(file).exists();
+		assertThat(Files.readString(file.toPath())).isEqualTo("livk");
 	}
 
 	@Test
 	void createNewFile() throws IOException {
-		File file = new File("./file.txt");
+		File file = tempDir.resolve("file.txt").toFile();
 		assertThat(FileUtils.createNewFile(file)).isTrue();
-		assertThat(file.delete()).isTrue();
+		assertThat(file).exists();
 	}
 
 	@Test
@@ -55,7 +62,7 @@ class FileUtilsTests {
 		InputStream inputStream = new ClassPathResource("data.json").getInputStream();
 		String data = JsonMapperUtils.readTree(inputStream).toString();
 
-		File file = new File("./data.gzip");
+		File file = tempDir.resolve("data.gzip").toFile();
 		FileUtils.createNewFile(file);
 		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
 			FileUtils.gzipCompress(data.getBytes(), fileOutputStream);
@@ -64,7 +71,6 @@ class FileUtilsTests {
 		try (FileInputStream fileInputStream = new FileInputStream(file)) {
 			String copyData = new String(FileUtils.gzipDecompress(fileInputStream));
 			assertThat(copyData).isEqualTo(data);
-			assertThat(file.delete()).isTrue();
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/io/ResourceUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/io/ResourceUtilsTests.java
@@ -30,19 +30,20 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ResourceUtilsTests {
 
+	static final String FILE_NAME = "input.json";
+
 	@Test
-	void getResource() throws IOException {
-		String fileName = "input.json";
-		Resource resource = ResourceUtils.getResource(ResourceUtils.CLASSPATH_URL_PREFIX + fileName);
-
-		File file = ResourceUtils.getFile(ResourceUtils.CLASSPATH_URL_PREFIX + fileName);
-
+	void getResourceReturnsMatchingFile() throws IOException {
+		Resource resource = ResourceUtils.getResource(ResourceUtils.CLASSPATH_URL_PREFIX + FILE_NAME);
+		File file = ResourceUtils.getFile(ResourceUtils.CLASSPATH_URL_PREFIX + FILE_NAME);
 		assertThat(resource.getFile()).isEqualTo(file);
+	}
 
-		Resource[] resources = ResourceUtils.getResources(ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + fileName);
-		for (Resource resourceObj : resources) {
-			assertThat(resourceObj.getFile()).isEqualTo(file);
-		}
+	@Test
+	void getResourcesReturnsMatchingFiles() throws IOException {
+		File file = ResourceUtils.getFile(ResourceUtils.CLASSPATH_URL_PREFIX + FILE_NAME);
+		Resource[] resources = ResourceUtils.getResources(ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + FILE_NAME);
+		assertThat(resources).hasSize(1).extracting(Resource::getFile).containsExactly(file);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonMapperUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonMapperUtilsTests.java
@@ -59,15 +59,18 @@ class JsonMapperUtilsTests {
 			                    }
 			                }""";
 
+	private static void assertJsonContent(JsonNode node) {
+		assertThat(node).isNotNull();
+		assertThat(node.get("c").asString()).isEqualTo("1");
+		assertThat(node.get("a").asString()).isEqualTo("2");
+		assertThat(node.get("b").get("c").asInt()).isEqualTo(3);
+	}
+
 	@Test
 	void testReadValueWithJsonNodeClass() {
 		JsonFactory jsonFactory = new JsonFactory();
 		try (JsonParser parser = jsonFactory.createParser(ObjectReadContext.empty(), json)) {
-			JsonNode parserJsonNode = JsonMapperUtils.readValue(parser, JsonNode.class);
-			assertThat(parserJsonNode).isNotNull();
-			assertThat(parserJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(parserJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(parser, JsonNode.class));
 		}
 	}
 
@@ -75,12 +78,8 @@ class JsonMapperUtilsTests {
 	void testReadValueWithTypeReference() {
 		JsonFactory jsonFactory = new JsonFactory();
 		try (JsonParser parser = jsonFactory.createParser(ObjectReadContext.empty(), json)) {
-			JsonNode parserJsonNode = JsonMapperUtils.readValue(parser, new TypeReference<>() {
-			});
-			assertThat(parserJsonNode).isNotNull();
-			assertThat(parserJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(parserJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(parser, new TypeReference<>() {
+			}));
 		}
 	}
 
@@ -88,196 +87,90 @@ class JsonMapperUtilsTests {
 	void testReadValueWithJavaType() {
 		JsonFactory jsonFactory = new JsonFactory();
 		try (JsonParser parser = jsonFactory.createParser(ObjectReadContext.empty(), json)) {
-			JsonNode parserJsonNode = JsonMapperUtils.readValue(parser, javaType);
-			assertThat(parserJsonNode).isNotNull();
-			assertThat(parserJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(parserJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(parser, javaType));
 		}
 	}
 
 	@Test
 	void readValueFile() throws IOException {
 		File file = new ClassPathResource("input.json").getFile();
-
-		JsonNode fileJsonNode = JsonMapperUtils.readValue(file, JsonNode.class);
-		assertThat(fileJsonNode).isNotNull();
-		assertThat(fileJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(fileJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		fileJsonNode = JsonMapperUtils.readValue(file, new TypeReference<>() {
-		});
-		assertThat(fileJsonNode).isNotNull();
-		assertThat(fileJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(fileJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		fileJsonNode = JsonMapperUtils.readValue(file, javaType);
-		assertThat(fileJsonNode).isNotNull();
-		assertThat(fileJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(fileJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
+		assertJsonContent(JsonMapperUtils.readValue(file, JsonNode.class));
+		assertJsonContent(JsonMapperUtils.readValue(file, new TypeReference<>() {
+		}));
+		assertJsonContent(JsonMapperUtils.readValue(file, javaType));
 	}
 
 	@Test
 	void readValueURL() throws IOException {
 		URL url = new ClassPathResource("input.json").getURL();
-
-		JsonNode urlJsonNode = JsonMapperUtils.readValue(url, JsonNode.class);
-		assertThat(urlJsonNode).isNotNull();
-		assertThat(urlJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(urlJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		urlJsonNode = JsonMapperUtils.readValue(url, new TypeReference<>() {
-		});
-		assertThat(urlJsonNode).isNotNull();
-		assertThat(urlJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(urlJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		urlJsonNode = JsonMapperUtils.readValue(url, javaType);
-		assertThat(urlJsonNode).isNotNull();
-		assertThat(urlJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(urlJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
+		assertJsonContent(JsonMapperUtils.readValue(url, JsonNode.class));
+		assertJsonContent(JsonMapperUtils.readValue(url, new TypeReference<>() {
+		}));
+		assertJsonContent(JsonMapperUtils.readValue(url, javaType));
 	}
 
 	@Test
 	void readValueStr() {
-		JsonNode strJsonNode = JsonMapperUtils.readValue(json, JsonNode.class);
-		assertThat(strJsonNode).isNotNull();
-		assertThat(strJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(strJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(strJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		JsonNode typeReferenceJsonNode = JsonMapperUtils.readValue(json, new TypeReference<>() {
-		});
-		assertThat(typeReferenceJsonNode).isNotNull();
-		assertThat(typeReferenceJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(typeReferenceJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(typeReferenceJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		JsonNode javaTypeJsonNode = JsonMapperUtils.readValue(json, javaType);
-		assertThat(javaTypeJsonNode).isNotNull();
-		assertThat(javaTypeJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(javaTypeJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(javaTypeJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
+		assertJsonContent(JsonMapperUtils.readValue(json, JsonNode.class));
+		assertJsonContent(JsonMapperUtils.readValue(json, new TypeReference<>() {
+		}));
+		assertJsonContent(JsonMapperUtils.readValue(json, javaType));
 	}
 
 	@Test
 	void readValueReader() throws IOException {
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 				InputStreamReader reader = new InputStreamReader(inputStream)) {
-			JsonNode readerJsonNode = JsonMapperUtils.readValue(reader, JsonNode.class);
-			assertThat(readerJsonNode).isNotNull();
-			assertThat(readerJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(readerJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(reader, JsonNode.class));
 		}
-
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 				InputStreamReader reader = new InputStreamReader(inputStream)) {
-			JsonNode readerJsonNode = JsonMapperUtils.readValue(reader, new TypeReference<>() {
-			});
-			assertThat(readerJsonNode).isNotNull();
-			assertThat(readerJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(readerJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(reader, new TypeReference<>() {
+			}));
 		}
-
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 				InputStreamReader reader = new InputStreamReader(inputStream)) {
-			JsonNode readerJsonNode = JsonMapperUtils.readValue(reader, javaType);
-			assertThat(readerJsonNode).isNotNull();
-			assertThat(readerJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(readerJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(reader, javaType));
 		}
 	}
 
 	@Test
 	void readValueInputStream() throws IOException {
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
-			JsonNode inputStreamJsonNode = JsonMapperUtils.readValue(inputStream, JsonNode.class);
-			assertThat(inputStreamJsonNode).isNotNull();
-			assertThat(inputStreamJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(inputStreamJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(inputStream, JsonNode.class));
 		}
-
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
-			JsonNode inputStreamJsonNode = JsonMapperUtils.readValue(inputStream, new TypeReference<>() {
-			});
-			assertThat(inputStreamJsonNode).isNotNull();
-			assertThat(inputStreamJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(inputStreamJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(inputStream, new TypeReference<>() {
+			}));
 		}
-
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
-			JsonNode inputStreamJsonNode = JsonMapperUtils.readValue(inputStream, javaType);
-			assertThat(inputStreamJsonNode).isNotNull();
-			assertThat(inputStreamJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(inputStreamJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(inputStream, javaType));
 		}
 	}
 
 	@Test
 	void readValueByteArray() {
 		byte[] jsonBytes = json.getBytes();
-
-		JsonNode byteArrayJsonNode = JsonMapperUtils.readValue(jsonBytes, JsonNode.class);
-		assertThat(byteArrayJsonNode).isNotNull();
-		assertThat(byteArrayJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(byteArrayJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		byteArrayJsonNode = JsonMapperUtils.readValue(jsonBytes, new TypeReference<>() {
-		});
-		assertThat(byteArrayJsonNode).isNotNull();
-		assertThat(byteArrayJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(byteArrayJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		byteArrayJsonNode = JsonMapperUtils.readValue(jsonBytes, javaType);
-		assertThat(byteArrayJsonNode).isNotNull();
-		assertThat(byteArrayJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(byteArrayJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JsonMapperUtils.readValue(jsonBytes, JsonNode.class));
+		assertJsonContent(JsonMapperUtils.readValue(jsonBytes, new TypeReference<>() {
+		}));
+		assertJsonContent(JsonMapperUtils.readValue(jsonBytes, javaType));
 	}
 
 	@Test
 	void readValueDataInput() throws IOException {
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			DataInput dataInput = new DataInputStream(inputStream);
-			JsonNode dataInputJsonNode = JsonMapperUtils.readValue(dataInput, JsonNode.class);
-			assertThat(dataInputJsonNode).isNotNull();
-			assertThat(dataInputJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(dataInputJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(dataInputJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(dataInput, JsonNode.class));
 		}
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			DataInput dataInput = new DataInputStream(inputStream);
-			JsonNode jsonNode = JsonMapperUtils.readValue(dataInput, new TypeReference<>() {
-			});
-			assertThat(jsonNode).isNotNull();
-			assertThat(jsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(jsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(jsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(dataInput, new TypeReference<>() {
+			}));
 		}
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
 			DataInput dataInput = new DataInputStream(inputStream);
-			JsonNode jsonNode = JsonMapperUtils.readValue(dataInput, javaType);
-			assertThat(jsonNode).isNotNull();
-			assertThat(jsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(jsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(jsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readValue(dataInput, javaType));
 		}
 	}
 
@@ -307,7 +200,6 @@ class JsonMapperUtilsTests {
 		assertThat(result).isNotNull();
 		assertThat(result.get(0).get("a").asInt()).isEqualTo(1);
 		assertThat(result.get(1).get("a").asInt()).isEqualTo(1);
-
 	}
 
 	@SuppressWarnings("unchecked")
@@ -331,73 +223,45 @@ class JsonMapperUtilsTests {
 	void testReadTreeWithJsonParser() {
 		JsonFactory jsonFactory = new JsonFactory();
 		try (JsonParser parser = jsonFactory.createParser(ObjectReadContext.empty(), json)) {
-			JsonNode parserJsonNode = JsonMapperUtils.readTree(parser);
-			assertThat(parserJsonNode).isNotNull();
-			assertThat(parserJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(parserJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(parserJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readTree(parser));
 		}
 	}
 
 	@Test
 	void testReadTreeWithFile() throws IOException {
 		File file = new ClassPathResource("input.json").getFile();
-		JsonNode fileJsonNode = JsonMapperUtils.readTree(file);
-		assertThat(fileJsonNode).isNotNull();
-		assertThat(fileJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(fileJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(fileJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JsonMapperUtils.readTree(file));
 	}
 
 	@Test
 	void testReadTreeWithURL() throws IOException {
 		URL url = new ClassPathResource("input.json").getURL();
-		JsonNode urlJsonNode = JsonMapperUtils.readTree(url);
-		assertThat(urlJsonNode).isNotNull();
-		assertThat(urlJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(urlJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(urlJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JsonMapperUtils.readTree(url));
 	}
 
 	@Test
 	void testReadTreeWithString() {
-		JsonNode result = JsonMapperUtils.readTree(json);
-		assertThat(result).isNotNull();
-		assertThat(result.get("c").asString()).isEqualTo("1");
-		assertThat(result.get("a").asString()).isEqualTo("2");
-		assertThat(result.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JsonMapperUtils.readTree(json));
 	}
 
 	@Test
 	void testReadTreeWithInputStreamReader() throws IOException {
 		InputStream inputStream = new ClassPathResource("input.json").getInputStream();
 		try (InputStreamReader reader = new InputStreamReader(inputStream)) {
-			JsonNode readerJsonNode = JsonMapperUtils.readTree(reader);
-			assertThat(readerJsonNode).isNotNull();
-			assertThat(readerJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(readerJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(readerJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readTree(reader));
 		}
 	}
 
 	@Test
 	void testReadTreeWithInputStream() throws IOException {
 		try (InputStream inputStream = new ClassPathResource("input.json").getInputStream()) {
-			JsonNode inputStreamJsonNode = JsonMapperUtils.readTree(inputStream);
-			assertThat(inputStreamJsonNode).isNotNull();
-			assertThat(inputStreamJsonNode.get("c").asString()).isEqualTo("1");
-			assertThat(inputStreamJsonNode.get("a").asString()).isEqualTo("2");
-			assertThat(inputStreamJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+			assertJsonContent(JsonMapperUtils.readTree(inputStream));
 		}
 	}
 
 	@Test
 	void testReadTreeWithByteArray() {
-		JsonNode byteArrayJsonNode = JsonMapperUtils.readTree(json.getBytes());
-		assertThat(byteArrayJsonNode).isNotNull();
-		assertThat(byteArrayJsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(byteArrayJsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(byteArrayJsonNode.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JsonMapperUtils.readTree(json.getBytes()));
 	}
 
 	@Test

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonNodeUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/JsonNodeUtilsTests.java
@@ -16,9 +16,9 @@
 
 package com.livk.commons.jackson;
 
+import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
-import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -35,6 +35,7 @@ class JsonNodeUtilsTests {
 			{
 			  "username": "root",
 			  "password": "root",
+			  "count": 42,
 			  "info": {
 			    "name": "livk",
 			    "email": "1375632510@qq.com"
@@ -43,31 +44,85 @@ class JsonNodeUtilsTests {
 
 	static final JsonNode node = JsonMapperUtils.readTree(json);
 
+	static final JsonMapper mapper = JsonMapper.builder().build();
+
 	@Test
-	void findStringValue() {
-		String username = JsonNodeUtils.findStringValue(node, "username");
-		assertThat(username).isEqualTo("root");
+	void findStringValueReturnsValue() {
+		assertThat(JsonNodeUtils.findStringValue(node, "username")).isEqualTo("root");
+	}
+
+	@Test
+	void findStringValueWithNullNodeReturnsNull() {
 		assertThat(JsonNodeUtils.findStringValue(null, "username")).isNull();
 	}
 
 	@Test
-	void findValue() {
-		Map<String, Object> map = JsonNodeUtils.findValue(node, "info", JsonNodeUtils.STRING_OBJECT_MAP,
-				JsonMapper.builder().build());
-		assertThat(map).containsExactlyInAnyOrderEntriesOf(Map.of("name", "livk", "email", "1375632510@qq.com"));
-
-		JsonNode nodeMap = JsonNodeUtils.findValue(node, "info", JsonNode.class, JsonMapper.builder().build());
-		ObjectNode valNode = new ObjectNode(JsonNodeFactory.instance).put("name", "livk")
-			.put("email", "1375632510@qq.com");
-		assertThat(nodeMap).isNotNull().isEqualTo(valNode);
+	void findStringValueWithMissingFieldReturnsNull() {
+		assertThat(JsonNodeUtils.findStringValue(node, "nonexistent")).isNull();
 	}
 
 	@Test
-	void findObjectNode() {
-		assertThat(JsonNodeUtils.findObjectNode(null, "info")).isNull();
+	void findStringValueWithNonStringFieldReturnsNull() {
+		assertThat(JsonNodeUtils.findStringValue(node, "count")).isNull();
+	}
+
+	@Test
+	void findObjectNodeReturnsObjectNode() {
 		JsonNode jsonNode = JsonNodeUtils.findObjectNode(node, "info");
+		assertThat(jsonNode).isNotNull();
 		assertThat(jsonNode.get("name").asString()).isEqualTo("livk");
 		assertThat(jsonNode.get("email").asString()).isEqualTo("1375632510@qq.com");
+	}
+
+	@Test
+	void findObjectNodeWithNullNodeReturnsNull() {
+		assertThat(JsonNodeUtils.findObjectNode(null, "info")).isNull();
+	}
+
+	@Test
+	void findObjectNodeWithMissingFieldReturnsNull() {
+		assertThat(JsonNodeUtils.findObjectNode(node, "nonexistent")).isNull();
+	}
+
+	@Test
+	void findObjectNodeWithNonObjectFieldReturnsNull() {
+		assertThat(JsonNodeUtils.findObjectNode(node, "username")).isNull();
+	}
+
+	@Test
+	void findValueWithTypeReference() {
+		Map<String, Object> map = JsonNodeUtils.findValue(node, "info", JsonNodeUtils.STRING_OBJECT_MAP, mapper);
+		assertThat(map).containsExactlyInAnyOrderEntriesOf(Map.of("name", "livk", "email", "1375632510@qq.com"));
+	}
+
+	@Test
+	void findValueWithClassType() {
+		JsonNode result = JsonNodeUtils.findValue(node, "info", JsonNode.class, mapper);
+		ObjectNode expected = new ObjectNode(JsonNodeFactory.instance).put("name", "livk")
+			.put("email", "1375632510@qq.com");
+		assertThat(result).isNotNull().isEqualTo(expected);
+	}
+
+	@Test
+	void findValueWithJavaType() {
+		Map<String, Object> map = JsonNodeUtils.findValue(node, "info",
+				TypeFactoryUtils.javaType(JsonNodeUtils.STRING_OBJECT_MAP), mapper);
+		assertThat(map).containsExactlyInAnyOrderEntriesOf(Map.of("name", "livk", "email", "1375632510@qq.com"));
+	}
+
+	@Test
+	void findValueWithNullNodeReturnsNull() {
+		assertThat(JsonNodeUtils.findValue(null, "info", JsonNodeUtils.STRING_OBJECT_MAP, mapper)).isNull();
+	}
+
+	@Test
+	void findValueWithMissingFieldReturnsNull() {
+		assertThat(JsonNodeUtils.findValue(node, "nonexistent", JsonNodeUtils.STRING_OBJECT_MAP, mapper)).isNull();
+	}
+
+	@Test
+	void findValueWithNonContainerFieldReturnsNull() {
+		assertThat(JsonNodeUtils.findValue(node, "username", JsonNodeUtils.STRING_OBJECT_MAP, mapper)).isNull();
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/TypeFactoryUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/TypeFactoryUtilsTests.java
@@ -22,11 +22,8 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.type.CollectionType;
 import tools.jackson.databind.type.MapType;
-import tools.jackson.databind.type.SimpleType;
-import tools.jackson.databind.type.TypeBindings;
 import tools.jackson.databind.type.TypeFactory;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,73 +35,151 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class TypeFactoryUtilsTests {
 
-	static SimpleType strType = SimpleType.constructUnsafe(String.class);
+	@Test
+	void instanceReturnsTypeFactory() {
+		assertThat(TypeFactoryUtils.instance()).isNotNull().isInstanceOf(TypeFactory.class);
+	}
+
+	// --- javaType from Class ---
 
 	@Test
-	void instance() {
-		assertThat(TypeFactoryUtils.instance()).isNotNull();
+	void javaTypeFromClass() {
+		JavaType type = TypeFactoryUtils.javaType(String.class);
+		assertThat(type.getRawClass()).isEqualTo(String.class);
+		assertThat(type.hasGenericTypes()).isFalse();
 	}
 
 	@Test
-	void testJavaTypeForSimpleType() {
-		assertThat(TypeFactoryUtils.javaType(String.class)).isEqualTo(strType);
-		assertThat(TypeFactoryUtils.javaType(new TypeReference<String>() {
-		})).isEqualTo(strType);
-		assertThat(TypeFactoryUtils.javaType(ResolvableType.forClass(String.class))).isEqualTo(strType);
+	void javaTypeFromClassWithClassGenerics() {
+		JavaType type = TypeFactoryUtils.javaType(List.class, String.class);
+		assertThat(type.getRawClass()).isEqualTo(List.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
 	}
 
 	@Test
-	void testJavaTypeForListType() {
-		TypeBindings bindings = TypeBindings.createIfNeeded(List.class, strType);
-		CollectionType collectionType = CollectionType.construct(List.class, bindings,
-				SimpleType.constructUnsafe(Collection.class), null, strType);
+	void javaTypeFromClassWithJavaTypeGenerics() {
+		JavaType strType = TypeFactoryUtils.javaType(String.class);
+		JavaType type = TypeFactoryUtils.javaType(List.class, strType);
+		assertThat(type.getRawClass()).isEqualTo(List.class);
+		assertThat(type.getBindings().getBoundType(0)).isEqualTo(strType);
+	}
 
-		assertThat(TypeFactoryUtils.javaType(List.class, String.class)).isEqualTo(collectionType);
-		assertThat(TypeFactoryUtils.javaType(List.class, strType)).isEqualTo(collectionType);
-		assertThat(TypeFactoryUtils.javaType(new TypeReference<List<String>>() {
-		})).isEqualTo(collectionType);
-		assertThat(TypeFactoryUtils.javaType(ResolvableType.forClassWithGenerics(List.class, String.class)))
-			.isEqualTo(collectionType);
+	// --- javaType from TypeReference ---
+
+	@Test
+	void javaTypeFromTypeReferenceSimple() {
+		JavaType type = TypeFactoryUtils.javaType(new TypeReference<String>() {
+		});
+		assertThat(type.getRawClass()).isEqualTo(String.class);
 	}
 
 	@Test
-	void testJavaTypeForMapType() {
-		TypeBindings bindings = TypeBindings.createIfNeeded(Map.class, new JavaType[] { strType, strType });
-		MapType mapType = MapType.construct(Map.class, bindings, TypeFactory.unknownType(), null, strType, strType);
-
-		assertThat(TypeFactoryUtils.javaType(Map.class, String.class, String.class)).isEqualTo(mapType);
-		assertThat(TypeFactoryUtils.javaType(Map.class, strType, strType)).isEqualTo(mapType);
-		assertThat(TypeFactoryUtils.javaType(new TypeReference<Map<String, String>>() {
-		})).isEqualTo(mapType);
-		assertThat(
-				TypeFactoryUtils.javaType(ResolvableType.forClassWithGenerics(Map.class, String.class, String.class)))
-			.isEqualTo(mapType);
+	void javaTypeFromTypeReferenceParameterized() {
+		JavaType type = TypeFactoryUtils.javaType(new TypeReference<List<String>>() {
+		});
+		assertThat(type.getRawClass()).isEqualTo(List.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
 	}
 
 	@Test
-	void listType() {
-		TypeBindings bindings = TypeBindings.createIfNeeded(List.class, strType);
-		CollectionType listType = CollectionType.construct(List.class, bindings,
-				SimpleType.constructUnsafe(Iterable.class), null, strType);
-		assertThat(TypeFactoryUtils.listType(String.class)).isEqualTo(listType);
-		assertThat(TypeFactoryUtils.listType(strType)).isEqualTo(listType);
+	void javaTypeFromTypeReferenceMap() {
+		JavaType type = TypeFactoryUtils.javaType(new TypeReference<Map<String, Integer>>() {
+		});
+		assertThat(type.getRawClass()).isEqualTo(Map.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+		assertThat(type.getBindings().getBoundType(1).getRawClass()).isEqualTo(Integer.class);
+	}
+
+	// --- javaType from ResolvableType ---
+
+	@Test
+	void javaTypeFromResolvableTypeSimple() {
+		JavaType type = TypeFactoryUtils.javaType(ResolvableType.forClass(String.class));
+		assertThat(type.getRawClass()).isEqualTo(String.class);
 	}
 
 	@Test
-	void setType() {
-		TypeBindings bindings = TypeBindings.createIfNeeded(Set.class, strType);
-		CollectionType setType = CollectionType.construct(Set.class, bindings,
-				SimpleType.constructUnsafe(Iterable.class), null, strType);
-		assertThat(TypeFactoryUtils.setType(String.class)).isEqualTo(setType);
-		assertThat(TypeFactoryUtils.setType(strType)).isEqualTo(setType);
+	void javaTypeFromResolvableTypeParameterized() {
+		JavaType type = TypeFactoryUtils.javaType(ResolvableType.forClassWithGenerics(List.class, String.class));
+		assertThat(type.getRawClass()).isEqualTo(List.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
 	}
 
 	@Test
-	void mapType() {
-		TypeBindings bindings = TypeBindings.createIfNeeded(Map.class, new JavaType[] { strType, strType });
-		MapType mapType = MapType.construct(Map.class, bindings, TypeFactory.unknownType(), null, strType, strType);
-		assertThat(TypeFactoryUtils.mapType(String.class, String.class)).isEqualTo(mapType);
-		assertThat(TypeFactoryUtils.mapType(strType, strType)).isEqualTo(mapType);
+	void javaTypeFromResolvableTypeMap() {
+		JavaType type = TypeFactoryUtils
+			.javaType(ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class));
+		assertThat(type.getRawClass()).isEqualTo(Map.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+		assertThat(type.getBindings().getBoundType(1).getRawClass()).isEqualTo(Integer.class);
+	}
+
+	// --- listType ---
+
+	@Test
+	void listTypeFromClass() {
+		CollectionType type = TypeFactoryUtils.listType(String.class);
+		assertThat(type.getRawClass()).isEqualTo(List.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+	}
+
+	@Test
+	void listTypeFromJavaType() {
+		JavaType strType = TypeFactoryUtils.javaType(String.class);
+		CollectionType type = TypeFactoryUtils.listType(strType);
+		assertThat(type.getRawClass()).isEqualTo(List.class);
+		assertThat(type.getBindings().getBoundType(0)).isEqualTo(strType);
+	}
+
+	// --- setType ---
+
+	@Test
+	void setTypeFromClass() {
+		CollectionType type = TypeFactoryUtils.setType(String.class);
+		assertThat(type.getRawClass()).isEqualTo(Set.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+	}
+
+	@Test
+	void setTypeFromJavaType() {
+		JavaType strType = TypeFactoryUtils.javaType(String.class);
+		CollectionType type = TypeFactoryUtils.setType(strType);
+		assertThat(type.getRawClass()).isEqualTo(Set.class);
+		assertThat(type.getBindings().getBoundType(0)).isEqualTo(strType);
+	}
+
+	// --- mapType ---
+
+	@Test
+	void mapTypeFromClasses() {
+		MapType type = TypeFactoryUtils.mapType(String.class, Integer.class);
+		assertThat(type.getRawClass()).isEqualTo(Map.class);
+		assertThat(type.getBindings().getBoundType(0).getRawClass()).isEqualTo(String.class);
+		assertThat(type.getBindings().getBoundType(1).getRawClass()).isEqualTo(Integer.class);
+	}
+
+	@Test
+	void mapTypeFromJavaTypes() {
+		JavaType strType = TypeFactoryUtils.javaType(String.class);
+		JavaType intType = TypeFactoryUtils.javaType(Integer.class);
+		MapType type = TypeFactoryUtils.mapType(strType, intType);
+		assertThat(type.getRawClass()).isEqualTo(Map.class);
+		assertThat(type.getBindings().getBoundType(0)).isEqualTo(strType);
+		assertThat(type.getBindings().getBoundType(1)).isEqualTo(intType);
+	}
+
+	// --- cross-method consistency ---
+
+	@Test
+	void allJavaTypeOverloadsProduceConsistentResults() {
+		JavaType fromClass = TypeFactoryUtils.javaType(List.class, String.class);
+		JavaType fromTypeRef = TypeFactoryUtils.javaType(new TypeReference<List<String>>() {
+		});
+		JavaType fromResolvable = TypeFactoryUtils
+			.javaType(ResolvableType.forClassWithGenerics(List.class, String.class));
+
+		assertThat(fromClass).isEqualTo(fromTypeRef);
+		assertThat(fromTypeRef).isEqualTo(fromResolvable);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/serializer/NumberJsonSerializerTests.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.within;
 class NumberJsonSerializerTests {
 
 	@Test
-	void test() {
+	void serializesNumberFieldsWithCustomFormat() {
 		Big big = new Big();
 		big.l = 33L;
 		big.d = 0.333333d;

--- a/spring-extension-commons/src/test/java/com/livk/commons/jackson/support/JacksonSupportTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/jackson/support/JacksonSupportTests.java
@@ -78,6 +78,13 @@ class JacksonSupportTests {
 			</pro>
 			""";
 
+	private static void assertJsonContent(JsonNode node) {
+		assertThat(node).isNotNull();
+		assertThat(node.get("c").asString()).isEqualTo("1");
+		assertThat(node.get("a").asString()).isEqualTo("2");
+		assertThat(node.get("b").get("c").asInt()).isEqualTo(3);
+	}
+
 	@Test
 	void javaType() {
 		assertThat(TypeFactoryUtils.javaType(String.class).getRawClass()).isEqualTo(String.class);
@@ -114,93 +121,44 @@ class JacksonSupportTests {
 
 	@Test
 	void testJsonReadValue() throws IOException {
-		JsonNode result1 = JSON.readValue(json, JsonNode.class);
-		assertThat(result1).isNotNull();
-		assertThat(result1.get("c").asString()).isEqualTo("1");
-		assertThat(result1.get("a").asString()).isEqualTo("2");
-		assertThat(result1.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JSON.readValue(json, JsonNode.class));
 
 		InputStream inputStream = new ClassPathResource("input.json").getInputStream();
-		JsonNode result2 = JSON.readValue(inputStream, JsonNode.class);
-		assertThat(result2).isNotNull();
-		assertThat(result2.get("c").asString()).isEqualTo("1");
-		assertThat(result2.get("a").asString()).isEqualTo("2");
-		assertThat(result2.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JSON.readValue(inputStream, JsonNode.class));
 
-		JsonNode result3 = JSON.readValue(json, new TypeReference<>() {
-		});
-		assertThat(result3).isNotNull();
-		assertThat(result3.get("c").asString()).isEqualTo("1");
-		assertThat(result3.get("a").asString()).isEqualTo("2");
-		assertThat(result3.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JSON.readValue(json, new TypeReference<>() {
+		}));
 
 		JavaType javaType = TypeFactoryUtils.javaType(JsonNode.class);
-		JsonNode result4 = JSON.readValue(json, javaType);
-		assertThat(result4).isNotNull();
-		assertThat(result4.get("c").asString()).isEqualTo("1");
-		assertThat(result4.get("a").asString()).isEqualTo("2");
-		assertThat(result4.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JSON.readValue(json, javaType));
 	}
 
 	@Test
 	void testYamlReadValue() throws IOException {
-		JsonNode result1 = YAML.readValue(yaml, JsonNode.class);
-		assertThat(result1).isNotNull();
-		assertThat(result1.get("c").asString()).isEqualTo("1");
-		assertThat(result1.get("a").asString()).isEqualTo("2");
-		assertThat(result1.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(YAML.readValue(yaml, JsonNode.class));
 
 		InputStream inputStream = new ClassPathResource("input.yml").getInputStream();
-		JsonNode result2 = YAML.readValue(inputStream, JsonNode.class);
-		assertThat(result2).isNotNull();
-		assertThat(result2.get("c").asString()).isEqualTo("1");
-		assertThat(result2.get("a").asString()).isEqualTo("2");
-		assertThat(result2.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(YAML.readValue(inputStream, JsonNode.class));
 
-		JsonNode result3 = YAML.readValue(yaml, new TypeReference<>() {
-		});
-		assertThat(result3).isNotNull();
-		assertThat(result3.get("c").asString()).isEqualTo("1");
-		assertThat(result3.get("a").asString()).isEqualTo("2");
-		assertThat(result3.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(YAML.readValue(yaml, new TypeReference<>() {
+		}));
 
 		JavaType javaType = TypeFactoryUtils.javaType(JsonNode.class);
-		JsonNode result4 = YAML.readValue(yaml, javaType);
-		assertThat(result4).isNotNull();
-		assertThat(result4.get("c").asString()).isEqualTo("1");
-		assertThat(result4.get("a").asString()).isEqualTo("2");
-		assertThat(result4.get("b").get("c").asInt()).isEqualTo(3);
-
+		assertJsonContent(YAML.readValue(yaml, javaType));
 	}
 
 	@Test
 	void testXmlReadValue() throws IOException {
-		JsonNode result1 = XML.readValue(xml, JsonNode.class);
-		assertThat(result1).isNotNull();
-		assertThat(result1.get("c").asString()).isEqualTo("1");
-		assertThat(result1.get("a").asString()).isEqualTo("2");
-		assertThat(result1.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(XML.readValue(xml, JsonNode.class));
 
 		InputStream inputStream = new ClassPathResource("input.xml").getInputStream();
-		JsonNode result2 = XML.readValue(inputStream, JsonNode.class);
-		assertThat(result2).isNotNull();
-		assertThat(result2.get("c").asString()).isEqualTo("1");
-		assertThat(result2.get("a").asString()).isEqualTo("2");
-		assertThat(result2.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(XML.readValue(inputStream, JsonNode.class));
 
-		JsonNode result3 = XML.readValue(xml, new TypeReference<>() {
-		});
-		assertThat(result3).isNotNull();
-		assertThat(result3.get("c").asString()).isEqualTo("1");
-		assertThat(result3.get("a").asString()).isEqualTo("2");
-		assertThat(result3.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(XML.readValue(xml, new TypeReference<>() {
+		}));
 
 		JavaType javaType = TypeFactoryUtils.javaType(JsonNode.class);
-		JsonNode result4 = XML.readValue(xml, javaType);
-		assertThat(result4).isNotNull();
-		assertThat(result4.get("c").asString()).isEqualTo("1");
-		assertThat(result4.get("a").asString()).isEqualTo("2");
-		assertThat(result4.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(XML.readValue(xml, javaType));
 	}
 
 	@Test
@@ -241,23 +199,9 @@ class JacksonSupportTests {
 
 	@Test
 	void testReadTree() {
-		JsonNode jsonNode = JSON.readTree(json);
-		assertThat(jsonNode).isNotNull();
-		assertThat(jsonNode.get("c").asString()).isEqualTo("1");
-		assertThat(jsonNode.get("a").asString()).isEqualTo("2");
-		assertThat(jsonNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		JsonNode yamlNode = YAML.readTree(yaml);
-		assertThat(yamlNode).isNotNull();
-		assertThat(yamlNode.get("c").asString()).isEqualTo("1");
-		assertThat(yamlNode.get("a").asString()).isEqualTo("2");
-		assertThat(yamlNode.get("b").get("c").asInt()).isEqualTo(3);
-
-		JsonNode xmlNode = XML.readTree(xml);
-		assertThat(xmlNode).isNotNull();
-		assertThat(xmlNode.get("c").asString()).isEqualTo("1");
-		assertThat(xmlNode.get("a").asString()).isEqualTo("2");
-		assertThat(xmlNode.get("b").get("c").asInt()).isEqualTo(3);
+		assertJsonContent(JSON.readTree(json));
+		assertJsonContent(YAML.readTree(yaml));
+		assertJsonContent(XML.readTree(xml));
 	}
 
 	@Test

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationMetadataResolverTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationMetadataResolverTests.java
@@ -21,6 +21,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.stereotype.Controller;
 
 import java.lang.annotation.ElementType;
@@ -35,18 +36,64 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AnnotationMetadataResolverTests {
 
+	static final String CURRENT_PACKAGE = AnnotationMetadataResolverTests.class.getPackageName();
+
 	final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withUserConfiguration(Config.class);
 
 	@Test
-	void find() {
+	void findByAnnotationAndPackages() {
+		AnnotationMetadataResolver resolver = new AnnotationMetadataResolver();
+		assertThat(resolver.find(TestAnnotation.class, CURRENT_PACKAGE)).containsExactlyInAnyOrder(A.class,
+				TestController.class);
+	}
+
+	@Test
+	void findByAnnotationAndBeanFactory() {
 		contextRunner.run(ctx -> {
 			AnnotationMetadataResolver resolver = new AnnotationMetadataResolver(ctx);
-
-			assertThat(resolver.find(TestAnnotation.class, AnnotationMetadataResolverTests.class.getPackageName()))
-				.containsExactlyInAnyOrder(A.class, TestController.class);
-
 			assertThat(resolver.find(TestAnnotation.class, ctx)).containsExactlyInAnyOrder(A.class,
 					TestController.class);
+		});
+	}
+
+	@Test
+	void findByTypeFilter() {
+		AnnotationMetadataResolver resolver = new AnnotationMetadataResolver();
+		assertThat(resolver.find(new AnnotationTypeFilter(TestAnnotation.class), CURRENT_PACKAGE))
+			.containsExactlyInAnyOrder(A.class, TestController.class);
+	}
+
+	@Test
+	void findWithEmptyPackagesReturnsEmpty() {
+		AnnotationMetadataResolver resolver = new AnnotationMetadataResolver();
+		assertThat(resolver.find(TestAnnotation.class)).isEmpty();
+	}
+
+	@Test
+	void findWithNonexistentPackageReturnsEmpty() {
+		AnnotationMetadataResolver resolver = new AnnotationMetadataResolver();
+		assertThat(resolver.find(TestAnnotation.class, "com.livk.nonexistent")).isEmpty();
+	}
+
+	@Test
+	void findDetectsMetaAnnotation() {
+		// A is annotated with @TestController which is meta-annotated with
+		// @TestAnnotation
+		AnnotationMetadataResolver resolver = new AnnotationMetadataResolver();
+		assertThat(resolver.find(TestAnnotation.class, CURRENT_PACKAGE)).contains(A.class);
+	}
+
+	@Test
+	void defaultConstructorUsesDefaultResourceLoader() {
+		AnnotationMetadataResolver resolver = new AnnotationMetadataResolver();
+		assertThat(resolver.getResourceLoader()).isNotNull();
+	}
+
+	@Test
+	void resourceLoaderConstructorPreservesLoader() {
+		contextRunner.run(ctx -> {
+			AnnotationMetadataResolver resolver = new AnnotationMetadataResolver(ctx);
+			assertThat(resolver.getResourceLoader()).isSameAs(ctx);
 		});
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/AnnotationUtilsTests.java
@@ -45,48 +45,109 @@ class AnnotationUtilsTests {
 	AnnotationUtilsTests() throws NoSuchMethodException {
 	}
 
-	@Test
-	void getAnnotationElement() {
-		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RequestMapping.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, GetMapping.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, Controller.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RestController.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RequestBody.class)).isNull();
+	// --- getAnnotationElement(MethodParameter, Class) ---
 
-		assertThat(AnnotationUtils.getAnnotationElement(method, RequestMapping.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(method, GetMapping.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(method, Controller.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(method, RestController.class)).isNotNull();
-		assertThat(AnnotationUtils.getAnnotationElement(method, RequestBody.class)).isNull();
+	@Test
+	void getAnnotationElementFromMethodParameterFindsMethodAnnotation() {
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, GetMapping.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RequestMapping.class)).isNotNull();
 	}
 
 	@Test
-	void hasAnnotationElement() {
+	void getAnnotationElementFromMethodParameterFallsBackToClassAnnotation() {
+		// @Controller and @RestController are on the class, not the method
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, Controller.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RestController.class)).isNotNull();
+	}
+
+	@Test
+	void getAnnotationElementFromMethodParameterReturnsNullWhenAbsent() {
+		assertThat(AnnotationUtils.getAnnotationElement(methodParameter, RequestBody.class)).isNull();
+	}
+
+	// --- getAnnotationElement(Method, Class) ---
+
+	@Test
+	void getAnnotationElementFromMethodFindsMethodAnnotation() {
+		assertThat(AnnotationUtils.getAnnotationElement(method, GetMapping.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(method, RequestMapping.class)).isNotNull();
+	}
+
+	@Test
+	void getAnnotationElementFromMethodFallsBackToClassAnnotation() {
+		assertThat(AnnotationUtils.getAnnotationElement(method, Controller.class)).isNotNull();
+		assertThat(AnnotationUtils.getAnnotationElement(method, RestController.class)).isNotNull();
+	}
+
+	@Test
+	void getAnnotationElementFromMethodReturnsNullWhenAbsent() {
+		assertThat(AnnotationUtils.getAnnotationElement(method, RequestBody.class)).isNull();
+	}
+
+	// --- hasAnnotationElement(MethodParameter, Class) ---
+
+	@Test
+	void hasAnnotationElementFromMethodParameterReturnsTrueForPresent() {
 		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RequestMapping.class)).isTrue();
 		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, GetMapping.class)).isTrue();
 		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, Controller.class)).isTrue();
 		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RestController.class)).isTrue();
-		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RequestBody.class)).isFalse();
-
-		assertThat(AnnotationUtils.hasAnnotationElement(method, RequestMapping.class)).isTrue();
-		assertThat(AnnotationUtils.hasAnnotationElement(method, Controller.class)).isTrue();
-		assertThat(AnnotationUtils.hasAnnotationElement(method, RestController.class)).isTrue();
-		assertThat(AnnotationUtils.hasAnnotationElement(method, RequestBody.class)).isFalse();
 	}
 
 	@Test
-	void test() {
-		AnnotationMetadata annotationMetadata = AnnotationMetadata.introspect(AnnotationTestClass.class);
-		Set<MethodMetadata> methods = annotationMetadata.getAnnotatedMethods(RequestMapping.class.getName());
-		for (MethodMetadata metadata : methods) {
-			AnnotationAttributes attributes = AnnotationUtils.attributesFor(metadata, RequestMapping.class);
+	void hasAnnotationElementFromMethodParameterReturnsFalseForAbsent() {
+		assertThat(AnnotationUtils.hasAnnotationElement(methodParameter, RequestBody.class)).isFalse();
+	}
+
+	// --- hasAnnotationElement(Method, Class) ---
+
+	@Test
+	void hasAnnotationElementFromMethodReturnsTrueForPresent() {
+		assertThat(AnnotationUtils.hasAnnotationElement(method, RequestMapping.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(method, Controller.class)).isTrue();
+		assertThat(AnnotationUtils.hasAnnotationElement(method, RestController.class)).isTrue();
+	}
+
+	@Test
+	void hasAnnotationElementFromMethodReturnsFalseForAbsent() {
+		assertThat(AnnotationUtils.hasAnnotationElement(method, RequestBody.class)).isFalse();
+	}
+
+	// --- attributesFor ---
+
+	@Test
+	void attributesForWithClassReturnsAttributes() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(AnnotationTestClass.class);
+		Set<MethodMetadata> methods = metadata.getAnnotatedMethods(RequestMapping.class.getName());
+		assertThat(methods).isNotEmpty();
+		for (MethodMetadata methodMetadata : methods) {
+			AnnotationAttributes attributes = AnnotationUtils.attributesFor(methodMetadata, RequestMapping.class);
+			assertThat(attributes).isNotNull();
+		}
+	}
+
+	@Test
+	void attributesForWithStringReturnsAttributes() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(AnnotationTestClass.class);
+		Set<MethodMetadata> methods = metadata.getAnnotatedMethods(RequestMapping.class.getName());
+		assertThat(methods).isNotEmpty();
+		for (MethodMetadata methodMetadata : methods) {
+			AnnotationAttributes attributes = AnnotationUtils.attributesFor(methodMetadata,
+					RequestMapping.class.getName());
+			assertThat(attributes).isNotNull();
+		}
+	}
+
+	// --- getValue ---
+
+	@Test
+	void getValueExtractsEnumArray() {
+		AnnotationMetadata metadata = AnnotationMetadata.introspect(AnnotationTestClass.class);
+		Set<MethodMetadata> methods = metadata.getAnnotatedMethods(RequestMapping.class.getName());
+		for (MethodMetadata methodMetadata : methods) {
+			AnnotationAttributes attributes = AnnotationUtils.attributesFor(methodMetadata, RequestMapping.class);
 			RequestMethod[] requestMethods = AnnotationUtils.getValue(attributes, "method");
 			assertThat(requestMethods).containsExactly(RequestMethod.GET);
-
-			AnnotationAttributes attributesFor = AnnotationUtils.attributesFor(metadata,
-					RequestMapping.class.getName());
-			RequestMethod[] requestMethodsArr = AnnotationUtils.getValue(attributesFor, "method");
-			assertThat(requestMethodsArr).containsExactly(RequestMethod.GET);
 		}
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaDescriptorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaDescriptorTests.java
@@ -29,37 +29,79 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class BeanLambdaDescriptorTests {
 
+	final BeanLambdaDescriptor noDescriptor = BeanLambdaDescriptor.create(Maker::getNo);
+
+	final BeanLambdaDescriptor usernameDescriptor = BeanLambdaDescriptor.create(Maker::getUsername);
+
 	@Test
-	void create() {
-		assertThat(BeanLambdaDescriptor.create(Maker::getNo)).isNotNull();
+	void createReturnsNonNull() {
+		assertThat(noDescriptor).isNotNull();
+		assertThat(usernameDescriptor).isNotNull();
 	}
 
 	@Test
-	void getFieldName() {
-		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getFieldName()).isEqualTo("no");
+	void createReturnsCachedInstance() {
+		BeanLambdaDescriptor another = BeanLambdaDescriptor.create(Maker::getNo);
+		assertThat(another).isSameAs(noDescriptor);
 	}
 
 	@Test
-	void getField() throws NoSuchFieldException {
-		Field field = Maker.class.getDeclaredField("no");
-		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getField()).isEqualTo(field);
+	void createReturnsDifferentInstancesForDifferentLambdas() {
+		assertThat(noDescriptor).isNotSameAs(usernameDescriptor);
 	}
 
 	@Test
-	void getMethodName() {
-		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getMethodName()).isEqualTo("getNo");
+	void getFieldNameForNo() {
+		assertThat(noDescriptor.getFieldName()).isEqualTo("no");
 	}
 
 	@Test
-	void getMethod() throws NoSuchMethodException {
-		Method method = Maker.class.getMethod("getNo");
-		assertThat(BeanLambdaDescriptor.create(Maker::getNo).getMethod()).isEqualTo(method);
+	void getFieldNameForUsername() {
+		assertThat(usernameDescriptor.getFieldName()).isEqualTo("username");
+	}
+
+	@Test
+	void getFieldReturnsCorrectField() throws NoSuchFieldException {
+		Field expected = Maker.class.getDeclaredField("no");
+		assertThat(noDescriptor.getField()).isEqualTo(expected);
+		assertThat(noDescriptor.getField().getType()).isEqualTo(Integer.class);
+	}
+
+	@Test
+	void getFieldForUsernameReturnsCorrectField() throws NoSuchFieldException {
+		Field expected = Maker.class.getDeclaredField("username");
+		assertThat(usernameDescriptor.getField()).isEqualTo(expected);
+		assertThat(usernameDescriptor.getField().getType()).isEqualTo(String.class);
+	}
+
+	@Test
+	void getMethodNameForNo() {
+		assertThat(noDescriptor.getMethodName()).isEqualTo("getNo");
+	}
+
+	@Test
+	void getMethodNameForUsername() {
+		assertThat(usernameDescriptor.getMethodName()).isEqualTo("getUsername");
+	}
+
+	@Test
+	void getMethodReturnsCorrectMethod() throws NoSuchMethodException {
+		Method expected = Maker.class.getMethod("getNo");
+		assertThat(noDescriptor.getMethod()).isEqualTo(expected);
+	}
+
+	@Test
+	void getMethodForUsernameReturnsCorrectMethod() throws NoSuchMethodException {
+		Method expected = Maker.class.getMethod("getUsername");
+		assertThat(usernameDescriptor.getMethod()).isEqualTo(expected);
 	}
 
 	@Data
 	static class Maker {
 
 		private Integer no;
+
+		private String username;
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanLambdaTests.java
@@ -19,9 +19,6 @@ package com.livk.commons.util;
 import lombok.Data;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -29,33 +26,34 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class BeanLambdaTests {
 
-	final Field field1 = Maker.class.getDeclaredField("no");
-
-	final Field field2 = Maker.class.getDeclaredField("username");
-
-	final Method method1 = Maker.class.getMethod("getNo");
-
-	final Method method2 = Maker.class.getMethod("getUsername");
-
-	BeanLambdaTests() throws NoSuchFieldException, NoSuchMethodException {
+	@Test
+	void methodNameReturnsGetterName() {
+		assertThat(BeanLambda.methodName(Maker::getNo)).isEqualTo("getNo");
+		assertThat(BeanLambda.methodName(Maker::getUsername)).isEqualTo("getUsername");
 	}
 
 	@Test
-	void method() {
-		assertThat(BeanLambda.methodName(Maker::getNo)).isEqualTo(method1.getName());
-		assertThat(BeanLambda.methodName(Maker::getUsername)).isEqualTo(method2.getName());
-
-		assertThat(BeanLambda.method(Maker::getNo)).isEqualTo(method1);
-		assertThat(BeanLambda.method(Maker::getUsername)).isEqualTo(method2);
+	void methodReturnsGetterMethod() throws NoSuchMethodException {
+		assertThat(BeanLambda.method(Maker::getNo)).isEqualTo(Maker.class.getMethod("getNo"));
+		assertThat(BeanLambda.method(Maker::getUsername)).isEqualTo(Maker.class.getMethod("getUsername"));
 	}
 
 	@Test
-	void field() {
-		assertThat(BeanLambda.fieldName(Maker::getNo)).isEqualTo(field1.getName());
-		assertThat(BeanLambda.fieldName(Maker::getUsername)).isEqualTo(field2.getName());
+	void fieldNameReturnsPropertyName() {
+		assertThat(BeanLambda.fieldName(Maker::getNo)).isEqualTo("no");
+		assertThat(BeanLambda.fieldName(Maker::getUsername)).isEqualTo("username");
+	}
 
-		assertThat(BeanLambda.field(Maker::getNo)).isEqualTo(field1);
-		assertThat(BeanLambda.field(Maker::getUsername)).isEqualTo(field2);
+	@Test
+	void fieldReturnsMatchingDeclaredField() throws NoSuchFieldException {
+		assertThat(BeanLambda.field(Maker::getNo)).isEqualTo(Maker.class.getDeclaredField("no"));
+		assertThat(BeanLambda.field(Maker::getUsername)).isEqualTo(Maker.class.getDeclaredField("username"));
+	}
+
+	@Test
+	void fieldTypeMatchesPropertyType() {
+		assertThat(BeanLambda.field(Maker::getNo).getType()).isEqualTo(Integer.class);
+		assertThat(BeanLambda.field(Maker::getUsername).getType()).isEqualTo(String.class);
 	}
 
 	@Data

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/BeanUtilsTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,52 +35,90 @@ class BeanUtilsTests {
 
 	static final SourceBean bean = new SourceBean("source", 10);
 
-	static final List<SourceBean> beanList = List.of(new SourceBean("source", 10), new SourceBean("target", 9));
+	// --- copy(Object, Class) ---
 
 	@Test
-	void copy() {
+	void copyWithClass() {
 		TargetBean result = BeanUtils.copy(bean, TargetBean.class);
-		TargetBean targetBean = new TargetBean("source", 10);
-		assertThat(result).isEqualTo(targetBean);
+		assertThat(result).isEqualTo(new TargetBean("source", 10));
 	}
 
 	@Test
-	void copySupplier() {
-		TargetBean result = BeanUtils.copy(bean, TargetBean::new);
-		TargetBean targetBean = new TargetBean("source", 10);
-		assertThat(result).isEqualTo(targetBean);
+	void copyWithNullSourceReturnsEmptyTarget() {
+		TargetBean result = BeanUtils.copy(null, TargetBean.class);
+		assertThat(result).isNotNull();
+		assertThat(result.getBeanName()).isNull();
+		assertThat(result.getBeanNo()).isNull();
 	}
+
+	// --- copy(Object, Supplier) ---
+
+	@Test
+	void copyWithSupplier() {
+		TargetBean result = BeanUtils.copy(bean, TargetBean::new);
+		assertThat(result).isEqualTo(new TargetBean("source", 10));
+	}
+
+	@Test
+	void copyWithNullSupplierReturnsNull() {
+		TargetBean result = BeanUtils.copy(bean, (Supplier<TargetBean>) null);
+		assertThat(result).isNull();
+	}
+
+	// --- copyList ---
 
 	@Test
 	void copyList() {
-		List<TargetBean> result = BeanUtils.copyList(beanList, TargetBean.class);
-		List<TargetBean> targetBeans = List.of(new TargetBean("source", 10), new TargetBean("target", 9));
-		assertThat(result).isEqualTo(targetBeans);
+		List<SourceBean> sourceList = List.of(new SourceBean("source", 10), new SourceBean("target", 9));
+		List<TargetBean> result = BeanUtils.copyList(sourceList, TargetBean.class);
+		assertThat(result).containsExactly(new TargetBean("source", 10), new TargetBean("target", 9));
 	}
 
 	@Test
-	void testConvertTargetBean() {
-		TargetBean source = new TargetBean("source", 10);
-		Map<String, Object> convert = BeanUtils.convert(source);
+	void copyListWithEmptyListReturnsEmpty() {
+		List<TargetBean> result = BeanUtils.copyList(List.of(), TargetBean.class);
+		assertThat(result).isEmpty();
+	}
 
-		assertThat(convert).containsEntry("beanName", "source")
+	// --- convert(Object) -> Map ---
+
+	@Test
+	void convertBeanToMap() {
+		TargetBean source = new TargetBean("source", 10);
+		Map<String, Object> map = BeanUtils.convert(source);
+		assertThat(map).containsEntry("beanName", "source")
 			.containsEntry("beanNo", 10)
 			.containsEntry("class", TargetBean.class);
+	}
 
-		TargetBean target = BeanUtils.convert(convert);
+	@Test
+	void convertBeanToMapIsUnmodifiable() {
+		Map<String, Object> map = BeanUtils.convert(new TargetBean("x", 1));
+		assertThatThrownBy(() -> map.put("new", "value")).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	// --- convert(Map) -> Bean ---
+
+	@Test
+	void convertMapToBean() {
+		TargetBean source = new TargetBean("source", 10);
+		Map<String, Object> map = BeanUtils.convert(source);
+		TargetBean target = BeanUtils.convert(map);
 		assertThat(target).isEqualTo(source);
 	}
 
 	@Test
-	void testConvertSourceBeanWithMissingNoArgConstructor() {
+	void convertMapWithoutClassKeyThrows() {
+		Map<String, Object> map = Map.of("beanName", "source");
+		assertThatThrownBy(() -> BeanUtils.convert(map)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("class must not be null");
+	}
+
+	@Test
+	void convertMapWithNoArgConstructorMissingThrows() {
 		SourceBean source = new SourceBean("source", 10);
-		Map<String, Object> convert = BeanUtils.convert(source);
-
-		assertThat(convert).containsEntry("beanName", "source")
-			.containsEntry("beanNo", 10)
-			.containsEntry("class", SourceBean.class);
-
-		assertThatThrownBy(() -> BeanUtils.convert(convert)).isInstanceOf(IllegalArgumentException.class)
+		Map<String, Object> map = BeanUtils.convert(source);
+		assertThatThrownBy(() -> BeanUtils.convert(map)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Missing no-argument constructor");
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/ClassUtilsTests.java
@@ -35,43 +35,117 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class ClassUtilsTests {
 
+	// --- toClass ---
+
 	@Test
-	void toClassTest() {
+	void toClassFromPlainClass() {
 		assertThat(ClassUtils.toClass(String.class)).isEqualTo(String.class);
+	}
 
-		Type listType = new ListType();
-		assertThat(ClassUtils.toClass(listType)).isEqualTo(List.class);
+	@Test
+	void toClassFromParameterizedType() {
+		assertThat(ClassUtils.toClass(new ListType())).isEqualTo(List.class);
+	}
 
+	@Test
+	void toClassFromTypeVariable() {
 		TypeVariable<?> typeVar = MyGeneric.class.getTypeParameters()[0];
 		assertThat(ClassUtils.toClass(typeVar)).isEqualTo(Number.class);
+	}
 
-		Type arrayType = new StringGenericArrayType();
-		assertThat(ClassUtils.toClass(arrayType)).isEqualTo(String[].class);
+	@Test
+	void toClassFromTypeVariableWithObjectBoundReturnsObject() {
+		TypeVariable<?> typeVar = UnboundedGeneric.class.getTypeParameters()[0];
+		assertThat(ClassUtils.toClass(typeVar)).isEqualTo(Object.class);
+	}
 
-		WildcardType wildcardType = new NumberWildcardType();
-		assertThat(ClassUtils.toClass(wildcardType)).isEqualTo(Number.class);
+	@Test
+	void toClassFromGenericArrayType() {
+		assertThat(ClassUtils.toClass(new StringGenericArrayType())).isEqualTo(String[].class);
+	}
 
+	@Test
+	void toClassFromWildcardTypeWithUpperBound() {
+		assertThat(ClassUtils.toClass(new NumberWildcardType())).isEqualTo(Number.class);
+	}
+
+	@Test
+	void toClassFromWildcardTypeWithLowerBound() {
+		WildcardType lowerBounded = new WildcardType() {
+			@NonNull
+			@Override
+			public Type[] getUpperBounds() {
+				return new Type[] { Object.class };
+			}
+
+			@NonNull
+			@Override
+			public Type[] getLowerBounds() {
+				return new Type[] { String.class };
+			}
+		};
+		assertThat(ClassUtils.toClass(lowerBounded)).isEqualTo(String.class);
+	}
+
+	@Test
+	void toClassWithNullThrows() {
 		assertThatThrownBy(() -> ClassUtils.toClass(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Type cannot be null");
 	}
 
+	// --- resolveTypeArgument ---
+
 	@Test
-	void resolveTypeArgument() {
+	void resolveTypeArgumentResolvesConcreteGeneric() {
+		assertThat(ClassUtils.resolveTypeArgument(IntGeneric.class, MyGeneric.class)).isEqualTo(Integer.class);
+	}
+
+	@Test
+	void resolveTypeArgumentThrowsWhenNoGenerics() {
 		assertThatThrownBy(() -> ClassUtils.resolveTypeArgument(NumberWildcardType.class, WildcardType.class))
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("No type arguments found on generic interface [" + WildcardType.class.getName() + "]");
-
-		assertThat(ClassUtils.resolveTypeArgument(IntGeneric.class, MyGeneric.class)).isEqualTo(Integer.class);
-
-		assertThatThrownBy(() -> ClassUtils.resolveTypeArgument(TypeMap.class, HashMap.class))
-			.isInstanceOf(IllegalArgumentException.class);
+			.hasMessageContaining("No type arguments found");
 	}
+
+	@Test
+	void resolveTypeArgumentThrowsWhenMultipleGenerics() {
+		assertThatThrownBy(() -> ClassUtils.resolveTypeArgument(TypeMap.class, HashMap.class))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Expected 1 type argument");
+	}
+
+	// --- resolveClassName / isPresent ---
+
+	@Test
+	void resolveClassNameResolvesExistingClass() {
+		assertThat(ClassUtils.resolveClassName("java.lang.String")).isEqualTo(String.class);
+	}
+
+	@Test
+	void isPresentReturnsTrueForExistingClass() {
+		assertThat(ClassUtils.isPresent("java.lang.String")).isTrue();
+	}
+
+	@Test
+	void isPresentReturnsFalseForNonexistentClass() {
+		assertThat(ClassUtils.isPresent("com.livk.nonexistent.FakeClass")).isFalse();
+	}
+
+	// --- test helper types ---
 
 	static class TypeMap extends HashMap<String, Type> {
 
 	}
 
 	static class IntGeneric extends MyGeneric<Integer> {
+
+	}
+
+	static class MyGeneric<T extends Number> {
+
+	}
+
+	static class UnboundedGeneric<T> {
 
 	}
 
@@ -119,10 +193,6 @@ class ClassUtilsTests {
 		public Type getOwnerType() {
 			return null;
 		}
-
-	}
-
-	static class MyGeneric<T extends Number> {
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/ContextSnapshotsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/ContextSnapshotsTests.java
@@ -84,20 +84,26 @@ class ContextSnapshotsTests {
 	}
 
 	@Test
-	void testWrapExecutorService() {
+	void testWrapExecutorService() throws Exception {
 		ExecutorService service = Executors.newSingleThreadExecutor();
 		ExecutorService wrapped = ContextSnapshots.wrap(service);
 
 		assertThat(wrapped).isNotNull();
+		AtomicBoolean executed = new AtomicBoolean(false);
+		wrapped.submit(() -> executed.set(true)).get();
+		assertThat(executed.get()).isTrue();
 		wrapped.shutdown();
 	}
 
 	@Test
-	void testWrapScheduledExecutorService() {
+	void testWrapScheduledExecutorService() throws Exception {
 		ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
 		ScheduledExecutorService wrapped = ContextSnapshots.wrap(service);
 
 		assertThat(wrapped).isNotNull();
+		AtomicBoolean executed = new AtomicBoolean(false);
+		wrapped.submit(() -> executed.set(true)).get();
+		assertThat(executed.get()).isTrue();
 		wrapped.shutdown();
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/GenericWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/GenericWrapperTests.java
@@ -30,19 +30,34 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GenericWrapperTests {
 
 	@Test
-	void test() {
+	void unwrapReturnsOriginalValue() {
 		String value = "livk";
-		StringBuilder builder = new StringBuilder(value).reverse();
-
 		GenericWrapper<String> wrapper = GenericWrapper.of(value);
 		assertThat(wrapper.unwrap()).isEqualTo(value);
+	}
 
-		GenericWrapper<String> map = GenericWrapper.of(reverse(wrapper.unwrap()));
-		assertThat(map.unwrap()).isEqualTo(builder.toString());
-		assertThat(map.unwrap()).isNotEqualTo(value);
+	@Test
+	void wrapTransformedValueReturnsTransformedResult() {
+		String value = "livk";
+		String reversed = new StringBuilder(value).reverse().toString();
 
-		GenericWrapper<String> flatmap = GenericWrapper.of(wrapper.unwrap());
-		assertThat(flatmap.unwrap()).isEqualTo(value);
+		GenericWrapper<String> wrapper = GenericWrapper.of(reverse(value));
+		assertThat(wrapper.unwrap()).isEqualTo(reversed);
+		assertThat(wrapper.unwrap()).isNotEqualTo(value);
+	}
+
+	@Test
+	void rewrapReturnsSameValue() {
+		String value = "livk";
+		GenericWrapper<String> wrapper = GenericWrapper.of(value);
+		GenericWrapper<String> rewrapped = GenericWrapper.of(wrapper.unwrap());
+		assertThat(rewrapped.unwrap()).isEqualTo(value);
+	}
+
+	@Test
+	void optionalReturnsNonEmptyForWrappedValue() {
+		GenericWrapper<String> wrapper = GenericWrapper.of("livk");
+		assertThat(wrapper.optional()).isPresent().hasValue("livk");
 	}
 
 	String reverse(String str) {

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/GenericsByteBuddyTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/GenericsByteBuddyTests.java
@@ -29,9 +29,9 @@ import net.bytebuddy.matcher.ElementMatchers;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
@@ -44,95 +44,98 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class GenericsByteBuddyTests {
 
+	// --- makeEnumeration ---
+
 	@Test
-	void testEnumWithoutValuesIsIllegal() {
+	void makeEnumerationWithoutValuesThrows() {
 		assertThatThrownBy(() -> new GenericsByteBuddy().makeEnumeration()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Require at least one enumeration constant");
 	}
 
 	@Test
-	void testEnumeration() throws Exception {
+	void makeEnumerationCreatesEnumType() throws Exception {
 		try (DynamicType.Unloaded<?> unloaded = new GenericsByteBuddy().makeEnumeration("foo").make()) {
 			Class<?> type = unloaded.load(getClass().getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
-			assertThat(type.getModifiers())
-				.satisfiesAnyOf(modifiers -> assertThat(Modifier.isPublic(modifiers)).isTrue());
+			assertThat(Modifier.isPublic(type.getModifiers())).isTrue();
 			assertThat(type.isEnum()).isTrue();
 			assertThat(type).isNotInterface();
-			assertThat(type).isNotAnnotation();
 		}
 	}
 
+	// --- makeInterface ---
+
 	@Test
-	void testInterface() {
+	void makeInterfaceCreatesInterfaceType() {
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().makeInterface().make()) {
 			Class<?> type = unloaded.load(getClass().getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
-			assertThat(type.getModifiers())
-				.satisfiesAnyOf(modifiers -> assertThat(Modifier.isPublic(modifiers)).isTrue());
-			assertThat(type.isEnum()).isFalse();
+			assertThat(Modifier.isPublic(type.getModifiers())).isTrue();
 			assertThat(type).isInterface();
+			assertThat(type.isEnum()).isFalse();
 			assertThat(type).isNotAnnotation();
 		}
 	}
 
+	// --- makeAnnotation ---
+
 	@Test
-	void testAnnotation() {
+	void makeAnnotationCreatesAnnotationType() {
 		try (DynamicType.Unloaded<Annotation> unloaded = new GenericsByteBuddy().makeAnnotation().make()) {
 			Class<?> type = unloaded.load(getClass().getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
-			assertThat(type.getModifiers())
-				.satisfiesAnyOf(modifiers -> assertThat(Modifier.isPublic(modifiers)).isTrue());
-			assertThat(type.isEnum()).isFalse();
-			assertThat(type).isInterface();
+			assertThat(Modifier.isPublic(type.getModifiers())).isTrue();
 			assertThat(type).isAnnotation();
 		}
 	}
 
+	// --- makeRecord ---
+
 	@Test
-	void testRecordWithoutMember() throws Exception {
+	void makeRecordWithoutMember() throws Exception {
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().with(ClassFileVersion.JAVA_V21)
 			.makeRecord()
 			.make()) {
 			Class<?> type = unloaded.load(getClass().getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
-			assertThat((Boolean) Class.class.getMethod("isRecord").invoke(type)).isTrue();
+			assertThat(type.isRecord()).isTrue();
 			Object record = type.getConstructor().newInstance();
 
-			assertThat((Integer) type.getMethod("hashCode").invoke(record)).isZero();
-			assertThat((Boolean) type.getMethod("equals", Object.class).invoke(record, new Object())).isFalse();
-			assertThat((Boolean) type.getMethod("equals", Object.class).invoke(record, record)).isTrue();
-			assertThat(type.getMethod("toString").invoke(record)).isEqualTo(type.getSimpleName() + "[]");
+			assertThat(record.hashCode()).isZero();
+			assertThat(record.equals(new Object())).isFalse();
+			assertThat(record.equals(record)).isTrue();
+			assertThat(record.toString()).isEqualTo(type.getSimpleName() + "[]");
 		}
 	}
 
 	@Test
-	void testRecordWithMember() throws Exception {
+	void makeRecordWithMember() throws Exception {
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().with(ClassFileVersion.JAVA_V21)
 			.makeRecord()
 			.defineRecordComponent("foo", String.class)
 			.make()) {
 			Class<?> type = unloaded.load(getClass().getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
-			assertThat((Boolean) Class.class.getMethod("isRecord").invoke(type)).isTrue();
+			assertThat(type.isRecord()).isTrue();
+
 			Object record = type.getConstructor(String.class).newInstance("bar");
 			assertThat(type.getMethod("foo").invoke(record)).isEqualTo("bar");
-			assertThat((Integer) type.getMethod("hashCode").invoke(record)).isEqualTo("bar".hashCode());
-			assertThat((Boolean) type.getMethod("equals", Object.class).invoke(record, new Object())).isFalse();
-			assertThat((Boolean) type.getMethod("equals", Object.class).invoke(record, record)).isTrue();
-			assertThat(type.getMethod("toString").invoke(record)).isEqualTo(type.getSimpleName() + "[foo=bar]");
-			Object[] parameters = (Object[]) Constructor.class.getMethod("getParameters")
-				.invoke(type.getDeclaredConstructor(String.class));
+			assertThat(record.hashCode()).isEqualTo("bar".hashCode());
+			assertThat(record.equals(new Object())).isFalse();
+			assertThat(record.equals(record)).isTrue();
+			assertThat(record.toString()).isEqualTo(type.getSimpleName() + "[foo=bar]");
+
+			Parameter[] parameters = type.getDeclaredConstructor(String.class).getParameters();
 			assertThat(parameters).hasSize(1);
-			assertThat(Class.forName("java.lang.reflect.Parameter").getMethod("getName").invoke(parameters[0]))
-				.isEqualTo("foo");
-			assertThat(Class.forName("java.lang.reflect.Parameter").getMethod("getModifiers").invoke(parameters[0]))
-				.isEqualTo(0);
+			assertThat(parameters[0].getName()).isEqualTo("foo");
+			assertThat(parameters[0].getModifiers()).isZero();
 		}
 	}
 
+	// --- type initializer ---
+
 	@Test
-	void testTypeInitializerInstrumentation() throws Exception {
+	void typeInitializerInstrumentationExecutesOnLoad() throws Exception {
 		Recorder recorder = new Recorder();
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().subclass(Object.class)
 			.invokable(ElementMatchers.isTypeInitializer())
@@ -145,8 +148,10 @@ class GenericsByteBuddyTests {
 		}
 	}
 
+	// --- class loading strategies ---
+
 	@Test
-	void testImplicitStrategyBootstrap() {
+	void implicitStrategyBootstrapUsesNonNullClassLoader() {
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().subclass(Object.class).make()) {
 			Class<?> type = unloaded.load(ClassLoadingStrategy.BOOTSTRAP_LOADER).getLoaded();
 			assertThat(type.getClassLoader()).isNotNull();
@@ -154,7 +159,7 @@ class GenericsByteBuddyTests {
 	}
 
 	@Test
-	void testImplicitStrategyNonBootstrap() {
+	void implicitStrategyNonBootstrapUsesNewClassLoader() {
 		ClassLoader classLoader = new URLClassLoader(new URL[0], ClassLoadingStrategy.BOOTSTRAP_LOADER);
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().subclass(Object.class).make()) {
 			Class<?> type = unloaded.load(classLoader).getLoaded();
@@ -163,7 +168,7 @@ class GenericsByteBuddyTests {
 	}
 
 	@Test
-	void testImplicitStrategyInjectable() {
+	void implicitStrategyInjectableUsesProvidedClassLoader() {
 		ClassLoader classLoader = new ByteArrayClassLoader(ClassLoadingStrategy.BOOTSTRAP_LOADER, false,
 				Collections.emptyMap());
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy().subclass(Object.class).make()) {
@@ -172,8 +177,10 @@ class GenericsByteBuddyTests {
 		}
 	}
 
+	// --- many methods ---
+
 	@Test
-	void testClassWithManyMethods() {
+	void classWithManyMethodsDefinesAllMethods() {
 		DynamicType.Builder<?> builder = new GenericsByteBuddy().subclass(Object.class);
 		for (int index = 0; index < 1000; index++) {
 			builder = builder.defineMethod("method" + index, void.class, Visibility.PUBLIC)
@@ -183,6 +190,19 @@ class GenericsByteBuddyTests {
 			Class<?> type = make.load(ClassLoadingStrategy.BOOTSTRAP_LOADER, ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
 			assertThat(type.getDeclaredMethods()).hasSize(1000);
+		}
+	}
+
+	@Test
+	void subclassWithManyMethodsOverridesAllMethods() {
+		DynamicType.Builder<?> builder = new GenericsByteBuddy().subclass(Object.class);
+		for (int index = 0; index < 1000; index++) {
+			builder = builder.defineMethod("method" + index, void.class, Visibility.PUBLIC)
+				.intercept(StubMethod.INSTANCE);
+		}
+		try (DynamicType.Unloaded<?> make = builder.make()) {
+			Class<?> type = make.load(ClassLoadingStrategy.BOOTSTRAP_LOADER, ClassLoadingStrategy.Default.WRAPPER)
+				.getLoaded();
 
 			DynamicType.Builder<?> subclassBuilder = new GenericsByteBuddy().subclass(type);
 			for (Method method : type.getDeclaredMethods()) {
@@ -196,8 +216,10 @@ class GenericsByteBuddyTests {
 		}
 	}
 
+	// --- redefine / naming ---
+
 	@Test
-	void testClassCompiledToJsr14() throws Exception {
+	void redefineJsr14ClassSucceeds() throws Exception {
 		try (DynamicType.Unloaded<?> unloaded = new GenericsByteBuddy()
 			.redefine(Class.forName("com.livk.commons.util.GenericsByteBuddyTests$Jsr14Sample"))
 			.make()) {
@@ -209,7 +231,7 @@ class GenericsByteBuddyTests {
 	}
 
 	@Test
-	void testCallerSuffixNamingStrategy() {
+	void callerSuffixNamingStrategyProducesExpectedName() {
 		try (DynamicType.Unloaded<Object> unloaded = new GenericsByteBuddy()
 			.with(new NamingStrategy.Suffixing("SuffixedName",
 					new GenericsByteBuddy.WithCallerSuffix(
@@ -219,10 +241,12 @@ class GenericsByteBuddyTests {
 			Class<?> type = unloaded.load(ClassLoadingStrategy.BOOTSTRAP_LOADER, ClassLoadingStrategy.Default.WRAPPER)
 				.getLoaded();
 			String expectedName = "foo.Bar$" + GenericsByteBuddyTests.class.getName().replace('.', '$')
-					+ "$testCallerSuffixNamingStrategy$SuffixedName";
+					+ "$callerSuffixNamingStrategyProducesExpectedName$SuffixedName";
 			assertThat(type.getName()).isEqualTo(expectedName);
 		}
 	}
+
+	// --- helper types ---
 
 	@SuppressWarnings("unused")
 	public static class Recorder {

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/HttpReactiveUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/HttpReactiveUtilsTests.java
@@ -16,12 +16,12 @@
 
 package com.livk.commons.util;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.codec.multipart.Part;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.util.LinkedMultiValueMap;
@@ -42,51 +42,64 @@ import static org.mockito.Mockito.mock;
  */
 class HttpReactiveUtilsTests {
 
-	@Test
-	void getPartValues() {
-		Part part = mock(Part.class);
-		given(part.name()).willReturn("file");
+	static final String FILE_CONTENT = "file content";
 
-		ServerWebExchange exchange = mock(ServerWebExchange.class);
+	Part mockPart;
+
+	ServerWebExchange exchange;
+
+	@BeforeEach
+	void setUp() {
+		DataBuffer buffer = new DefaultDataBufferFactory().wrap(FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
+
+		mockPart = mock(Part.class);
+		given(mockPart.name()).willReturn("file");
+		given(mockPart.headers()).willReturn(new HttpHeaders());
+		given(mockPart.content()).willReturn(Flux.just(buffer));
 
 		MultiValueMap<String, Part> partMap = new LinkedMultiValueMap<>();
-		partMap.add("file", part);
+		partMap.add("file", mockPart);
 
+		exchange = mock(ServerWebExchange.class);
+		given(exchange.getRequest()).willReturn(MockServerHttpRequest.post("/upload").build());
 		given(exchange.getMultipartData()).willReturn(Mono.just(partMap));
+	}
 
+	@Test
+	void getPartValuesReturnsMatchingPart() {
 		StepVerifier.create(HttpReactiveUtils.getPartValues("file", exchange))
-			.assertNext(p -> assertThat(p).isSameAs(part))
+			.assertNext(p -> assertThat(p).isSameAs(mockPart))
 			.verifyComplete();
 	}
 
 	@Test
-	void getPartRequest() {
-		String fileContent = "file content";
-		DataBuffer buffer = new DefaultDataBufferFactory().wrap(fileContent.getBytes(StandardCharsets.UTF_8));
+	void getPartValuesWithMissingNameCompletesEmpty() {
+		StepVerifier.create(HttpReactiveUtils.getPartValues("nonexistent", exchange)).verifyComplete();
+	}
 
-		Part mockPart = mock(Part.class);
-		given(mockPart.headers()).willReturn(new HttpHeaders());
-		given(mockPart.content()).willReturn(Flux.just(buffer));
+	@Test
+	void getPartRequestReturnsDecoratorWithPartHeaders() {
+		StepVerifier.create(HttpReactiveUtils.getPartRequest("file", exchange)).assertNext(decorator -> {
+			assertThat(decorator.getHeaders()).isSameAs(mockPart.headers());
+		}).verifyComplete();
+	}
 
-		LinkedMultiValueMap<String, Part> partMap = new LinkedMultiValueMap<>();
-		partMap.add("file", mockPart);
-
-		ServerHttpRequest originalRequest = MockServerHttpRequest.post("/upload").build();
-		ServerWebExchange exchange = mock(ServerWebExchange.class);
-		given(exchange.getRequest()).willReturn(originalRequest);
-		given(exchange.getMultipartData()).willReturn(Mono.just(partMap));
-
+	@Test
+	void getPartRequestReturnsDecoratorWithPartBody() {
 		Mono<ServerHttpRequestDecorator> resultMono = HttpReactiveUtils.getPartRequest("file", exchange);
 
 		StepVerifier.create(resultMono).assertNext(decorator -> {
-			assertThat(decorator.getHeaders()).isSameAs(mockPart.headers());
-
 			StepVerifier.create(decorator.getBody()).consumeNextWith(data -> {
 				byte[] bytes = new byte[data.readableByteCount()];
 				data.read(bytes);
-				assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo(fileContent);
+				assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo(FILE_CONTENT);
 			}).verifyComplete();
 		}).verifyComplete();
+	}
+
+	@Test
+	void getPartRequestWithMissingNameCompletesEmpty() {
+		StepVerifier.create(HttpReactiveUtils.getPartRequest("nonexistent", exchange)).verifyComplete();
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/HttpServletUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/HttpServletUtilsTests.java
@@ -109,6 +109,24 @@ class HttpServletUtilsTests {
 	}
 
 	@Test
+	void realIpWithXForwardedFor() {
+		request.addHeader("X-Forwarded-For", "10.0.0.1, 192.168.1.1");
+		assertThat(HttpServletUtils.realIp(request)).isEqualTo("10.0.0.1");
+	}
+
+	@Test
+	void realIpWithXRealIp() {
+		request.addHeader("X-Real-IP", "172.16.0.1");
+		assertThat(HttpServletUtils.realIp(request)).isEqualTo("172.16.0.1");
+	}
+
+	@Test
+	void realIpIgnoresUnknownHeader() {
+		request.addHeader("X-Forwarded-For", "unknown");
+		assertThat(HttpServletUtils.realIp(request)).isEqualTo("127.0.0.1");
+	}
+
+	@Test
 	void outJson() {
 		Map<String, String> result = Map.of("username", "livk", "password", "123456");
 		HttpServletUtils.outJson(response, result);

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/Jsr310UtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/Jsr310UtilsTests.java
@@ -37,196 +37,268 @@ class Jsr310UtilsTests {
 
 	private static final ZoneId ZONE = ZoneId.systemDefault();
 
-	@Test
-	void testTimestamp() {
-		LocalDateTime dt = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
-		long seconds = Jsr310Utils.timestamp(dt);
-		long expected = dt.atZone(ZONE).toEpochSecond();
+	private static final ZoneId UTC = ZoneId.of("UTC");
 
-		assertThat(seconds).isEqualTo(expected);
+	private static final ZoneId TOKYO = ZoneId.of("Asia/Tokyo");
+
+	// --- timestamp ---
+
+	@Test
+	void timestamp() {
+		LocalDateTime dt = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+		assertThat(Jsr310Utils.timestamp(dt)).isEqualTo(dt.atZone(ZONE).toEpochSecond());
 	}
 
 	@Test
-	void testTimestampWithZone() {
-		ZoneId utc = ZoneId.of("UTC");
+	void timestampWithZone() {
 		LocalDateTime dt = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
-		long seconds = Jsr310Utils.timestamp(dt, utc);
-		assertThat(seconds).isEqualTo(dt.atZone(utc).toEpochSecond());
+		assertThat(Jsr310Utils.timestamp(dt, UTC)).isEqualTo(dt.atZone(UTC).toEpochSecond());
 	}
 
 	@Test
-	void testTimestampMillis() {
+	void timestampMillis() {
 		LocalDateTime dt = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
-		long millis = Jsr310Utils.timestampMillis(dt);
-		assertThat(millis).isEqualTo(dt.atZone(ZONE).toInstant().toEpochMilli());
+		assertThat(Jsr310Utils.timestampMillis(dt)).isEqualTo(dt.atZone(ZONE).toInstant().toEpochMilli());
 	}
 
 	@Test
-	void testTimestampMillisWithZone() {
-		ZoneId utc = ZoneId.of("UTC");
+	void timestampMillisWithZone() {
 		LocalDateTime dt = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
-		long millis = Jsr310Utils.timestampMillis(dt, utc);
-		assertThat(millis).isEqualTo(dt.atZone(utc).toInstant().toEpochMilli());
+		assertThat(Jsr310Utils.timestampMillis(dt, UTC)).isEqualTo(dt.atZone(UTC).toInstant().toEpochMilli());
 	}
 
+	// --- datetime from timestamp ---
+
 	@Test
-	void testDatetime() {
+	void datetimeFromSeconds() {
 		long now = Instant.now().getEpochSecond();
 		assertThat(Jsr310Utils.datetime(now)).isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochSecond(now), ZONE));
 	}
 
 	@Test
-	void testDatetimeWithZone() {
+	void datetimeFromSecondsWithZone() {
 		long now = Instant.now().getEpochSecond();
-		ZoneId utc = ZoneId.of("UTC");
-		assertThat(Jsr310Utils.datetime(now, utc)).isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochSecond(now), utc));
+		assertThat(Jsr310Utils.datetime(now, UTC)).isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochSecond(now), UTC));
 	}
 
 	@Test
-	void testDatetimeMillis() {
+	void datetimeFromMillis() {
 		long now = Instant.now().toEpochMilli();
 		assertThat(Jsr310Utils.dateTimeMillis(now)).isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochMilli(now), ZONE));
 	}
 
 	@Test
-	void testDatetimeMillisWithZone() {
+	void datetimeFromMillisWithZone() {
 		long now = Instant.now().toEpochMilli();
-		ZoneId utc = ZoneId.of("UTC");
-		assertThat(Jsr310Utils.dateTimeMillis(now, utc))
-			.isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochMilli(now), utc));
+		assertThat(Jsr310Utils.dateTimeMillis(now, UTC))
+			.isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochMilli(now), UTC));
 	}
 
+	// --- format ---
+
 	@Test
-	void testFormatWithPattern() {
+	void formatWithPattern() {
 		LocalDateTime dt = LocalDateTime.of(2025, 5, 20, 12, 34, 56);
-		String formatted = Jsr310Utils.format(dt, "yyyy/MM/dd HH:mm");
-		assertThat(formatted).isEqualTo("2025/05/20 12:34");
+		assertThat(Jsr310Utils.format(dt, "yyyy/MM/dd HH:mm")).isEqualTo("2025/05/20 12:34");
 	}
 
 	@Test
-	void testFormatWithPatternAndZone() {
+	void formatWithPatternAndZone() {
 		Instant instant = Instant.parse("2025-05-20T12:34:56Z");
-		String formatted = Jsr310Utils.format(instant, "yyyy-MM-dd HH:mm:ss", ZoneId.of("UTC"));
-		assertThat(formatted).isEqualTo("2025-05-20 12:34:56");
+		assertThat(Jsr310Utils.format(instant, "yyyy-MM-dd HH:mm:ss", UTC)).isEqualTo("2025-05-20 12:34:56");
 	}
 
 	@Test
-	void testFormatWithGetFormatter() {
+	void formatWithDateTimeFormatter() {
 		LocalDateTime dt = LocalDateTime.of(2025, 5, 20, 12, 34, 56);
-		String formatted = Jsr310Utils.format(dt, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
-		assertThat(formatted).isEqualTo("20250520123456");
+		assertThat(Jsr310Utils.format(dt, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))).isEqualTo("20250520123456");
 	}
 
 	@Test
-	void testFormatShortcuts() {
+	void formatDate() {
 		LocalDateTime dt = LocalDateTime.of(2025, 5, 20, 12, 34, 56);
 		assertThat(Jsr310Utils.formatDate(dt)).isEqualTo("2025-05-20");
+	}
+
+	@Test
+	void formatDateTime() {
+		LocalDateTime dt = LocalDateTime.of(2025, 5, 20, 12, 34, 56);
 		assertThat(Jsr310Utils.formatDateTime(dt)).isEqualTo("2025-05-20 12:34:56");
+	}
+
+	@Test
+	void formatTime() {
+		LocalDateTime dt = LocalDateTime.of(2025, 5, 20, 12, 34, 56);
 		assertThat(Jsr310Utils.formatTime(dt)).isEqualTo("12:34:56");
 	}
 
 	@Test
-	void testParseDateTimeShortcuts() {
+	void formatDateWithZoneId() {
+		Instant instant = Instant.parse("2025-05-20T00:00:00Z");
+		assertThat(Jsr310Utils.formatDate(instant, UTC)).isEqualTo("2025-05-20");
+		assertThat(Jsr310Utils.formatDate(instant, TOKYO)).isEqualTo("2025-05-20");
+	}
+
+	@Test
+	void formatDateTimeWithZoneId() {
+		Instant instant = Instant.parse("2025-05-20T00:00:00Z");
+		assertThat(Jsr310Utils.formatDateTime(instant, UTC)).isEqualTo("2025-05-20 00:00:00");
+		assertThat(Jsr310Utils.formatDateTime(instant, TOKYO)).isEqualTo("2025-05-20 09:00:00");
+	}
+
+	@Test
+	void formatTimeWithZoneId() {
+		Instant instant = Instant.parse("2025-05-20T00:00:00Z");
+		assertThat(Jsr310Utils.formatTime(instant, UTC)).isEqualTo("00:00:00");
+		assertThat(Jsr310Utils.formatTime(instant, TOKYO)).isEqualTo("09:00:00");
+	}
+
+	// --- parse ---
+
+	@Test
+	void parseDateTimeWithDefaultPattern() {
 		assertThat(Jsr310Utils.parseDateTime("2025-05-20 12:34:56"))
 			.isEqualTo(LocalDateTime.of(2025, 5, 20, 12, 34, 56));
+	}
 
+	@Test
+	void parseDateTimeWithCustomPattern() {
+		assertThat(Jsr310Utils.parseDateTime("20250520123456", "yyyyMMddHHmmss"))
+			.isEqualTo(LocalDateTime.of(2025, 5, 20, 12, 34, 56));
+	}
+
+	@Test
+	void parseDateWithDefaultPattern() {
 		assertThat(Jsr310Utils.parseDate("2025-05-20")).isEqualTo(LocalDate.of(2025, 5, 20));
+	}
 
+	@Test
+	void parseDateWithCustomPattern() {
+		assertThat(Jsr310Utils.parseDate("20250520", "yyyyMMdd")).isEqualTo(LocalDate.of(2025, 5, 20));
+	}
+
+	@Test
+	void parseTimeWithDefaultPattern() {
 		assertThat(Jsr310Utils.parseTime("12:34:56")).isEqualTo(LocalTime.of(12, 34, 56));
 	}
 
 	@Test
-	void testPlusMinus() {
+	void parseTimeWithCustomPattern() {
+		assertThat(Jsr310Utils.parseTime("123456", "HHmmss")).isEqualTo(LocalTime.of(12, 34, 56));
+	}
+
+	// --- plus / minus ---
+
+	@Test
+	void plusDays() {
 		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 		assertThat(Jsr310Utils.plusDays(base, 2)).isEqualTo(base.plusDays(2));
+	}
+
+	@Test
+	void minusDays() {
+		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 		assertThat(Jsr310Utils.minusDays(base, 2)).isEqualTo(base.minusDays(2));
+	}
+
+	@Test
+	void plusHours() {
+		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 		assertThat(Jsr310Utils.plusHours(base, 3)).isEqualTo(base.plusHours(3));
+	}
+
+	@Test
+	void minusHours() {
+		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 		assertThat(Jsr310Utils.minusHours(base, 3)).isEqualTo(base.minusHours(3));
+	}
+
+	@Test
+	void plusMinutes() {
+		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 		assertThat(Jsr310Utils.plusMinutes(base, 15)).isEqualTo(base.plusMinutes(15));
+	}
+
+	@Test
+	void minusMinutes() {
+		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 		assertThat(Jsr310Utils.minusMinutes(base, 15)).isEqualTo(base.minusMinutes(15));
 	}
 
+	// --- day boundaries ---
+
 	@Test
-	void testStartAndEndOfDay() {
+	void startOfDay() {
 		LocalDate date = LocalDate.of(2025, 5, 20);
 		assertThat(Jsr310Utils.startOfDay(date)).isEqualTo(date.atStartOfDay());
+	}
+
+	@Test
+	void endOfDay() {
+		LocalDate date = LocalDate.of(2025, 5, 20);
 		assertThat(Jsr310Utils.endOfDay(date)).isEqualTo(date.atTime(LocalTime.MAX));
 	}
 
+	// --- month boundaries ---
+
 	@Test
-	void testMonthBoundaries() {
-		LocalDate date = LocalDate.of(2025, 2, 15);
-		assertThat(Jsr310Utils.firstDayOfMonth(date)).isEqualTo(LocalDate.of(2025, 2, 1));
-		assertThat(Jsr310Utils.lastDayOfMonth(date)).isEqualTo(LocalDate.of(2025, 2, 28));
+	void firstDayOfMonth() {
+		assertThat(Jsr310Utils.firstDayOfMonth(LocalDate.of(2025, 2, 15))).isEqualTo(LocalDate.of(2025, 2, 1));
 	}
 
 	@Test
-	void testFirstDayOfWeek() {
+	void lastDayOfMonth() {
+		assertThat(Jsr310Utils.lastDayOfMonth(LocalDate.of(2025, 2, 15))).isEqualTo(LocalDate.of(2025, 2, 28));
+	}
+
+	@Test
+	void firstDayOfWeek() {
 		LocalDate wednesday = LocalDate.of(2025, 5, 21);
-		LocalDate monday = Jsr310Utils.firstDayOfWeek(wednesday);
-		assertThat(monday.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+		assertThat(Jsr310Utils.firstDayOfWeek(wednesday).getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+	}
+
+	// --- before / after now ---
+
+	@Test
+	void isBeforeNow() {
+		assertThat(Jsr310Utils.isBeforeNow(LocalDateTime.now().minusDays(1))).isTrue();
+		assertThat(Jsr310Utils.isBeforeNow(LocalDateTime.now().plusDays(1))).isFalse();
 	}
 
 	@Test
-	void testBeforeAfterNow() {
-		LocalDateTime past = LocalDateTime.now().minusDays(1);
-		LocalDateTime future = LocalDateTime.now().plusDays(1);
-
-		assertThat(Jsr310Utils.isBeforeNow(past)).isTrue();
-		assertThat(Jsr310Utils.isAfterNow(future)).isTrue();
+	void isAfterNow() {
+		assertThat(Jsr310Utils.isAfterNow(LocalDateTime.now().plusDays(1))).isTrue();
+		assertThat(Jsr310Utils.isAfterNow(LocalDateTime.now().minusDays(1))).isFalse();
 	}
 
+	// --- between calculations ---
+
 	@Test
-	void testBetweenCalculations() {
+	void secondsBetween() {
 		LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
 		LocalDateTime end = LocalDateTime.of(2025, 1, 2, 1, 1, 1);
-
 		assertThat(Jsr310Utils.secondsBetween(start, end)).isEqualTo(Duration.between(start, end).getSeconds());
+	}
+
+	@Test
+	void minutesBetween() {
+		LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+		LocalDateTime end = LocalDateTime.of(2025, 1, 2, 1, 1, 1);
 		assertThat(Jsr310Utils.minutesBetween(start, end)).isEqualTo(Duration.between(start, end).toMinutes());
+	}
+
+	@Test
+	void hoursBetween() {
+		LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+		LocalDateTime end = LocalDateTime.of(2025, 1, 2, 1, 1, 1);
 		assertThat(Jsr310Utils.hoursBetween(start, end)).isEqualTo(Duration.between(start, end).toHours());
+	}
+
+	@Test
+	void daysBetween() {
+		LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+		LocalDateTime end = LocalDateTime.of(2025, 1, 2, 1, 1, 1);
 		assertThat(Jsr310Utils.daysBetween(start, end)).isEqualTo(ChronoUnit.DAYS.between(start, end));
-	}
-
-	@Test
-	void testFormatDateWithZoneId() {
-		// UTC 时间 2025-05-20T00:00Z，在东京（+9）应是 2025-05-20 09:00
-		Instant instant = Instant.parse("2025-05-20T00:00:00Z");
-		ZoneId utc = ZoneId.of("UTC");
-		ZoneId tokyo = ZoneId.of("Asia/Tokyo");
-
-		String utcDate = Jsr310Utils.formatDate(instant, utc);
-		String tokyoDate = Jsr310Utils.formatDate(instant, tokyo);
-
-		assertThat(utcDate).isEqualTo("2025-05-20");
-		// 注意：在东京是当天早上9点，仍是同一天
-		assertThat(tokyoDate).isEqualTo("2025-05-20");
-	}
-
-	@Test
-	void testFormatDateTimeWithZoneId() {
-		Instant instant = Instant.parse("2025-05-20T00:00:00Z");
-		ZoneId utc = ZoneId.of("UTC");
-		ZoneId tokyo = ZoneId.of("Asia/Tokyo");
-
-		String utcDateTime = Jsr310Utils.formatDateTime(instant, utc);
-		String tokyoDateTime = Jsr310Utils.formatDateTime(instant, tokyo);
-
-		assertThat(utcDateTime).isEqualTo("2025-05-20 00:00:00");
-		// UTC+9 → 09:00:00
-		assertThat(tokyoDateTime).isEqualTo("2025-05-20 09:00:00");
-	}
-
-	@Test
-	void testFormatTimeWithZoneId() {
-		Instant instant = Instant.parse("2025-05-20T00:00:00Z");
-		ZoneId utc = ZoneId.of("UTC");
-		ZoneId tokyo = ZoneId.of("Asia/Tokyo");
-
-		String utcTime = Jsr310Utils.formatTime(instant, utc);
-		String tokyoTime = Jsr310Utils.formatTime(instant, tokyo);
-
-		assertThat(utcTime).isEqualTo("00:00:00");
-		assertThat(tokyoTime).isEqualTo("09:00:00");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/MultiValueMapSplitterTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/MultiValueMapSplitterTests.java
@@ -16,36 +16,86 @@
 
 package com.livk.commons.util;
 
+import com.google.common.base.Splitter;
 import org.junit.jupiter.api.Test;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
  */
 class MultiValueMapSplitterTests {
 
-	@Test
-	void testSplitWithKeyValuePairs() {
-		String param = "names=admin&names=root&password=123456";
-		MultiValueMap<String, String> valueMap = MultiValueMapSplitter.of("&", "=").split(param);
-		Map<String, List<String>> map = Map.of("names", List.of("admin", "root"), "password", List.of("123456"));
+	// --- split without value regex ---
 
-		assertThat(valueMap).isEqualTo(CollectionUtils.toMultiValueMap(map));
+	@Test
+	void splitWithDuplicateKeys() {
+		String param = "names=admin&names=root&password=123456";
+		MultiValueMap<String, String> result = MultiValueMapSplitter.of("&", "=").split(param);
+		assertThat(result.get("names")).containsExactly("admin", "root");
+		assertThat(result.get("password")).containsExactly("123456");
 	}
 
 	@Test
-	void testSplitWithMultiValueKeysAndCommaSeparator() {
-		String str = "root=1,2,3&root=4&a=b&a=c";
-		MultiValueMap<String, String> multiValueMap = MultiValueMapSplitter.of("&", "=").split(str, ",");
-		Map<String, List<String>> map = Map.of("root", List.of("1", "2", "3", "4"), "a", List.of("b", "c"));
+	void splitWithoutRegexKeepsCommaInValue() {
+		String str = "root=1,2,3&a=b";
+		MultiValueMap<String, String> result = MultiValueMapSplitter.of("&", "=").split(str);
+		assertThat(result.get("root")).containsExactly("1,2,3");
+		assertThat(result.get("a")).containsExactly("b");
+	}
 
-		assertThat(multiValueMap).isEqualTo(CollectionUtils.toMultiValueMap(map));
+	// --- split with value regex ---
+
+	@Test
+	void splitWithRegexSplitsValues() {
+		String str = "root=1,2,3&root=4&a=b&a=c";
+		MultiValueMap<String, String> result = MultiValueMapSplitter.of("&", "=").split(str, ",");
+		assertThat(result.get("root")).containsExactly("1", "2", "3", "4");
+		assertThat(result.get("a")).containsExactly("b", "c");
+	}
+
+	// --- factory method overloads ---
+
+	@Test
+	void ofWithSplitterAndSplitter() {
+		MultiValueMapSplitter splitter = MultiValueMapSplitter.of(Splitter.on("&"), Splitter.on("="));
+		MultiValueMap<String, String> result = splitter.split("a=1&b=2");
+		assertThat(result.get("a")).containsExactly("1");
+		assertThat(result.get("b")).containsExactly("2");
+	}
+
+	@Test
+	void ofWithSplitterAndString() {
+		MultiValueMapSplitter splitter = MultiValueMapSplitter.of(Splitter.on("&"), "=");
+		MultiValueMap<String, String> result = splitter.split("a=1&b=2");
+		assertThat(result.get("a")).containsExactly("1");
+		assertThat(result.get("b")).containsExactly("2");
+	}
+
+	// --- immutability ---
+
+	@Test
+	void splitReturnsUnmodifiableMap() {
+		MultiValueMap<String, String> result = MultiValueMapSplitter.of("&", "=").split("a=1");
+		assertThatThrownBy(() -> result.put("b", List.of("2"))).isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	// --- invalid input ---
+
+	@Test
+	void splitWithMissingValueThrows() {
+		assertThatThrownBy(() -> MultiValueMapSplitter.of("&", "=").split("keyonly"))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void splitWithTooManyPartsThrows() {
+		assertThatThrownBy(() -> MultiValueMapSplitter.of("&", "=").split("a=b=c"))
+			.isInstanceOf(IllegalArgumentException.class);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/PairTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/PairTests.java
@@ -33,58 +33,109 @@ class PairTests {
 
 	static final Pair<String, Integer> pair = Pair.of("livk", 123456);
 
+	// --- basic accessors ---
+
 	@Test
-	void pairJsonSerializerTest() {
-		String json = "{\"livk\":123456}";
-		String result = JsonMapperUtils.writeValueAsString(pair);
-		assertThat(result).isEqualTo(json);
+	void keyAndValueReturnConstructorArgs() {
+		assertThat(pair.key()).isEqualTo("livk");
+		assertThat(pair.value()).isEqualTo(123456);
 	}
 
 	@Test
-	void pairJsonDeserializerTest() {
+	void ofFromMapEntry() {
+		Map.Entry<String, Integer> entry = Map.entry("livk", 123456);
+		Pair<String, Integer> result = Pair.of(entry);
+		assertThat(result.key()).isEqualTo("livk");
+		assertThat(result.value()).isEqualTo(123456);
+		assertThat(result).isEqualTo(pair);
+	}
+
+	// --- equals / hashCode / toString / clone ---
+
+	@Test
+	void equalsAndHashCode() {
+		Pair<String, Integer> same = Pair.of("livk", 123456);
+		Pair<String, Integer> different = Pair.of("other", 0);
+		assertThat(pair).isEqualTo(same);
+		assertThat(pair.hashCode()).isEqualTo(same.hashCode());
+		assertThat(pair).isNotEqualTo(different);
+	}
+
+	@Test
+	void toStringFormat() {
+		assertThat(pair.toString()).isEqualTo("{livk:123456}");
+	}
+
+	@Test
+	void cloneReturnsCopy() {
+		Pair<String, Integer> cloned = pair.clone();
+		assertThat(cloned).isEqualTo(pair).isNotSameAs(pair);
+	}
+
+	// --- serialization ---
+
+	@Test
+	void serializesToJson() {
+		assertThat(JsonMapperUtils.writeValueAsString(pair)).isEqualTo("{\"livk\":123456}");
+	}
+
+	// --- deserialization ---
+
+	@Test
+	void deserializesEmptyObjectToEmptyPair() {
 		Pair<String, Integer> empty = JsonMapperUtils.readValue("{}", new TypeReference<>() {
 		});
 		assertThat(empty.key()).isNull();
 		assertThat(empty.value()).isNull();
 		assertThat(empty).isEqualTo(Pair.EMPTY);
+	}
 
+	@Test
+	void deserializesSimpleKeyValue() {
 		@Language("JSON")
 		String json = "{\"livk\":123456}";
 		Pair<String, Integer> result = JsonMapperUtils.readValue(json, new TypeReference<>() {
 		});
-		assertThat(result.key()).isEqualTo("livk");
-		assertThat(result.value()).isEqualTo(123456);
 		assertThat(result).isEqualTo(pair);
+	}
 
+	@Test
+	void deserializesNestedPairValue() {
 		@Language("JSON")
-		String json2 = """
+		String json = """
 				{"livk": {"root": "username"}}""";
-		Pair<String, Pair<String, String>> result2 = JsonMapperUtils.readValue(json2, new TypeReference<>() {
+		Pair<String, Pair<String, String>> result = JsonMapperUtils.readValue(json, new TypeReference<>() {
 		});
-		assertThat(result2.key()).isEqualTo("livk");
-		assertThat(result2.value().key()).isEqualTo("root");
-		assertThat(result2.value().value()).isEqualTo("username");
+		assertThat(result.key()).isEqualTo("livk");
+		assertThat(result.value().key()).isEqualTo("root");
+		assertThat(result.value().value()).isEqualTo("username");
+	}
 
+	@Test
+	void deserializesListValue() {
 		@Language("JSON")
-		String json3 = """
-				{"livk":  [1,2,3]}""";
-		Pair<String, List<Integer>> result3 = JsonMapperUtils.readValue(json3, new TypeReference<>() {
+		String json = """
+				{"livk": [1,2,3]}""";
+		Pair<String, List<Integer>> result = JsonMapperUtils.readValue(json, new TypeReference<>() {
 		});
-		assertThat(result3.key()).isEqualTo("livk");
-		assertThat(result3.value()).containsExactly(1, 2, 3);
+		assertThat(result.key()).isEqualTo("livk");
+		assertThat(result.value()).containsExactly(1, 2, 3);
+	}
 
+	@Test
+	void deserializesMapValue() {
 		@Language("JSON")
-		String json4 = """
+		String json = """
 				{
 				  "livk": {
 				    "username": "root",
 				    "password": "root"
 				  }
 				}""";
-		Pair<String, Map<String, String>> result4 = JsonMapperUtils.readValue(json4, new TypeReference<>() {
+		Pair<String, Map<String, String>> result = JsonMapperUtils.readValue(json, new TypeReference<>() {
 		});
-		assertThat(result4.key()).isEqualTo("livk");
-		assertThat(result4.value()).containsAllEntriesOf(Map.of("username", "root", "password", "root"));
+		assertThat(result.key()).isEqualTo("livk");
+		assertThat(result.value()).containsAllEntriesOf(Map.of("username", "root", "password", "root"));
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/ReflectionUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/ReflectionUtilsTests.java
@@ -17,10 +17,10 @@
 package com.livk.commons.util;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
@@ -38,49 +38,101 @@ class ReflectionUtilsTests {
 	ReflectionUtilsTests() throws NoSuchFieldException {
 	}
 
+	// --- setFieldAndAccessible ---
+
 	@Test
-	void setFieldAndAccessibleTest() {
+	void setFieldAndAccessible() {
 		Maker maker = new Maker();
 		ReflectionUtils.setFieldAndAccessible(fieldNo, maker, 2);
 		assertThat(maker.getNo()).isEqualTo(2);
 	}
 
-	@Test
-	void getReadMethod() throws InvocationTargetException, IllegalAccessException {
-		Maker maker = new Maker();
-		maker.setNo(10);
-		maker.setUsername("root");
-		Method readMethod = ReflectionUtils.getReadMethod(Maker.class, fieldNo);
-		assertThat(readMethod.getName()).isEqualTo("getNo");
-		assertThat(readMethod.invoke(maker)).isEqualTo(10);
+	// --- getReadMethod / getReadMethods ---
 
-		Set<Method> readMethods = ReflectionUtils.getReadMethods(Maker.class);
-		Set<String> methodNames = readMethods.stream().map(Method::getName).collect(Collectors.toSet());
-		assertThat(methodNames).containsExactlyInAnyOrder("getNo", "getUsername");
+	@Test
+	void getReadMethodReturnsGetter() {
+		Method readMethod = ReflectionUtils.getReadMethod(Maker.class, fieldNo);
+		assertThat(readMethod).isNotNull();
+		assertThat(readMethod.getName()).isEqualTo("getNo");
 	}
 
 	@Test
-	void getWriteMethod() throws InvocationTargetException, IllegalAccessException {
+	void getReadMethodInvokesCorrectly() throws Exception {
 		Maker maker = new Maker();
 		maker.setNo(10);
-		maker.setUsername("root");
-		Method writeMethod = ReflectionUtils.getWriteMethod(Maker.class, fieldNo);
-		assertThat(writeMethod.getName()).isEqualTo("setNo");
+		Method readMethod = ReflectionUtils.getReadMethod(Maker.class, fieldNo);
+		assertThat(readMethod.invoke(maker)).isEqualTo(10);
+	}
 
+	@Test
+	void getReadMethodsReturnsAllGetters() {
+		Set<Method> readMethods = ReflectionUtils.getReadMethods(Maker.class);
+		Set<String> names = readMethods.stream().map(Method::getName).collect(Collectors.toSet());
+		assertThat(names).containsExactlyInAnyOrder("getNo", "getUsername");
+	}
+
+	// --- getWriteMethod / getWriteMethods ---
+
+	@Test
+	void getWriteMethodReturnsSetter() {
+		Method writeMethod = ReflectionUtils.getWriteMethod(Maker.class, fieldNo);
+		assertThat(writeMethod).isNotNull();
+		assertThat(writeMethod.getName()).isEqualTo("setNo");
+	}
+
+	@Test
+	void getWriteMethodInvokesCorrectly() throws Exception {
+		Maker maker = new Maker();
+		Method writeMethod = ReflectionUtils.getWriteMethod(Maker.class, fieldNo);
 		writeMethod.invoke(maker, 20);
 		assertThat(maker.getNo()).isEqualTo(20);
-
-		Set<Method> writeMethods = ReflectionUtils.getWriteMethods(Maker.class);
-		Set<String> methodNames = writeMethods.stream().map(Method::getName).collect(Collectors.toSet());
-		assertThat(methodNames).containsExactlyInAnyOrder("setNo", "setUsername");
 	}
 
 	@Test
-	void getAllFields() {
-		List<Field> fields = ReflectionUtils.getAllFields(Maker.class);
-		List<String> fieldNames = fields.stream().map(Field::getName).collect(Collectors.toList());
+	void getWriteMethodsReturnsAllSetters() {
+		Set<Method> writeMethods = ReflectionUtils.getWriteMethods(Maker.class);
+		Set<String> names = writeMethods.stream().map(Method::getName).collect(Collectors.toSet());
+		assertThat(names).containsExactlyInAnyOrder("setNo", "setUsername");
+	}
+
+	// --- getAllFields ---
+
+	@Test
+	void getAllFieldsReturnsDeclaredFields() {
+		List<String> fieldNames = ReflectionUtils.getAllFields(Maker.class)
+			.stream()
+			.map(Field::getName)
+			.collect(Collectors.toList());
 		assertThat(fieldNames).containsExactly("no", "username");
 	}
+
+	@Test
+	void getAllFieldsIncludesParentFields() {
+		List<String> fieldNames = ReflectionUtils.getAllFields(SubMaker.class)
+			.stream()
+			.map(Field::getName)
+			.collect(Collectors.toList());
+		assertThat(fieldNames).containsExactly("extra", "no", "username");
+	}
+
+	// --- getDeclaredFieldValue ---
+
+	@Test
+	void getDeclaredFieldValueReadsPrivateField() {
+		Maker maker = new Maker();
+		maker.setNo(42);
+		Object value = ReflectionUtils.getDeclaredFieldValue(fieldNo, maker);
+		assertThat(value).isEqualTo(42);
+	}
+
+	@Test
+	void getDeclaredFieldValueReturnsNullForUnsetField() {
+		Maker maker = new Maker();
+		Object value = ReflectionUtils.getDeclaredFieldValue(fieldNo, maker);
+		assertThat(value).isNull();
+	}
+
+	// --- test helper types ---
 
 	@Data
 	static class Maker {
@@ -88,6 +140,14 @@ class ReflectionUtilsTests {
 		private Integer no;
 
 		private String username;
+
+	}
+
+	@Data
+	@EqualsAndHashCode(callSuper = true)
+	static class SubMaker extends Maker {
+
+		private String extra;
 
 	}
 

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/SnowflakeIdGeneratorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/SnowflakeIdGeneratorTests.java
@@ -69,15 +69,22 @@ class SnowflakeIdGeneratorTests {
 	}
 
 	@Test
-	void testTimeRollbackHandling() throws InterruptedException {
+	void testTimeRollbackHandling() {
+		// Generate an ID to set lastTimestamp
 		long id1 = generator.nextId();
 
-		System.setProperty("user.timezone", "UTC"); // 模拟时区变化
-		Thread.sleep(1000);
-
+		// Verify that IDs generated in quick succession are still unique
+		// (exercises the same-millisecond and sequence overflow paths)
 		long id2 = generator.nextId();
+		long id3 = generator.nextId();
 
-		assertThat(id1).isNotEqualTo(id2).withFailMessage("生成的 ID 相同，时间回拨没有处理正确");
+		assertThat(id1).isNotEqualTo(id2);
+		assertThat(id2).isNotEqualTo(id3);
+
+		// Note: true time rollback testing requires abstracting the time source
+		// (e.g., injecting a Clock or Supplier<Long>) to simulate backward time movement.
+		// System.setProperty("user.timezone", ...) does not affect
+		// System.currentTimeMillis().
 	}
 
 	@Test

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/StreamUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/StreamUtilsTests.java
@@ -106,12 +106,13 @@ class StreamUtilsTests {
 
 	@Test
 	void forEachWithIndex() {
-		// 这里断言不涉及状态变化，所以保留打印；如果需要断言，可以用Mockito等捕获调用
-		List.of("root", "livk", "admin")
-			.forEach(StreamUtils.forEachWithIndex(0, (s, i) -> System.out.println("index:" + i + " data:" + s)));
+		List<String> results1 = new java.util.ArrayList<>();
+		List.of("root", "livk", "admin").forEach(StreamUtils.forEachWithIndex(0, (s, i) -> results1.add(i + ":" + s)));
+		assertThat(results1).containsExactly("0:root", "1:livk", "2:admin");
 
-		List.of("root", "livk", "admin")
-			.forEach(StreamUtils.forEachWithIndex(10, (s, i) -> System.out.println("index:" + i + " data:" + s)));
+		List<String> results2 = new java.util.ArrayList<>();
+		List.of("root", "livk", "admin").forEach(StreamUtils.forEachWithIndex(10, (s, i) -> results2.add(i + ":" + s)));
+		assertThat(results2).containsExactly("10:root", "11:livk", "12:admin");
 	}
 
 	@Test

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/TreeNodeTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/TreeNodeTests.java
@@ -16,12 +16,8 @@
 
 package com.livk.commons.util;
 
-import com.livk.commons.jackson.JsonMapperUtils;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.List;
 
@@ -30,23 +26,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-@Slf4j
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class TreeNodeTests {
 
-	static TreeNode<Long, String> root;
+	TreeNode<Long, String> root;
 
-	@Order(1)
-	@Test
-	void createRoot() {
+	@BeforeEach
+	void setUp() {
 		root = TreeNode.createRoot(0L, "root");
-		log.info("{}", root);
-		assertThat(root).isNotNull();
-	}
-
-	@Order(2)
-	@Test
-	void setChildren() {
 		var nodes = List.of(new TreeNode<Long, String>(1L).setNode("1").setPid(0L),
 				new TreeNode<Long, String>(2L).setNode("2").setPid(0L),
 				new TreeNode<Long, String>(3L).setNode("3").setPid(1L),
@@ -54,25 +40,65 @@ class TreeNodeTests {
 				new TreeNode<Long, String>(5L).setNode("5").setPid(2L),
 				new TreeNode<Long, String>(6L).setNode("6").setPid(3L));
 		root.setChildren(nodes);
-		log.info("{}", root);
-		log.info("{}", JsonMapperUtils.writeValueAsString(root));
-		assertThat(root).isNotNull();
 	}
 
-	@Order(3)
+	@Test
+	void createRoot() {
+		TreeNode<Long, String> newRoot = TreeNode.createRoot(0L, "root");
+		assertThat(newRoot).isNotNull();
+		assertThat(newRoot.getId()).isEqualTo(0L);
+		assertThat(newRoot.getNode()).isEqualTo("root");
+		assertThat(newRoot.getChildren()).isNotNull().isEmpty();
+	}
+
+	@Test
+	void setChildren() {
+		assertThat(root.getChildren()).isNotNull().hasSize(2);
+		assertThat(root.getChildren().get(0).getId()).isEqualTo(1L);
+		assertThat(root.getChildren().get(1).getId()).isEqualTo(2L);
+
+		TreeNode<Long, String> child1 = root.findById(1L);
+		assertThat(child1).isNotNull();
+		assertThat(child1.getChildren()).hasSize(2);
+	}
+
 	@Test
 	void addChild() {
 		TreeNode<Long, String> node = new TreeNode<Long, String>(7L).setNode("7").setPid(4L);
-		root.addChild(node);
-		log.info("{}", root);
-		log.info("{}", JsonMapperUtils.writeValueAsString(root));
+		boolean added = root.addChild(node);
+		assertThat(added).isTrue();
+
+		TreeNode<Long, String> found = root.findById(7L);
+		assertThat(found).isNotNull();
+		assertThat(found.getNode()).isEqualTo("7");
 	}
 
-	@Order(4)
+	@Test
+	void addChildWithDuplicateIdReturnsFalse() {
+		TreeNode<Long, String> duplicate = new TreeNode<Long, String>(3L).setNode("dup").setPid(1L);
+		boolean added = root.addChild(duplicate);
+		assertThat(added).isFalse();
+	}
+
+	@Test
+	void addChildWithInvalidParentReturnsFalse() {
+		TreeNode<Long, String> orphan = new TreeNode<Long, String>(99L).setNode("orphan").setPid(999L);
+		boolean added = root.addChild(orphan);
+		assertThat(added).isFalse();
+	}
+
 	@Test
 	void findById() {
 		TreeNode<Long, String> childNode = root.findById(3L);
-		log.info("{}", childNode);
+		assertThat(childNode).isNotNull();
+		assertThat(childNode.getNode()).isEqualTo("3");
+		assertThat(childNode.getPid()).isEqualTo(1L);
+	}
+
+	@Test
+	void findByIdReturnsNullForMissingId() {
+		TreeNode<Long, String> missing = root.findById(999L);
+		assertThat(missing).isNull();
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/util/YamlUtilsTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/util/YamlUtilsTests.java
@@ -17,11 +17,9 @@
 package com.livk.commons.util;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.yaml.snakeyaml.Yaml;
 
-import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -32,23 +30,82 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class YamlUtilsTests {
 
-	final Resource yml = new ClassPathResource("yamlData.yml");
-
-	final Map<String, Object> map = Map.of("spring.redis.host", "livk.com", "spring.redis.port", 5672, "spring.env[0]",
-			1, "spring.env[1]", 2);
+	// --- convertMapToYaml ---
 
 	@Test
-	void convertMapToYaml() throws IOException {
-		Map<String, Object> load = new Yaml().load(yml.getInputStream());
-		Map<String, Object> result = YamlUtils.convertMapToYaml(map);
-		assertThat(result).isEqualTo(load);
+	void convertMapToYamlWithSimpleKeys() {
+		Map<String, Object> flat = Map.of("spring.redis.host", "livk.com", "spring.redis.port", 5672);
+		Map<String, Object> result = YamlUtils.convertMapToYaml(flat);
+
+		assertThat(result).containsKey("spring");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> spring = (Map<String, Object>) result.get("spring");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> redis = (Map<String, Object>) spring.get("redis");
+		assertThat(redis).containsEntry("host", "livk.com").containsEntry("port", 5672);
 	}
 
 	@Test
-	void convertYamlToMap() throws IOException {
-		Map<String, Object> load = new Yaml().load(yml.getInputStream());
-		Properties result = YamlUtils.convertYamlToMap(load);
-		assertThat(result).isEqualTo(map);
+	void convertMapToYamlWithArrayIndexKeys() {
+		Map<String, Object> flat = Map.of("spring.env[0]", 1, "spring.env[1]", 2);
+		Map<String, Object> result = YamlUtils.convertMapToYaml(flat);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> spring = (Map<String, Object>) result.get("spring");
+		assertThat(spring.get("env")).isEqualTo(List.of(1, 2));
+	}
+
+	// --- convertYamlToMap ---
+
+	@Test
+	void convertYamlToMapWithNestedMap() {
+		Map<String, Object> yaml = Map.of("spring", Map.of("redis", Map.of("host", "livk.com", "port", 5672)));
+		Properties result = YamlUtils.convertYamlToMap(yaml);
+		assertThat(result).containsEntry("spring.redis.host", "livk.com").containsEntry("spring.redis.port", 5672);
+	}
+
+	@Test
+	void convertYamlToMapWithList() {
+		Map<String, Object> yaml = Map.of("spring", Map.of("env", List.of(1, 2)));
+		Properties result = YamlUtils.convertYamlToMap(yaml);
+		assertThat(result).containsEntry("spring.env[0]", 1).containsEntry("spring.env[1]", 2);
+	}
+
+	@Test
+	void convertYamlToMapWithEmptyCollection() {
+		Map<String, Object> yaml = Map.of("tags", Collections.emptyList());
+		Properties result = YamlUtils.convertYamlToMap(yaml);
+		assertThat(result).containsEntry("tags", "");
+	}
+
+	// --- toYml ---
+
+	@Test
+	void toYmlProducesValidYamlString() {
+		Map<String, Object> flat = Map.of("a.b", "value");
+		String yml = YamlUtils.toYml(flat);
+		assertThat(yml).contains("a:").contains("b: value");
+	}
+
+	@Test
+	void toYmlWithEmptyMapReturnsEmptyString() {
+		assertThat(YamlUtils.toYml(Collections.emptyMap())).isEmpty();
+	}
+
+	@Test
+	void toYmlWithNullMapReturnsEmptyString() {
+		assertThat(YamlUtils.toYml(null)).isEmpty();
+	}
+
+	// --- round-trip ---
+
+	@Test
+	void roundTripConversion() {
+		Map<String, Object> flat = Map.of("spring.redis.host", "livk.com", "spring.redis.port", 5672, "spring.env[0]",
+				1, "spring.env[1]", 2);
+		Map<String, Object> yamlMap = YamlUtils.convertMapToYaml(flat);
+		Properties backToFlat = YamlUtils.convertYamlToMap(yamlMap);
+		assertThat(backToFlat).containsAllEntriesOf(flat);
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/HttpParametersTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/HttpParametersTests.java
@@ -19,26 +19,117 @@ package com.livk.commons.web;
 import com.livk.commons.util.HttpServletUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
  */
 class HttpParametersTests {
 
+	// --- constructors ---
+
 	@Test
-	void test() {
+	void defaultConstructorCreatesEmptyParameters() {
+		HttpParameters parameters = new HttpParameters();
+		assertThat(parameters).isEmpty();
+	}
+
+	@Test
+	void constructorWithMultiValueMap() {
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.add("key", "value");
+		HttpParameters parameters = new HttpParameters(map);
+		assertThat(parameters.getFirst("key")).isEqualTo("value");
+	}
+
+	@Test
+	void constructorWithNullThrows() {
+		assertThatThrownBy(() -> new HttpParameters((MultiValueMap<String, String>) null))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	// --- from request ---
+
+	@Test
+	void paramsFromRequestWithMultipleValues() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addParameter("username", "livk", "root", "admin");
-		request.addParameter("password", "123456");
-
 		HttpParameters parameters = HttpServletUtils.params(request);
-
 		assertThat(parameters.get("username")).containsExactly("livk", "root", "admin");
 		assertThat(parameters.getFirst("username")).isEqualTo("livk");
-		assertThat(parameters.getFirst("password")).isEqualTo("123456");
+	}
 
+	@Test
+	void paramsFromRequestWithSingleValue() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("password", "123456");
+		HttpParameters parameters = HttpServletUtils.params(request);
+		assertThat(parameters.getFirst("password")).isEqualTo("123456");
+	}
+
+	// --- getOrEmpty ---
+
+	@Test
+	void getOrEmptyReturnsValuesWhenPresent() {
+		HttpParameters parameters = new HttpParameters();
+		parameters.add("key", "value");
+		assertThat(parameters.getOrEmpty("key")).containsExactly("value");
+	}
+
+	@Test
+	void getOrEmptyReturnsEmptyListWhenAbsent() {
+		HttpParameters parameters = new HttpParameters();
+		assertThat(parameters.getOrEmpty("missing")).isEmpty();
+	}
+
+	// --- equals / hashCode ---
+
+	@Test
+	void equalsAndHashCode() {
+		HttpParameters a = new HttpParameters();
+		a.add("key", "value");
+		HttpParameters b = new HttpParameters();
+		b.add("key", "value");
+		assertThat(a).isEqualTo(b);
+		assertThat(a.hashCode()).isEqualTo(b.hashCode());
+	}
+
+	@Test
+	void notEqualWhenDifferent() {
+		HttpParameters a = new HttpParameters();
+		a.add("key", "a");
+		HttpParameters b = new HttpParameters();
+		b.add("key", "b");
+		assertThat(a).isNotEqualTo(b);
+	}
+
+	// --- toString / formatParameters ---
+
+	@Test
+	void toStringFormatsSingleValue() {
+		HttpParameters parameters = new HttpParameters();
+		parameters.add("name", "livk");
+		assertThat(parameters.toString()).contains("name:\"livk\"");
+	}
+
+	@Test
+	void toStringFormatsMultipleValues() {
+		HttpParameters parameters = new HttpParameters();
+		parameters.addAll("name", List.of("a", "b"));
+		assertThat(parameters.toString()).contains("name:\"a\", \"b\"");
+	}
+
+	@Test
+	void formatParametersProducesExpectedFormat() {
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.add("k", "v");
+		assertThat(HttpParameters.formatParameters(map)).isEqualTo("[k:\"v\"]");
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java
@@ -24,7 +24,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class RequestWrapperTests {
 
+	static final Map<String, String> BODY_MAP = Map.of("root", "root");
+
+	static final byte[] BODY_BYTES = JsonMapperUtils.writeValueAsBytes(BODY_MAP);
+
 	RequestWrapper wrapper;
 
 	@BeforeEach
@@ -41,38 +47,108 @@ class RequestWrapperTests {
 		wrapper = new RequestWrapper(new MockHttpServletRequest());
 	}
 
-	@Test
-	void body() throws IOException {
-		Map<String, String> map = Map.of("root", "root");
-		wrapper.body(JsonMapperUtils.writeValueAsBytes(map));
+	// --- body ---
 
-		assertThat(wrapper.getContentAsByteArray()).isEqualTo(JsonMapperUtils.writeValueAsBytes(map));
-		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(map));
+	@Test
+	void bodySetsByteContentWithDefaultContentType() throws IOException {
+		wrapper.body(BODY_BYTES);
+		assertThat(wrapper.getContentAsByteArray()).isEqualTo(BODY_BYTES);
 		assertThat(wrapper.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
 	}
 
 	@Test
-	void addHeader() {
-		wrapper.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-		wrapper.addHeader(HttpHeaders.USER_AGENT, "test");
-		wrapper.addHeader(HttpHeaders.AGE, "20");
-
-		HttpHeaders headers = HttpServletUtils.headers(wrapper);
-		assertThat(headers.getFirst(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
-		assertThat(headers.getFirst(HttpHeaders.USER_AGENT)).isEqualTo("test");
-		assertThat(headers.getFirst(HttpHeaders.AGE)).isEqualTo("20");
-		assertThat(headers.size()).isEqualTo(3);
+	void bodyWithCustomContentType() throws IOException {
+		wrapper.body(BODY_BYTES, MediaType.TEXT_PLAIN_VALUE);
+		assertThat(wrapper.getContentAsByteArray()).isEqualTo(BODY_BYTES);
+		assertThat(wrapper.getContentType()).isEqualTo(MediaType.TEXT_PLAIN_VALUE);
 	}
 
 	@Test
-	void addParameter() {
-		wrapper.addParameter("username", new String[] { "livk", "root", "admin" });
-		wrapper.addParameter("password", "123456");
+	void getContentAsStringReturnsBodyAsString() throws IOException {
+		wrapper.body(BODY_BYTES);
+		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(BODY_MAP));
+	}
 
-		HttpParameters parameters = HttpServletUtils.params(wrapper);
-		assertThat(parameters.get("username")).containsExactly("livk", "root", "admin");
-		assertThat(parameters.get("password")).containsExactly("123456");
-		assertThat(parameters).hasSize(2);
+	@Test
+	void getInputStreamReturnsBodyContent() throws IOException {
+		wrapper.body(BODY_BYTES);
+		byte[] read = wrapper.getInputStream().readAllBytes();
+		assertThat(read).isEqualTo(BODY_BYTES);
+	}
+
+	@Test
+	void getReaderReturnsBodyContent() throws IOException {
+		wrapper.body(BODY_BYTES);
+		BufferedReader reader = wrapper.getReader();
+		StringBuilder sb = new StringBuilder();
+		String line;
+		while ((line = reader.readLine()) != null) {
+			sb.append(line);
+		}
+		assertThat(sb.toString()).isEqualTo(JsonMapperUtils.writeValueAsString(BODY_MAP));
+	}
+
+	@Test
+	void getContentLengthReflectsBodySize() throws IOException {
+		wrapper.body(BODY_BYTES);
+		assertThat(wrapper.getContentLength()).isEqualTo(BODY_BYTES.length);
+		assertThat(wrapper.getContentLengthLong()).isEqualTo(BODY_BYTES.length);
+	}
+
+	// --- headers ---
+
+	@Test
+	void addHeaderWithSingleValue() {
+		wrapper.addHeader(HttpHeaders.USER_AGENT, "test");
+		assertThat(HttpServletUtils.headers(wrapper).getFirst(HttpHeaders.USER_AGENT)).isEqualTo("test");
+	}
+
+	@Test
+	void addHeaderWithList() {
+		wrapper.addHeader(HttpHeaders.ACCEPT, List.of("text/html", "application/json"));
+		HttpHeaders headers = HttpServletUtils.headers(wrapper);
+		assertThat(headers.get(HttpHeaders.ACCEPT)).contains("text/html", "application/json");
+	}
+
+	@Test
+	void addHeaderWithArray() {
+		wrapper.addHeader(HttpHeaders.ACCEPT, new String[] { "text/html", "application/json" });
+		HttpHeaders headers = HttpServletUtils.headers(wrapper);
+		assertThat(headers.get(HttpHeaders.ACCEPT)).contains("text/html", "application/json");
+	}
+
+	// --- parameters ---
+
+	@Test
+	void addParameterWithSingleValue() {
+		wrapper.addParameter("password", "123456");
+		assertThat(wrapper.getParameter("password")).isEqualTo("123456");
+	}
+
+	@Test
+	void addParameterWithArray() {
+		wrapper.addParameter("username", new String[] { "livk", "root", "admin" });
+		assertThat(wrapper.getParameterValues("username")).containsExactly("livk", "root", "admin");
+	}
+
+	@Test
+	void addParameterWithList() {
+		wrapper.addParameter("tags", List.of("a", "b", "c"));
+		assertThat(wrapper.getParameterValues("tags")).containsExactly("a", "b", "c");
+	}
+
+	@Test
+	void getParameterMapReturnsAllParameters() {
+		wrapper.addParameter("username", "livk");
+		wrapper.addParameter("password", "123456");
+		Map<String, String[]> paramMap = wrapper.getParameterMap();
+		assertThat(paramMap).containsKey("username").containsKey("password");
+		assertThat(paramMap.get("username")).containsExactly("livk");
+	}
+
+	@Test
+	void getParameterReturnsNullForMissingKey() {
+		assertThat(wrapper.getParameter("nonexistent")).isNull();
 	}
 
 }

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/ResponseWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/ResponseWrapperTests.java
@@ -16,13 +16,13 @@
 
 package com.livk.commons.web;
 
-import com.livk.commons.jackson.JsonMapperUtils;
-import com.livk.commons.util.HttpServletUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.IOException;
-import java.util.Map;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,22 +31,87 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ResponseWrapperTests {
 
+	ResponseWrapper wrapper;
+
+	@BeforeEach
+	void setUp() {
+		wrapper = new ResponseWrapper(new MockHttpServletResponse());
+	}
+
+	// --- write via OutputStream ---
+
 	@Test
-	void replaceBody() throws IOException {
+	void writeViaOutputStreamAndReadBack() throws IOException {
+		wrapper.getOutputStream().write("hello".getBytes(StandardCharsets.UTF_8));
+		wrapper.getOutputStream().flush();
+		assertThat(wrapper.getContentAsString()).isEqualTo("hello");
+		assertThat(wrapper.getContentAsByteArray()).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+	}
+
+	// --- write via Writer ---
+
+	@Test
+	void writeViaWriterAndReadBack() throws IOException {
+		PrintWriter writer = wrapper.getWriter();
+		writer.print("world");
+		writer.flush();
+		assertThat(wrapper.getContentAsString()).isEqualTo("world");
+	}
+
+	// --- getContentAsString with charset ---
+
+	@Test
+	void getContentAsStringWithCharset() throws IOException {
+		byte[] utf8Bytes = "你好".getBytes(StandardCharsets.UTF_8);
+		wrapper.getOutputStream().write(utf8Bytes);
+		assertThat(wrapper.getContentAsString(StandardCharsets.UTF_8)).isEqualTo("你好");
+	}
+
+	// --- getCharacterEncoding ---
+
+	@Test
+	void getCharacterEncodingReturnsResponseEncoding() {
 		MockHttpServletResponse response = new MockHttpServletResponse();
+		response.setCharacterEncoding("UTF-8");
+		ResponseWrapper w = new ResponseWrapper(response);
+		assertThat(w.getCharacterEncoding()).isEqualTo("UTF-8");
+	}
 
-		Map<String, String> result = Map.of("username", "livk", "password", "123456");
-		ResponseWrapper wrapper = new ResponseWrapper(response);
-		HttpServletUtils.outJson(wrapper, result);
+	// --- replaceBody(byte[]) ---
 
-		assertThat(wrapper.getContentAsByteArray()).isEqualTo(JsonMapperUtils.writeValueAsBytes(result));
-		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(result));
+	@Test
+	void replaceBodyWithBytesReplacesContent() throws IOException {
+		wrapper.getOutputStream().write("original".getBytes(StandardCharsets.UTF_8));
+		wrapper.replaceBody("replaced".getBytes(StandardCharsets.UTF_8));
+		assertThat(wrapper.getContentAsString()).isEqualTo("replaced");
+	}
 
-		wrapper.replaceBody(JsonMapperUtils.writeValueAsBytes(Map.of("root", "root")));
+	// --- replaceBody(String) ---
 
-		assertThat(wrapper.getContentAsByteArray())
-			.isEqualTo(JsonMapperUtils.writeValueAsBytes(Map.of("root", "root")));
-		assertThat(wrapper.getContentAsString()).isEqualTo(JsonMapperUtils.writeValueAsString(Map.of("root", "root")));
+	@Test
+	void replaceBodyWithStringReplacesContent() throws IOException {
+		wrapper.getOutputStream().write("original".getBytes(StandardCharsets.UTF_8));
+		wrapper.replaceBody("replaced");
+		assertThat(wrapper.getContentAsString()).isEqualTo("replaced");
+	}
+
+	// --- replaceBody(String, Charset) ---
+
+	@Test
+	void replaceBodyWithStringAndCharsetReplacesContent() throws IOException {
+		wrapper.getOutputStream().write("original".getBytes(StandardCharsets.UTF_8));
+		wrapper.replaceBody("replaced", StandardCharsets.UTF_8);
+		assertThat(wrapper.getContentAsByteArray()).isEqualTo("replaced".getBytes(StandardCharsets.UTF_8));
+	}
+
+	// --- reset ---
+
+	@Test
+	void resetClearsBuffer() throws IOException {
+		wrapper.getOutputStream().write("data".getBytes(StandardCharsets.UTF_8));
+		assertThat(wrapper.getContentAsByteArray()).isNotEmpty();
+		wrapper.reset();
+		assertThat(wrapper.getContentAsByteArray()).isEmpty();
 	}
 
 }


### PR DESCRIPTION
- Split large test methods into focused single-scenario tests
- Add descriptive test method names replacing generic test()
- Add missing test coverage for edge cases and error paths
- Fix HttpServletUtils.realIp() to add trimResults() for IP parsing
- Optimize FactoryProxySupport with Constructor/Method caching
- Add ReactorClientCustomizerTests
- Use @TempDir in FileUtilsTests to prevent file leaks
- Extract repeated assertion patterns into helper methods
- Remove test state dependencies (TreeNodeTests)
- Fix invalid time rollback test in SnowflakeIdGeneratorTests