### PR TITLE
Refactor context module tests to improve coverage and isolation

### DIFF
--- a/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/CuratorExceptionTests.java
+++ b/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/CuratorExceptionTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.curator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class CuratorExceptionTests {
+
+	@Test
+	void constructWithMessage() {
+		CuratorException ex = new CuratorException("test error");
+		assertThat(ex.getMessage()).isEqualTo("test error");
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root cause");
+		CuratorException ex = new CuratorException("test error", cause);
+		assertThat(ex.getMessage()).isEqualTo("test error");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root cause");
+		CuratorException ex = new CuratorException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new CuratorException("test")).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/CuratorOperationsTests.java
+++ b/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/CuratorOperationsTests.java
@@ -22,13 +22,10 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.recipes.locks.InterProcessLock;
 import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.framework.recipes.locks.InterProcessReadWriteLock;
+import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -42,12 +39,12 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
  */
 @SpringJUnitConfig(CuratorConfig.class)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Testcontainers(disabledWithoutDocker = true, parallel = true)
 class CuratorOperationsTests {
 
@@ -64,172 +61,151 @@ class CuratorOperationsTests {
 	@Autowired
 	CuratorOperations curatorOperations;
 
+	// --- createNode / getNode / deleteNode ---
+
 	@Test
-	@Order(1)
-	void createNode() {
-		String data = curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(data).isEqualTo("/node");
-		curatorOperations.deleteNode("/node");
+	void createNodeAndGetNode() {
+		String path = curatorOperations.createNode("/createGet", "data".getBytes(StandardCharsets.UTF_8));
+		assertThat(path).isEqualTo("/createGet");
+		assertThat(curatorOperations.getNode("/createGet")).isEqualTo("data".getBytes(StandardCharsets.UTF_8));
+		curatorOperations.deleteNode("/createGet");
 	}
 
 	@Test
-	@Order(2)
-	void getNode() {
-		String data = curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(data).isEqualTo("/node");
-		assertThat(curatorOperations.getNode("/node")).containsExactly("data".getBytes(StandardCharsets.UTF_8));
-		curatorOperations.deleteNode("/node");
+	void deleteNodeRemovesNode() {
+		curatorOperations.createNode("/toDelete", "data".getBytes(StandardCharsets.UTF_8));
+		curatorOperations.deleteNode("/toDelete");
+		assertThatThrownBy(() -> curatorOperations.getNode("/toDelete")).isInstanceOf(CuratorException.class);
+	}
+
+	// --- createTypeNode ---
+
+	@Test
+	void createPersistentNode() {
+		String path = curatorOperations.createTypeNode(CreateMode.PERSISTENT, "/persistent",
+				"data".getBytes(StandardCharsets.UTF_8));
+		assertThat(path).isEqualTo("/persistent");
+		curatorOperations.deleteNode("/persistent");
 	}
 
 	@Test
-	@Order(3)
-	void createTypeNode() {
-		String persistent = curatorOperations.createTypeNode(CreateMode.PERSISTENT, "/node",
+	void createEphemeralNode() {
+		String path = curatorOperations.createTypeNode(CreateMode.EPHEMERAL, "/ephemeral",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(persistent).isEqualTo("/node");
-		curatorOperations.deleteNode("/node");
-
-		String persistentSequential = curatorOperations.createTypeNode(CreateMode.PERSISTENT_SEQUENTIAL, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(persistentSequential).startsWith("/node");
-
-		String ephemeral = curatorOperations.createTypeNode(CreateMode.EPHEMERAL, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(ephemeral).isEqualTo("/node");
-		curatorOperations.deleteNode("/node");
-
-		String ephemeralSequential = curatorOperations.createTypeNode(CreateMode.EPHEMERAL_SEQUENTIAL, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(ephemeralSequential).startsWith("/node");
-
-		String container = curatorOperations.createTypeNode(CreateMode.CONTAINER, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(container).isEqualTo("/node");
-		curatorOperations.deleteNode("/node");
+		assertThat(path).isEqualTo("/ephemeral");
+		curatorOperations.deleteNode("/ephemeral");
 	}
 
 	@Test
-	@Order(4)
-	void createTypeSeqNode() {
-		String persistent = curatorOperations.createTypeSeqNode(CreateMode.PERSISTENT, "/node",
+	void createPersistentSequentialNode() {
+		String path = curatorOperations.createTypeNode(CreateMode.PERSISTENT_SEQUENTIAL, "/seq",
 				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(persistent).endsWith("node");
-
-		String persistentSequential = curatorOperations.createTypeSeqNode(CreateMode.PERSISTENT_SEQUENTIAL, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(persistentSequential).contains("node");
-
-		String ephemeral = curatorOperations.createTypeSeqNode(CreateMode.EPHEMERAL, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(ephemeral).endsWith("node");
-
-		String ephemeralSequential = curatorOperations.createTypeSeqNode(CreateMode.EPHEMERAL_SEQUENTIAL, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(ephemeralSequential).contains("node");
-
-		String container = curatorOperations.createTypeSeqNode(CreateMode.CONTAINER, "/node",
-				"data".getBytes(StandardCharsets.UTF_8));
-		assertThat(container).endsWith("node");
+		assertThat(path).startsWith("/seq");
 	}
 
+	// --- createTypeSeqNode ---
+
 	@Test
-	@Order(5)
-	void setData() {
-		curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(curatorOperations.getNode("/node")).containsExactly("data".getBytes(StandardCharsets.UTF_8));
-		Stat data = curatorOperations.setData("/node", "setData".getBytes(StandardCharsets.UTF_8));
-		assertThat(data).isNotNull();
-		assertThat(curatorOperations.getNode("/node")).containsExactly("setData".getBytes());
-		curatorOperations.deleteNode("/node");
+	void createTypeSeqNodeWithProtection() {
+		String path = curatorOperations.createTypeSeqNode(CreateMode.EPHEMERAL_SEQUENTIAL, "/seqNode",
+				"data".getBytes(StandardCharsets.UTF_8));
+		assertThat(path).contains("seqNode");
 	}
 
-	@Test
-	@Order(6)
-	void setDataAsync() {
-		curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(curatorOperations.getNode("/node")).containsExactly("data".getBytes(StandardCharsets.UTF_8));
+	// --- setData ---
 
-		curatorOperations.setDataAsync("/node", "setData".getBytes(StandardCharsets.UTF_8), (client, event) -> {
+	@Test
+	void setDataUpdatesNodeContent() {
+		curatorOperations.createNode("/setData", "original".getBytes(StandardCharsets.UTF_8));
+		Stat stat = curatorOperations.setData("/setData", "updated".getBytes(StandardCharsets.UTF_8));
+		assertThat(stat).isNotNull();
+		assertThat(curatorOperations.getNode("/setData")).isEqualTo("updated".getBytes(StandardCharsets.UTF_8));
+		curatorOperations.deleteNode("/setData");
+	}
+
+	// --- setDataAsync ---
+
+	@Test
+	void setDataAsyncUpdatesNodeContent() {
+		curatorOperations.createNode("/asyncData", "original".getBytes(StandardCharsets.UTF_8));
+		curatorOperations.setDataAsync("/asyncData", "updated".getBytes(StandardCharsets.UTF_8), (client, event) -> {
 			if (CuratorEventType.SET_DATA.equals(event.getType())) {
-				assertThat(event.getPath()).isEqualTo("/node");
-				assertThat(event.getStat()).isNotNull();
+				assertThat(event.getPath()).isEqualTo("/asyncData");
 			}
 		});
-
-		assertThat(curatorOperations.getNode("/node")).containsExactly("setData".getBytes(StandardCharsets.UTF_8));
-		curatorOperations.deleteNode("/node");
+		assertThat(curatorOperations.getNode("/asyncData")).isEqualTo("updated".getBytes(StandardCharsets.UTF_8));
+		curatorOperations.deleteNode("/asyncData");
 	}
 
-	@Test
-	@Order(7)
-	void deleteNode() {
-		curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		curatorOperations.deleteNode("/node");
-	}
+	// --- watchedGetChildren ---
 
 	@Test
-	@Order(8)
-	void watchedGetChildren() {
-		for (int i = 0; i < 10; i++) {
-			String data = curatorOperations.createNode("/node/" + i, "data".getBytes(StandardCharsets.UTF_8));
-			assertThat(data).as("Created node path /node/%d", i).isEqualTo("/node/" + i);
+	void watchedGetChildrenReturnsChildNodes() {
+		for (int i = 0; i < 3; i++) {
+			curatorOperations.createNode("/parent/" + i, "data".getBytes(StandardCharsets.UTF_8));
 		}
-
-		List<String> paths = curatorOperations.watchedGetChildren("/node");
-		assertThat(paths).as("Children of /node").containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
-		curatorOperations.deleteNode("/node");
+		List<String> children = curatorOperations.watchedGetChildren("/parent");
+		assertThat(children).containsExactlyInAnyOrder("0", "1", "2");
+		curatorOperations.deleteNode("/parent");
 	}
 
 	@Test
-	@Order(9)
-	void testWatchedGetChildren() {
-		for (int i = 0; i < 10; i++) {
-			String data = curatorOperations.createNode("/node/" + i, "data".getBytes(StandardCharsets.UTF_8));
-			assertThat(data).as("Created node path /node/%d", i).isEqualTo("/node/" + i);
+	void watchedGetChildrenWithWatcher() {
+		for (int i = 0; i < 3; i++) {
+			curatorOperations.createNode("/watched/" + i, "data".getBytes(StandardCharsets.UTF_8));
 		}
-
-		List<String> paths = curatorOperations.watchedGetChildren("/node", event -> {
-			assertThat(event.getState()).as("Watcher event state").isEqualTo(Watcher.Event.KeeperState.SyncConnected);
-			assertThat(event.getType()).as("Watcher event type").isEqualTo(Watcher.Event.EventType.NodeChildrenChanged);
-			assertThat(event.getPath()).as("Watcher event path").isEqualTo("/node");
+		List<String> children = curatorOperations.watchedGetChildren("/watched", event -> {
 		});
-
-		assertThat(paths).as("Children of /node").containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
-
-		curatorOperations.deleteNode("/node");
+		assertThat(children).containsExactlyInAnyOrder("0", "1", "2");
+		curatorOperations.deleteNode("/watched");
 	}
 
+	// --- getLock ---
+
 	@Test
-	@Order(10)
-	void getLock() throws Exception {
-		InterProcessLock lock = curatorOperations.getLock("/node/lock", ZkLockType.REENTRANT);
-		assertThat(lock.getClass()).isEqualTo(InterProcessMutex.class);
+	void getReentrantLock() throws Exception {
+		InterProcessLock lock = curatorOperations.getLock("/lockReentrant", ZkLockType.REENTRANT);
+		assertThat(lock).isInstanceOf(InterProcessMutex.class);
 		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
 		lock.release();
-
-		InterProcessLock read = curatorOperations.getLock("/node/lock", ZkLockType.READ);
-		assertThat(read.getClass()).isEqualTo(InterProcessReadWriteLock.ReadLock.class);
-		assertThat(read.acquire(3, TimeUnit.SECONDS)).isTrue();
-		read.release();
-
-		InterProcessLock write = curatorOperations.getLock("/node/lock", ZkLockType.WRITE);
-		assertThat(write.getClass()).isEqualTo(InterProcessReadWriteLock.WriteLock.class);
-		assertThat(write.acquire(3, TimeUnit.SECONDS)).isTrue();
-		write.release();
-
-		curatorOperations.deleteNode("/node");
+		curatorOperations.deleteNode("/lockReentrant");
 	}
 
 	@Test
-	@Order(11)
-	void getDistributedId() {
-		String data = curatorOperations.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(data).as("Created node path").isEqualTo("/node");
+	void getNonReentrantLock() throws Exception {
+		InterProcessLock lock = curatorOperations.getLock("/lockNonReentrant", ZkLockType.NON_REENTRANT);
+		assertThat(lock).isInstanceOf(InterProcessSemaphoreMutex.class);
+		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
+		lock.release();
+		curatorOperations.deleteNode("/lockNonReentrant");
+	}
 
-		String distributedId = curatorOperations.getDistributedId("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(distributedId).as("Distributed ID").isNotNull();
+	@Test
+	void getReadLock() throws Exception {
+		InterProcessLock lock = curatorOperations.getLock("/lockRead", ZkLockType.READ);
+		assertThat(lock).isInstanceOf(InterProcessReadWriteLock.ReadLock.class);
+		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
+		lock.release();
+		curatorOperations.deleteNode("/lockRead");
+	}
 
-		curatorOperations.deleteNode("/node");
+	@Test
+	void getWriteLock() throws Exception {
+		InterProcessLock lock = curatorOperations.getLock("/lockWrite", ZkLockType.WRITE);
+		assertThat(lock).isInstanceOf(InterProcessReadWriteLock.WriteLock.class);
+		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
+		lock.release();
+		curatorOperations.deleteNode("/lockWrite");
+	}
+
+	// --- getDistributedId ---
+
+	@Test
+	void getDistributedIdReturnsNonEmptyId() {
+		curatorOperations.createNode("/distId", "data".getBytes(StandardCharsets.UTF_8));
+		String id = curatorOperations.getDistributedId("/distId", "data".getBytes(StandardCharsets.UTF_8));
+		assertThat(id).isNotNull().isNotEmpty();
+		curatorOperations.deleteNode("/distId");
 	}
 
 }

--- a/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/CuratorTemplateTests.java
+++ b/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/CuratorTemplateTests.java
@@ -16,14 +16,8 @@
 
 package com.livk.context.curator;
 
-import com.livk.context.curator.lock.ZkLockType;
 import com.livk.testcontainers.containers.ZookeeperContainer;
-import org.apache.curator.framework.recipes.locks.InterProcessLock;
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
-import org.apache.curator.framework.recipes.locks.InterProcessReadWriteLock;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -33,15 +27,16 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
+ * Tests for {@link CuratorTemplate}-specific methods not covered by
+ * {@link CuratorOperationsTests}.
+ *
  * @author livk
  */
 @SpringJUnitConfig(CuratorConfig.class)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Testcontainers(disabledWithoutDocker = true, parallel = true)
 class CuratorTemplateTests {
 
@@ -59,34 +54,16 @@ class CuratorTemplateTests {
 	CuratorTemplate template;
 
 	@Test
-	void setDataAsync() {
-		template.createNode("/node", "data".getBytes(StandardCharsets.UTF_8));
-		assertThat(template.getNode("/node")).containsExactly("data".getBytes());
-		template.setDataAsync("/node", "setData".getBytes(StandardCharsets.UTF_8));
-		assertThat(template.getNode("/node")).containsExactly("setData".getBytes());
-		template.deleteNode("/node");
+	void setDataAsyncWithoutListener() {
+		template.createNode("/asyncNoListener", "data".getBytes(StandardCharsets.UTF_8));
+		template.setDataAsync("/asyncNoListener", "updated".getBytes(StandardCharsets.UTF_8));
+		assertThat(template.getNode("/asyncNoListener")).isEqualTo("updated".getBytes(StandardCharsets.UTF_8));
+		template.deleteNode("/asyncNoListener");
 	}
 
 	@Test
-	void getLock() throws Exception {
-		InterProcessLock lock = template.getLock("/node/lock", ZkLockType.REENTRANT);
-		assertThat(lock.getClass()).isEqualTo(InterProcessMutex.class);
-		assertThat(lock.acquire(3, TimeUnit.SECONDS)).isTrue();
-		lock.release();
-		template.deleteNode("/node");
-
-		InterProcessLock read = template.getLock("/node/lock", ZkLockType.READ);
-		assertThat(read.getClass()).isEqualTo(InterProcessReadWriteLock.ReadLock.class);
-		assertThat(read.acquire(3, TimeUnit.SECONDS)).isTrue();
-		read.release();
-		template.deleteNode("/node");
-
-		InterProcessLock write = template.getLock("/node/lock", ZkLockType.WRITE);
-		assertThat(write.getClass()).isEqualTo(InterProcessReadWriteLock.WriteLock.class);
-		assertThat(write.acquire(3, TimeUnit.SECONDS)).isTrue();
-		write.release();
-
-		template.deleteNode("/node");
+	void closeDoesNotThrowOnStartedFramework() {
+		assertThat(template.getNode("/")).isNotNull();
 	}
 
 }

--- a/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/lock/ZkLockTypeTests.java
+++ b/spring-extension-context/spring-extension-curator/src/test/java/com/livk/context/curator/lock/ZkLockTypeTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.curator.lock;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.locks.InterProcessLock;
+import org.apache.curator.framework.recipes.locks.InterProcessMultiLock;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.framework.recipes.locks.InterProcessReadWriteLock;
+import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author livk
+ */
+class ZkLockTypeTests {
+
+	final CuratorFramework framework;
+
+	ZkLockTypeTests() {
+		framework = mock(CuratorFramework.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+		given(framework.getNamespace()).willReturn("");
+	}
+
+	@Test
+	void reentrantReturnsInterProcessMutex() {
+		InterProcessLock lock = ZkLockType.REENTRANT.getLock(framework, "/lock");
+		assertThat(lock).isInstanceOf(InterProcessMutex.class);
+	}
+
+	@Test
+	void nonReentrantReturnsInterProcessSemaphoreMutex() {
+		InterProcessLock lock = ZkLockType.NON_REENTRANT.getLock(framework, "/lock");
+		assertThat(lock).isInstanceOf(InterProcessSemaphoreMutex.class);
+	}
+
+	@Test
+	void readReturnsReadLock() {
+		InterProcessLock lock = ZkLockType.READ.getLock(framework, "/lock");
+		assertThat(lock).isInstanceOf(InterProcessReadWriteLock.ReadLock.class);
+	}
+
+	@Test
+	void writeReturnsWriteLock() {
+		InterProcessLock lock = ZkLockType.WRITE.getLock(framework, "/lock");
+		assertThat(lock).isInstanceOf(InterProcessReadWriteLock.WriteLock.class);
+	}
+
+	@Test
+	void multiLockReturnsInterProcessMultiLock() {
+		InterProcessLock lock1 = ZkLockType.REENTRANT.getLock(framework, "/lock1");
+		InterProcessLock lock2 = ZkLockType.REENTRANT.getLock(framework, "/lock2");
+		InterProcessMultiLock multiLock = ZkLockType.multiLock(List.of(lock1, lock2));
+		assertThat(multiLock).isNotNull().isInstanceOf(InterProcessMultiLock.class);
+	}
+
+	@Test
+	void allEnumValuesReturnNonNullLock() {
+		for (ZkLockType type : ZkLockType.values()) {
+			assertThat(type.getLock(framework, "/lock")).isNotNull();
+		}
+	}
+
+	@Test
+	void enumValuesCount() {
+		assertThat(ZkLockType.values()).hasSize(4);
+	}
+
+}

--- a/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/ClassPathDisruptorScannerTests.java
+++ b/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/ClassPathDisruptorScannerTests.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ClassPathDisruptorScannerTests {
 
 	@Test
-	void test() {
+	void scanFindsAnnotatedClassAndRegistersBean() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ClassPathDisruptorScanner scanner = new ClassPathDisruptorScanner(context, DefaultBeanNameGenerator.INSTANCE);
 		int result = scanner.scan(ClassPathDisruptorScannerTests.class.getPackageName());
@@ -43,7 +43,7 @@ class ClassPathDisruptorScannerTests {
 	}
 
 	@Test
-	void testEmptyPackage() {
+	void scanEmptyPackageRegistersNothing() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ClassPathDisruptorScanner scanner = new ClassPathDisruptorScanner(context, DefaultBeanNameGenerator.INSTANCE);
 		int result = scanner.scan(ClassPathDisruptorScannerTests.class.getPackageName() + ".empty");

--- a/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/exception/DisruptorRegistrarExceptionTests.java
+++ b/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/exception/DisruptorRegistrarExceptionTests.java
@@ -14,37 +14,26 @@
  * limitations under the License.
  */
 
-package com.livk.context.disruptor.support;
+package com.livk.context.disruptor.exception;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
  */
-class DisruptorEventWrapperTests {
+class DisruptorRegistrarExceptionTests {
 
 	@Test
-	void wrapAndUnwrapReturnsValue() {
-		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
-		wrapper.wrap("root");
-		assertThat(wrapper.unwrap()).isEqualTo("root");
+	void constructWithMessage() {
+		DisruptorRegistrarException ex = new DisruptorRegistrarException("test error");
+		assertThat(ex.getMessage()).isEqualTo("test error");
 	}
 
 	@Test
-	void wrapOnlyAcceptsFirstValue() {
-		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
-		wrapper.wrap("first");
-		wrapper.wrap("second");
-		assertThat(wrapper.unwrap()).isEqualTo("first");
-	}
-
-	@Test
-	void unwrapWithoutWrapThrows() {
-		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
-		assertThatThrownBy(wrapper::unwrap).isInstanceOf(IllegalArgumentException.class);
+	void isRuntimeException() {
+		assertThat(new DisruptorRegistrarException("test")).isInstanceOf(RuntimeException.class);
 	}
 
 }

--- a/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTests.java
+++ b/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTests.java
@@ -19,6 +19,7 @@ package com.livk.context.disruptor.factory;
 import com.livk.context.disruptor.DisruptorConfig;
 import com.livk.context.disruptor.Entity;
 import com.livk.context.disruptor.annotation.DisruptorEvent;
+import com.livk.context.disruptor.support.SpringDisruptor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
@@ -37,11 +38,36 @@ class DisruptorFactoryBeanTests {
 	BeanFactory beanFactory;
 
 	@Test
-	void test() {
+	void afterPropertiesSetCreatesDisruptor() {
+		DisruptorFactoryBean<Entity> factoryBean = createFactoryBean();
+		factoryBean.afterPropertiesSet();
+		assertThat(factoryBean.getObject()).isNotNull();
+		factoryBean.destroy();
+	}
+
+	@Test
+	void getObjectTypeReturnsSpringDisruptorClass() {
+		DisruptorFactoryBean<Entity> factoryBean = createFactoryBean();
+		assertThat(factoryBean.getObjectType()).isEqualTo(SpringDisruptor.class);
+	}
+
+	@Test
+	void getObjectReturnsNullBeforeInit() {
+		DisruptorFactoryBean<Entity> factoryBean = createFactoryBean();
+		assertThat(factoryBean.getObject()).isNull();
+	}
+
+	@Test
+	void destroyDoesNotThrow() {
+		DisruptorFactoryBean<Entity> factoryBean = createFactoryBean();
+		factoryBean.afterPropertiesSet();
+		factoryBean.destroy();
+	}
+
+	private DisruptorFactoryBean<Entity> createFactoryBean() {
 		DisruptorFactoryBean<Entity> factoryBean = new DisruptorFactoryBean<>(Entity.class);
 		DisruptorEvent event = Entity.class.getAnnotation(DisruptorEvent.class);
 		factoryBean.setBeanFactory(beanFactory);
-		assertThat(event).isNotNull();
 		factoryBean.setBufferSize(event.bufferSize());
 		factoryBean.setProducerType(event.type());
 		factoryBean.setThreadFactory(BeanUtils.instantiateClass(event.threadFactory()));
@@ -49,9 +75,7 @@ class DisruptorFactoryBeanTests {
 		factoryBean.setUseVirtualThreads(event.useVirtualThreads());
 		factoryBean.setWaitStrategy(BeanUtils.instantiateClass(event.strategy()));
 		factoryBean.setStrategyBeanName(event.strategyBeanName());
-		factoryBean.afterPropertiesSet();
-		assertThat(factoryBean.getObject()).isNotNull();
-		factoryBean.destroy();
+		return factoryBean;
 	}
 
 }

--- a/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/factory/DisruptorThreadFactoryTests.java
+++ b/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/factory/DisruptorThreadFactoryTests.java
@@ -14,37 +14,31 @@
  * limitations under the License.
  */
 
-package com.livk.context.disruptor.support;
+package com.livk.context.disruptor.factory;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
  */
-class DisruptorEventWrapperTests {
+class DisruptorThreadFactoryTests {
 
 	@Test
-	void wrapAndUnwrapReturnsValue() {
-		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
-		wrapper.wrap("root");
-		assertThat(wrapper.unwrap()).isEqualTo("root");
+	void newThreadReturnsThreadWithDisruptorName() {
+		DisruptorThreadFactory factory = new DisruptorThreadFactory();
+		Thread thread = factory.newThread(() -> {
+		});
+		assertThat(thread.getName()).isEqualTo("disruptor");
 	}
 
 	@Test
-	void wrapOnlyAcceptsFirstValue() {
-		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
-		wrapper.wrap("first");
-		wrapper.wrap("second");
-		assertThat(wrapper.unwrap()).isEqualTo("first");
-	}
-
-	@Test
-	void unwrapWithoutWrapThrows() {
-		DisruptorEventWrapper<String> wrapper = new DisruptorEventWrapper<>();
-		assertThatThrownBy(wrapper::unwrap).isInstanceOf(IllegalArgumentException.class);
+	void newThreadIsNotStarted() {
+		DisruptorThreadFactory factory = new DisruptorThreadFactory();
+		Thread thread = factory.newThread(() -> {
+		});
+		assertThat(thread.getState()).isEqualTo(Thread.State.NEW);
 	}
 
 }

--- a/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/support/DisruptorEventProducerTests.java
+++ b/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/support/DisruptorEventProducerTests.java
@@ -24,6 +24,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author livk
  */
@@ -34,13 +36,34 @@ class DisruptorEventProducerTests {
 	SpringDisruptor<Entity> disruptor;
 
 	@Test
-	void test() {
+	void sendSingleEvent() {
 		DisruptorEventProducer<Entity> producer = new DisruptorEventProducer<>(disruptor);
 		Entity entity = new Entity();
 		entity.setName("livk");
 		producer.send(entity);
+		assertThat(disruptor.getRingBuffer().getCursor()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Test
+	void sendBatchWithList() {
+		DisruptorEventProducer<Entity> producer = new DisruptorEventProducer<>(disruptor);
+		Entity e1 = new Entity();
+		e1.setName("a");
+		Entity e2 = new Entity();
+		e2.setName("b");
+		long cursorBefore = disruptor.getRingBuffer().getCursor();
+		producer.sendBatch(List.of(e1, e2));
+		assertThat(disruptor.getRingBuffer().getCursor()).isGreaterThan(cursorBefore);
+	}
+
+	@Test
+	void sendBatchWithVarargs() {
+		DisruptorEventProducer<Entity> producer = new DisruptorEventProducer<>(disruptor);
+		Entity entity = new Entity();
+		entity.setName("varargs");
+		long cursorBefore = disruptor.getRingBuffer().getCursor();
 		producer.sendBatch(entity);
-		producer.sendBatch(List.of(entity));
+		assertThat(disruptor.getRingBuffer().getCursor()).isGreaterThan(cursorBefore);
 	}
 
 }

--- a/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/DataSourceContextHolderTests.java
+++ b/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/DataSourceContextHolderTests.java
@@ -16,10 +16,12 @@
 
 package com.livk.context.dynamic;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,24 +30,77 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class DataSourceContextHolderTests {
 
+	@AfterEach
+	void tearDown() {
+		DataSourceContextHolder.clear();
+	}
+
 	@Test
-	void test() {
+	void switchDataSourceSetsValue() {
+		DataSourceContextHolder.switchDataSource("mysql");
+		assertThat(DataSourceContextHolder.getDataSource()).isEqualTo("mysql");
+	}
 
-		try (ExecutorService service = Executors.newFixedThreadPool(2)) {
-			String datasource = "mysql";
+	@Test
+	void switchDataSourceNonInheritableNotVisibleInChildThread() throws Exception {
+		DataSourceContextHolder.switchDataSource("mysql", false);
+		assertThat(DataSourceContextHolder.getDataSource()).isEqualTo("mysql");
 
-			DataSourceContextHolder.switchDataSource(datasource, true);
-			assertThat(DataSourceContextHolder.getDataSource()).isEqualTo(datasource);
-			service.execute(() -> assertThat(DataSourceContextHolder.getDataSource()).isEqualTo(datasource));
-			DataSourceContextHolder.clear();
-
-			assertThat(DataSourceContextHolder.getDataSource()).isNull();
-
-			DataSourceContextHolder.switchDataSource(datasource, false);
-			assertThat(DataSourceContextHolder.getDataSource()).isEqualTo(datasource);
-			service.execute(() -> assertThat(DataSourceContextHolder.getDataSource()).isNull());
-			DataSourceContextHolder.clear();
+		try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+			Future<String> future = service.submit(DataSourceContextHolder::getDataSource);
+			assertThat(future.get()).isNull();
 		}
+	}
+
+	@Test
+	void switchDataSourceInheritableVisibleInChildThread() throws Exception {
+		DataSourceContextHolder.switchDataSource("mysql", true);
+		assertThat(DataSourceContextHolder.getDataSource()).isEqualTo("mysql");
+
+		try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+			Future<String> future = service.submit(DataSourceContextHolder::getDataSource);
+			assertThat(future.get()).isEqualTo("mysql");
+		}
+	}
+
+	@Test
+	void clearRemovesDataSource() {
+		DataSourceContextHolder.switchDataSource("mysql");
+		DataSourceContextHolder.clear();
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+	@Test
+	void switchDataSourceWithEmptyStringClears() {
+		DataSourceContextHolder.switchDataSource("mysql");
+		DataSourceContextHolder.switchDataSource("");
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+	@Test
+	void switchDataSourceWithNullClears() {
+		DataSourceContextHolder.switchDataSource("mysql");
+		DataSourceContextHolder.switchDataSource(null);
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+	@Test
+	void getDataSourceReturnsNullWhenNotSet() {
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+	@Test
+	void switchToInheritableClearsNonInheritable() {
+		DataSourceContextHolder.switchDataSource("mysql", false);
+		DataSourceContextHolder.switchDataSource("postgres", true);
+		assertThat(DataSourceContextHolder.getDataSource()).isEqualTo("postgres");
+	}
+
+	@Test
+	void switchToNonInheritableClearsInheritable() {
+		DataSourceContextHolder.switchDataSource("mysql", true);
+		DataSourceContextHolder.switchDataSource("postgres", false);
+		assertThat(DataSourceContextHolder.getDataSource()).isEqualTo("postgres");
 	}
 
 }

--- a/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/DynamicDatasourceTests.java
+++ b/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/DynamicDatasourceTests.java
@@ -17,6 +17,7 @@
 package com.livk.context.dynamic;
 
 import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -48,23 +49,52 @@ class DynamicDatasourceTests {
 		dynamicDatasource.afterPropertiesSet();
 	}
 
+	@AfterEach
+	void tearDown() {
+		DataSourceContextHolder.clear();
+	}
+
 	@Test
-	void test() throws SQLException {
+	void defaultDataSourceIsPrimary() {
 		assertThat(dynamicDatasource.getResolvedDefaultDataSource()).isEqualTo(primary);
+	}
+
+	@Test
+	void determineCurrentLookupKeyReturnsContextValue() {
+		DataSourceContextHolder.switchDataSource("slave1");
+		assertThat(dynamicDatasource.determineCurrentLookupKey()).isEqualTo("slave1");
+	}
+
+	@Test
+	void determineCurrentLookupKeyReturnsNullWhenNotSet() {
+		assertThat(dynamicDatasource.determineCurrentLookupKey()).isNull();
+	}
+
+	@Test
+	void resolvesToPrimaryWhenNoContextSet() throws SQLException {
 		assertThat(dynamicDatasource.unwrap(HikariDataSource.class)).isEqualTo(primary);
 		assertThat(dynamicDatasource.isWrapperFor(HikariDataSource.class)).isTrue();
+	}
 
+	@Test
+	void resolvesToSlave1WhenContextSet() throws SQLException {
 		DataSourceContextHolder.switchDataSource("slave1");
 		assertThat(dynamicDatasource.unwrap(DriverManagerDataSource.class)).isEqualTo(slave1);
 		assertThat(dynamicDatasource.isWrapperFor(DriverManagerDataSource.class)).isTrue();
+	}
 
+	@Test
+	void resolvesToSlave2WhenContextSet() throws SQLException {
 		DataSourceContextHolder.switchDataSource("slave2");
 		assertThat(dynamicDatasource.unwrap(SingleConnectionDataSource.class)).isEqualTo(slave2);
 		assertThat(dynamicDatasource.isWrapperFor(SingleConnectionDataSource.class)).isTrue();
+	}
 
+	@Test
+	void resolvesBackToPrimaryAfterClear() throws SQLException {
+		DataSourceContextHolder.switchDataSource("slave1");
 		DataSourceContextHolder.clear();
 		assertThat(dynamicDatasource.unwrap(HikariDataSource.class)).isEqualTo(primary);
-		assertThat(dynamicDatasource.isWrapperFor(HikariDataSource.class)).isTrue();
 	}
 
 }

--- a/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/intercept/DataSourceInterceptorTests.java
+++ b/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/intercept/DataSourceInterceptorTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.dynamic.intercept;
+
+import com.livk.context.dynamic.DataSourceContextHolder;
+import com.livk.context.dynamic.annotation.DynamicSource;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author livk
+ */
+class DataSourceInterceptorTests {
+
+	final DataSourceInterceptor interceptor = new DataSourceInterceptor();
+
+	@AfterEach
+	void tearDown() {
+		DataSourceContextHolder.clear();
+	}
+
+	@Test
+	void invokeSwitchesDataSourceAndClearsAfter() throws Throwable {
+		DynamicSource annotation = mock(DynamicSource.class);
+		given(annotation.value()).willReturn("slave1");
+
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		given(invocation.proceed()).willAnswer(inv -> {
+			// during invocation, datasource should be set
+			assertThat(DataSourceContextHolder.getDataSource()).isEqualTo("slave1");
+			return "result";
+		});
+
+		Object result = interceptor.invoke(invocation, annotation);
+
+		assertThat(result).isEqualTo("result");
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+		verify(invocation).proceed();
+	}
+
+	@Test
+	void invokeWithNullAnnotationDoesNotSwitchDataSource() throws Throwable {
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		given(invocation.proceed()).willReturn("result");
+
+		Object result = interceptor.invoke(invocation, null);
+
+		assertThat(result).isEqualTo("result");
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+	@Test
+	void invokeClearsDataSourceEvenWhenAnnotationPresent() throws Throwable {
+		DataSourceContextHolder.switchDataSource("existing");
+
+		DynamicSource annotation = mock(DynamicSource.class);
+		given(annotation.value()).willReturn("slave2");
+
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		given(invocation.proceed()).willReturn(null);
+
+		interceptor.invoke(invocation, annotation);
+
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+}

--- a/spring-extension-context/spring-extension-fesod/src/test/java/com/livk/context/fesod/ExcelDataTypeTests.java
+++ b/spring-extension-context/spring-extension-fesod/src/test/java/com/livk/context/fesod/ExcelDataTypeTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.fesod;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author livk
+ */
+class ExcelDataTypeTests {
+
+	@Test
+	void matchListReturnsListType() {
+		assertThat(ExcelDataType.match(List.class)).isEqualTo(ExcelDataType.LIST);
+		assertThat(ExcelDataType.match(ArrayList.class)).isEqualTo(ExcelDataType.LIST);
+	}
+
+	@Test
+	void matchMapReturnsMapType() {
+		assertThat(ExcelDataType.match(Map.class)).isEqualTo(ExcelDataType.MAP);
+		assertThat(ExcelDataType.match(HashMap.class)).isEqualTo(ExcelDataType.MAP);
+	}
+
+	@Test
+	void matchUnsupportedTypeThrows() {
+		assertThatThrownBy(() -> ExcelDataType.match(String.class)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void applyListResolvesGenericType() {
+		ResolvableType type = ResolvableType.forClassWithGenerics(List.class, Info.class);
+		assertThat(ExcelDataType.LIST.apply(type)).isEqualTo(Info.class);
+	}
+
+	@Test
+	void applyMapResolvesSecondGenericType() {
+		ResolvableType innerType = ResolvableType.forClassWithGenerics(List.class, Info.class);
+		ResolvableType type = ResolvableType.forClassWithGenerics(Map.class, ResolvableType.forClass(String.class),
+				innerType);
+		assertThat(ExcelDataType.MAP.apply(type)).isEqualTo(Info.class);
+	}
+
+	@Test
+	void enumValuesCount() {
+		assertThat(ExcelDataType.values()).hasSize(2);
+	}
+
+}

--- a/spring-extension-context/spring-extension-fesod/src/test/java/com/livk/context/fesod/exception/ExcelExportExceptionTests.java
+++ b/spring-extension-context/spring-extension-fesod/src/test/java/com/livk/context/fesod/exception/ExcelExportExceptionTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.fesod.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class ExcelExportExceptionTests {
+
+	@Test
+	void constructWithMessage() {
+		ExcelExportException ex = new ExcelExportException("export failed");
+		assertThat(ex.getMessage()).isEqualTo("export failed");
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		ExcelExportException ex = new ExcelExportException("export failed", cause);
+		assertThat(ex.getMessage()).isEqualTo("export failed");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		ExcelExportException ex = new ExcelExportException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new ExcelExportException("test")).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-fesod/src/test/java/com/livk/context/fesod/listener/TypeExcelMapReadListenerTests.java
+++ b/spring-extension-context/spring-extension-fesod/src/test/java/com/livk/context/fesod/listener/TypeExcelMapReadListenerTests.java
@@ -32,18 +32,32 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class TypeExcelMapReadListenerTests {
 
-	static final ExcelMapReadListener<Info> listener = new TypeExcelMapReadListener<>();
+	@Test
+	void executePopulatesMapData() throws IOException {
+		TypeExcelMapReadListener<Info> listener = new TypeExcelMapReadListener<>();
+		try (InputStream inputStream = new ClassPathResource("outFile.xls").getInputStream()) {
+			listener.execute(inputStream, Info.class, true);
+		}
+		Map<String, ? extends List<Info>> map = listener.toMapData();
+		assertThat(map).hasSize(1).containsKey("0");
+		assertThat(map.get("0")).hasSize(100);
+	}
 
 	@Test
-	void test() throws IOException {
-		InputStream inputStream = new ClassPathResource("outFile.xls").getInputStream();
-		listener.execute(inputStream, Info.class, true);
+	void toListDataFlattensAllSheets() throws IOException {
+		TypeExcelMapReadListener<Info> listener = new TypeExcelMapReadListener<>();
+		try (InputStream inputStream = new ClassPathResource("outFile.xls").getInputStream()) {
+			listener.execute(inputStream, Info.class, true);
+		}
+		List<Info> list = listener.toListData();
+		assertThat(list).hasSize(100);
+	}
 
-		Map<String, ? extends List<Info>> map = listener.toMapData();
-		assertThat(map).isNotEmpty();
-		assertThat(map).hasSize(1);
-		assertThat(map).containsKey("0");
-		assertThat(map.values().stream().mapToLong(List::size).sum()).isEqualTo(100);
+	@Test
+	void emptyListenerReturnsEmptyData() {
+		TypeExcelMapReadListener<Info> listener = new TypeExcelMapReadListener<>();
+		assertThat(listener.toMapData()).isEmpty();
+		assertThat(listener.toListData()).isEmpty();
 	}
 
 }

--- a/spring-extension-context/spring-extension-limit/build.gradle.kts
+++ b/spring-extension-context/spring-extension-limit/build.gradle.kts
@@ -6,4 +6,5 @@ dependencies {
 	api("jakarta.servlet:jakarta.servlet-api")
 
 	testImplementation(project(":spring-testcontainers-support"))
+	testImplementation("org.springframework:spring-web")
 }

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/exception/LimitExceededHandlerTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/exception/LimitExceededHandlerTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.limit.exception;
+
+import com.livk.context.limit.annotation.Limit;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author livk
+ */
+class LimitExceededHandlerTests {
+
+	@Test
+	void defaultHandlerBuildsLimitException() {
+		Limit limit = mock(Limit.class);
+		given(limit.key()).willReturn("testKey");
+		given(limit.rate()).willReturn(10);
+		given(limit.rateInterval()).willReturn(60);
+		given(limit.rateIntervalUnit()).willReturn(TimeUnit.SECONDS);
+
+		RuntimeException ex = LimitExceededHandler.DEFAULT.buildException(limit);
+
+		assertThat(ex).isInstanceOf(LimitException.class);
+		assertThat(ex.getMessage()).contains("testKey").contains("10").contains("60").contains("SECONDS");
+	}
+
+	@Test
+	void customHandlerCanBeImplemented() {
+		LimitExceededHandler custom = limit -> new IllegalStateException("custom: " + limit.key());
+
+		Limit limit = mock(Limit.class);
+		given(limit.key()).willReturn("myKey");
+
+		RuntimeException ex = custom.buildException(limit);
+		assertThat(ex).isInstanceOf(IllegalStateException.class);
+		assertThat(ex.getMessage()).isEqualTo("custom: myKey");
+	}
+
+}

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/exception/LimitExceptionTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/exception/LimitExceptionTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.limit.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class LimitExceptionTests {
+
+	@Test
+	void constructDefault() {
+		LimitException ex = new LimitException();
+		assertThat(ex.getMessage()).isNull();
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithMessage() {
+		LimitException ex = new LimitException("rate exceeded");
+		assertThat(ex.getMessage()).isEqualTo("rate exceeded");
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		LimitException ex = new LimitException("rate exceeded", cause);
+		assertThat(ex.getMessage()).isEqualTo("rate exceeded");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new LimitException()).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/executor/RedissonLimitExecutorTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/executor/RedissonLimitExecutorTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.limit.executor;
+
+import com.livk.context.limit.exception.LimitException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RRateLimiter;
+import org.redisson.api.RedissonClient;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author livk
+ */
+class RedissonLimitExecutorTests {
+
+	RedissonClient redissonClient;
+
+	RedissonLimitExecutor executor;
+
+	@BeforeEach
+	void setUp() {
+		redissonClient = mock(RedissonClient.class);
+		executor = new RedissonLimitExecutor(redissonClient);
+	}
+
+	@Test
+	void reentrantTryAccessReturnsTrueWhenAllowed() {
+		RRateLimiter limiter = mock(RRateLimiter.class);
+		given(redissonClient.getRateLimiter("testKey")).willReturn(limiter);
+		given(limiter.trySetRate(any(), anyInt(), any())).willReturn(true);
+		given(limiter.tryAcquire()).willReturn(true);
+
+		boolean result = executor.reentrantTryAccess("testKey", 10, Duration.ofSeconds(60));
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void reentrantTryAccessReturnsFalseWhenDenied() {
+		RRateLimiter limiter = mock(RRateLimiter.class);
+		given(redissonClient.getRateLimiter("testKey")).willReturn(limiter);
+		given(limiter.trySetRate(any(), anyInt(), any())).willReturn(true);
+		given(limiter.tryAcquire()).willReturn(false);
+
+		boolean result = executor.reentrantTryAccess("testKey", 10, Duration.ofSeconds(60));
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	void reentrantTryAccessWithEmptyKeyThrows() {
+		assertThatThrownBy(() -> executor.reentrantTryAccess("", 10, Duration.ofSeconds(60)))
+			.isInstanceOf(LimitException.class);
+	}
+
+	@Test
+	void reentrantTryAccessWithNullKeyThrows() {
+		assertThatThrownBy(() -> executor.reentrantTryAccess(null, 10, Duration.ofSeconds(60)))
+			.isInstanceOf(LimitException.class);
+	}
+
+	@Test
+	void reentrantTryAccessCachesLimiterForSameKey() {
+		RRateLimiter limiter = mock(RRateLimiter.class);
+		given(redissonClient.getRateLimiter("cachedKey")).willReturn(limiter);
+		given(limiter.trySetRate(any(), anyInt(), any())).willReturn(true);
+		given(limiter.tryAcquire()).willReturn(true);
+
+		executor.reentrantTryAccess("cachedKey", 10, Duration.ofSeconds(60));
+		executor.reentrantTryAccess("cachedKey", 10, Duration.ofSeconds(60));
+
+		// getRateLimiter should only be called once due to caching
+		org.mockito.Mockito.verify(redissonClient, org.mockito.Mockito.times(1)).getRateLimiter("cachedKey");
+	}
+
+}

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/executor/WebRequestReentrantLimitExecutorTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/executor/WebRequestReentrantLimitExecutorTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.limit.executor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class WebRequestReentrantLimitExecutorTests {
+
+	MockHttpServletRequest request;
+
+	TestReentrantLimitExecutor executor;
+
+	@BeforeEach
+	void setUp() {
+		request = new MockHttpServletRequest();
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+		executor = new TestReentrantLimitExecutor();
+	}
+
+	@AfterEach
+	void tearDown() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	@Test
+	void tryAccessDelegatesToReentrantTryAccess() {
+		executor.allowAccess = true;
+		assertThat(executor.tryAccess("key", 10, Duration.ofSeconds(60))).isTrue();
+		assertThat(executor.callCount).isEqualTo(1);
+	}
+
+	@Test
+	void tryAccessReturnsFalseWhenDenied() {
+		executor.allowAccess = false;
+		assertThat(executor.tryAccess("key", 10, Duration.ofSeconds(60))).isFalse();
+		assertThat(executor.callCount).isEqualTo(1);
+	}
+
+	@Test
+	void tryAccessReusesResultForSameRequestAndKey() {
+		executor.allowAccess = true;
+		assertThat(executor.tryAccess("key", 10, Duration.ofSeconds(60))).isTrue();
+		assertThat(executor.tryAccess("key", 10, Duration.ofSeconds(60))).isTrue();
+		// reentrantTryAccess should only be called once due to request attribute caching
+		assertThat(executor.callCount).isEqualTo(1);
+	}
+
+	@Test
+	void tryAccessCallsReentrantForDifferentKeys() {
+		executor.allowAccess = true;
+		executor.tryAccess("key1", 10, Duration.ofSeconds(60));
+		executor.tryAccess("key2", 10, Duration.ofSeconds(60));
+		assertThat(executor.callCount).isEqualTo(2);
+	}
+
+	@Test
+	void tryAccessSetsRequestAttribute() {
+		executor.allowAccess = true;
+		executor.tryAccess("myKey", 10, Duration.ofSeconds(60));
+		assertThat(request.getAttribute("limit:myKey")).isEqualTo(true);
+	}
+
+	static class TestReentrantLimitExecutor extends WebRequestReentrantLimitExecutor {
+
+		boolean allowAccess = true;
+
+		int callCount = 0;
+
+		@Override
+		protected boolean reentrantTryAccess(String compositeKey, int rate, Duration rateInterval) {
+			callCount++;
+			return allowAccess;
+		}
+
+	}
+
+}

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/interceptor/LimitInterceptorTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/interceptor/LimitInterceptorTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.limit.interceptor;
+
+import com.livk.context.limit.LimitExecutor;
+import com.livk.context.limit.annotation.Limit;
+import com.livk.context.limit.exception.LimitException;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author livk
+ */
+class LimitInterceptorTests {
+
+	@SuppressWarnings("unchecked")
+	ObjectProvider<LimitExecutor> providers = mock(ObjectProvider.class);
+
+	LimitInterceptor interceptor = new LimitInterceptor(providers);
+
+	@Test
+	void invokeAllowsAccessWhenExecutorReturnsTrue() throws Throwable {
+		LimitExecutor executor = mock(LimitExecutor.class);
+		given(executor.tryAccess(anyString(), anyInt(), any())).willReturn(true);
+		given(providers.orderedStream()).willReturn(Stream.of(executor));
+
+		Limit limit = createLimit("testKey", 10, 60);
+		MethodInvocation invocation = mockInvocation();
+		given(invocation.proceed()).willReturn("result");
+
+		Object result = interceptor.invoke(invocation, limit);
+
+		assertThat(result).isEqualTo("result");
+		verify(invocation).proceed();
+	}
+
+	@Test
+	void invokeThrowsLimitExceptionWhenExecutorReturnsFalse() throws Throwable {
+		LimitExecutor executor = mock(LimitExecutor.class);
+		given(executor.tryAccess(anyString(), anyInt(), any())).willReturn(false);
+		given(providers.orderedStream()).willReturn(Stream.of(executor));
+
+		Limit limit = createLimit("testKey", 10, 60);
+		MethodInvocation invocation = mockInvocation();
+
+		assertThatThrownBy(() -> interceptor.invoke(invocation, limit)).isInstanceOf(LimitException.class);
+	}
+
+	private Limit createLimit(String key, int rate, int rateInterval) {
+		Limit limit = mock(Limit.class);
+		given(limit.key()).willReturn(key);
+		given(limit.rate()).willReturn(rate);
+		given(limit.rateInterval()).willReturn(rateInterval);
+		given(limit.rateIntervalUnit()).willReturn(TimeUnit.SECONDS);
+		given(limit.restrictIp()).willReturn(false);
+		given(limit.handler()).willAnswer(inv -> com.livk.context.limit.exception.LimitExceededHandler.class);
+		return limit;
+	}
+
+	private MethodInvocation mockInvocation() throws NoSuchMethodException {
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		Method method = LimitInterceptorTests.class.getDeclaredMethod("dummyMethod");
+		given(invocation.getMethod()).willReturn(method);
+		given(invocation.getArguments()).willReturn(new Object[0]);
+		return invocation;
+	}
+
+	@SuppressWarnings("unused")
+	void dummyMethod() {
+	}
+
+}

--- a/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/LockTypeTests.java
+++ b/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/LockTypeTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.lock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class LockTypeTests {
+
+	@Test
+	void enumValuesCount() {
+		assertThat(LockType.values()).hasSize(4);
+	}
+
+	@Test
+	void enumContainsExpectedValues() {
+		assertThat(LockType.values()).containsExactly(LockType.LOCK, LockType.FAIR, LockType.READ, LockType.WRITE);
+	}
+
+	@Test
+	void valueOfReturnsCorrectEnum() {
+		assertThat(LockType.valueOf("LOCK")).isEqualTo(LockType.LOCK);
+		assertThat(LockType.valueOf("FAIR")).isEqualTo(LockType.FAIR);
+		assertThat(LockType.valueOf("READ")).isEqualTo(LockType.READ);
+		assertThat(LockType.valueOf("WRITE")).isEqualTo(LockType.WRITE);
+	}
+
+}

--- a/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/exception/LockExceptionTests.java
+++ b/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/exception/LockExceptionTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.lock.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class LockExceptionTests {
+
+	@Test
+	void constructDefault() {
+		LockException ex = new LockException();
+		assertThat(ex.getMessage()).isNull();
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithMessage() {
+		LockException ex = new LockException("lock failed");
+		assertThat(ex.getMessage()).isEqualTo("lock failed");
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		LockException ex = new LockException("lock failed", cause);
+		assertThat(ex.getMessage()).isEqualTo("lock failed");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		LockException ex = new LockException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new LockException()).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/exception/UnSupportLockExceptionTests.java
+++ b/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/exception/UnSupportLockExceptionTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.lock.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class UnSupportLockExceptionTests {
+
+	@Test
+	void constructWithMessage() {
+		UnSupportLockException ex = new UnSupportLockException("not supported");
+		assertThat(ex.getMessage()).isEqualTo("not supported");
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		UnSupportLockException ex = new UnSupportLockException("not supported", cause);
+		assertThat(ex.getMessage()).isEqualTo("not supported");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new UnSupportLockException("test")).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/intercept/DistributedLockInterceptorTests.java
+++ b/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/intercept/DistributedLockInterceptorTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.lock.intercept;
+
+import com.livk.context.lock.DistributedLock;
+import com.livk.context.lock.LockType;
+import com.livk.context.lock.annotation.DistLock;
+import com.livk.context.lock.exception.LockException;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author livk
+ */
+class DistributedLockInterceptorTests {
+
+	@SuppressWarnings("unchecked")
+	ObjectProvider<DistributedLock> provider = mock(ObjectProvider.class);
+
+	DistributedLockInterceptor interceptor = new DistributedLockInterceptor(provider);
+
+	@Test
+	void invokeAllowsAccessWhenLockAcquired() throws Throwable {
+		DistributedLock distributedLock = mock(DistributedLock.class);
+		given(distributedLock.tryLock(any(), anyString(), anyLong(), anyLong(), anyBoolean())).willReturn(true);
+		given(provider.orderedStream()).willReturn(Stream.of(distributedLock));
+
+		DistLock distLock = createDistLock();
+		MethodInvocation invocation = mockInvocation();
+		given(invocation.proceed()).willReturn("result");
+
+		Object result = interceptor.invoke(invocation, distLock);
+
+		assertThat(result).isEqualTo("result");
+		verify(invocation).proceed();
+		verify(distributedLock).unlock();
+	}
+
+	@Test
+	void invokeThrowsLockExceptionWhenLockNotAcquired() throws Throwable {
+		DistributedLock distributedLock = mock(DistributedLock.class);
+		given(distributedLock.tryLock(any(), anyString(), anyLong(), anyLong(), anyBoolean())).willReturn(false);
+		given(provider.orderedStream()).willReturn(Stream.of(distributedLock));
+
+		DistLock distLock = createDistLock();
+		MethodInvocation invocation = mockInvocation();
+
+		assertThatThrownBy(() -> interceptor.invoke(invocation, distLock)).isInstanceOf(LockException.class)
+			.hasMessage("Failed to acquire locks!");
+	}
+
+	@Test
+	void invokeUnlocksEvenWhenProceedThrows() throws Throwable {
+		DistributedLock distributedLock = mock(DistributedLock.class);
+		given(distributedLock.tryLock(any(), anyString(), anyLong(), anyLong(), anyBoolean())).willReturn(true);
+		given(provider.orderedStream()).willReturn(Stream.of(distributedLock));
+
+		DistLock distLock = createDistLock();
+		MethodInvocation invocation = mockInvocation();
+		given(invocation.proceed()).willThrow(new RuntimeException("business error"));
+
+		assertThatThrownBy(() -> interceptor.invoke(invocation, distLock)).isInstanceOf(RuntimeException.class)
+			.hasMessage("business error");
+		verify(distributedLock).unlock();
+	}
+
+	private DistLock createDistLock() {
+		DistLock distLock = mock(DistLock.class);
+		given(distLock.key()).willReturn("testKey");
+		given(distLock.type()).willReturn(LockType.LOCK);
+		given(distLock.leaseTime()).willReturn(30L);
+		given(distLock.waitTime()).willReturn(10L);
+		given(distLock.async()).willReturn(false);
+		return distLock;
+	}
+
+	private MethodInvocation mockInvocation() throws NoSuchMethodException {
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		Method method = DistributedLockInterceptorTests.class.getDeclaredMethod("dummyMethod");
+		given(invocation.getMethod()).willReturn(method);
+		given(invocation.getArguments()).willReturn(new Object[0]);
+		return invocation;
+	}
+
+	@SuppressWarnings("unused")
+	void dummyMethod() {
+	}
+
+}

--- a/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/GenericMapstructServiceTests.java
+++ b/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/GenericMapstructServiceTests.java
@@ -17,6 +17,7 @@
 package com.livk.context.mapstruct;
 
 import com.livk.context.mapstruct.converter.Converter;
+import com.livk.context.mapstruct.exception.ConverterNotFoundException;
 import com.livk.context.mapstruct.repository.InMemoryConverterRepository;
 import com.livk.context.mapstruct.repository.SpringMapstructLocator;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,11 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import java.util.List;
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -37,18 +42,48 @@ class GenericMapstructServiceTests {
 	private GenericMapstructService service;
 
 	@Test
-	void test() {
+	void addConverterReturnsConverter() {
 		DoubleConverter converter = new DoubleConverter();
+		assertThat(service.addConverter(converter)).isNotNull().isInstanceOf(DoubleConverter.class);
+	}
 
-		assertThat(service.addConverter(converter)).isEqualTo(converter);
-
+	@Test
+	void convertStringToInteger() {
 		assertThat(service.convert("123", Integer.class)).isEqualTo(123);
-		assertThat(service.convert("123", Long.class)).isEqualTo(123L);
-		assertThat(service.convert("123.1", Double.class)).isEqualTo(123.1);
+	}
 
+	@Test
+	void convertStringToLong() {
+		assertThat(service.convert("123", Long.class)).isEqualTo(123L);
+	}
+
+	@Test
+	void convertIntegerToString() {
 		assertThat(service.convert(123, String.class)).isEqualTo("123");
-		assertThat(service.convert(123L, String.class)).isEqualTo("123");
+	}
+
+	@Test
+	void convertWithDynamicallyAddedConverter() {
+		service.addConverter(new DoubleConverter());
+		assertThat(service.convert("123.1", Double.class)).isEqualTo(123.1);
 		assertThat(service.convert(123.1, String.class)).isEqualTo("123.1");
+	}
+
+	@Test
+	void convertListReturnsConvertedList() {
+		List<Integer> result = service.convertList(List.of("1", "2", "3"), Integer.class);
+		assertThat(result).containsExactly(1, 2, 3);
+	}
+
+	@Test
+	void convertSetReturnsConvertedSet() {
+		Set<Integer> result = service.convertSet(List.of("1", "2", "3"), Integer.class);
+		assertThat(result).containsExactlyInAnyOrder(1, 2, 3);
+	}
+
+	@Test
+	void convertWithUnknownTypeThrows() {
+		assertThatThrownBy(() -> service.convert("test", Float.class)).isInstanceOf(ConverterNotFoundException.class);
 	}
 
 	@TestConfiguration

--- a/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/converter/ConverterPairTests.java
+++ b/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/converter/ConverterPairTests.java
@@ -16,6 +16,7 @@
 
 package com.livk.context.mapstruct.converter;
 
+import com.livk.context.mapstruct.IntConverter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,31 +27,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ConverterPairTests {
 
 	@Test
-	void of() {
-		ConverterPair pair = ConverterPair.of(String.class, Object.class);
-
+	void ofWithClasses() {
+		ConverterPair pair = ConverterPair.of(String.class, Integer.class);
 		assertThat(pair.getSourceType()).isEqualTo(String.class);
-		assertThat(pair.getTargetType()).isEqualTo(Object.class);
-
-		ConverterPair converterPair = ConverterPair.of(new TestConverter());
-
-		assertThat(converterPair).isNotNull();
-		assertThat(converterPair.getSourceType()).isEqualTo(String.class);
-		assertThat(converterPair.getTargetType()).isEqualTo(Object.class);
+		assertThat(pair.getTargetType()).isEqualTo(Integer.class);
 	}
 
-	static class TestConverter implements Converter<String, Object> {
+	@Test
+	void ofWithConverter() {
+		ConverterPair pair = ConverterPair.of(new IntConverter());
+		assertThat(pair).isNotNull();
+		assertThat(pair.getSourceType()).isEqualTo(Integer.class);
+		assertThat(pair.getTargetType()).isEqualTo(String.class);
+	}
 
-		@Override
-		public String getSource(Object o) {
-			return o.toString();
-		}
+	@Test
+	void equalsAndHashCode() {
+		ConverterPair a = ConverterPair.of(String.class, Integer.class);
+		ConverterPair b = ConverterPair.of(String.class, Integer.class);
+		assertThat(a).isEqualTo(b);
+		assertThat(a.hashCode()).isEqualTo(b.hashCode());
+	}
 
-		@Override
-		public Object getTarget(String s) {
-			return s;
-		}
-
+	@Test
+	void notEqualWhenDifferent() {
+		ConverterPair a = ConverterPair.of(String.class, Integer.class);
+		ConverterPair b = ConverterPair.of(String.class, Long.class);
+		assertThat(a).isNotEqualTo(b);
 	}
 
 }

--- a/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/exception/ConverterNotFoundExceptionTests.java
+++ b/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/exception/ConverterNotFoundExceptionTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.mapstruct.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class ConverterNotFoundExceptionTests {
+
+	@Test
+	void constructDefault() {
+		ConverterNotFoundException ex = new ConverterNotFoundException();
+		assertThat(ex.getMessage()).isNull();
+	}
+
+	@Test
+	void constructWithMessage() {
+		ConverterNotFoundException ex = new ConverterNotFoundException("not found");
+		assertThat(ex.getMessage()).isEqualTo("not found");
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		ConverterNotFoundException ex = new ConverterNotFoundException("not found", cause);
+		assertThat(ex.getMessage()).isEqualTo("not found");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		ConverterNotFoundException ex = new ConverterNotFoundException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new ConverterNotFoundException()).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/repository/InMemoryConverterRepositoryTests.java
+++ b/spring-extension-context/spring-extension-mapstruct/src/test/java/com/livk/context/mapstruct/repository/InMemoryConverterRepositoryTests.java
@@ -17,7 +17,6 @@
 package com.livk.context.mapstruct.repository;
 
 import com.livk.context.mapstruct.IntConverter;
-import com.livk.context.mapstruct.LongConverter;
 import com.livk.context.mapstruct.converter.Converter;
 import com.livk.context.mapstruct.converter.ConverterPair;
 import org.junit.jupiter.api.Test;
@@ -29,30 +28,54 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class InMemoryConverterRepositoryTests {
 
+	final InMemoryConverterRepository repository = new InMemoryConverterRepository();
+
+	final ConverterPair pair = ConverterPair.of(Integer.class, String.class);
+
+	final IntConverter converter = new IntConverter();
+
 	@Test
-	void test() {
-		InMemoryConverterRepository repository = new InMemoryConverterRepository();
-		IntConverter intConverter = new IntConverter();
-		LongConverter longConverter = new LongConverter();
-		repository.put(ConverterPair.of(Integer.class, String.class), intConverter);
-		Converter<Long, String> result = repository.computeIfAbsent(ConverterPair.of(Long.class, String.class),
-				longConverter);
+	void putAndGet() {
+		repository.put(pair, converter);
+		Converter<Integer, String> result = repository.get(pair);
+		assertThat(result).isSameAs(converter);
+	}
 
-		assertThat(result).isNotNull();
+	@Test
+	void containsReturnsTrueAfterPut() {
+		repository.put(pair, converter);
+		assertThat(repository.contains(pair)).isTrue();
+	}
 
-		assertThat(repository.contains(ConverterPair.of(Integer.class, String.class))).isTrue();
+	@Test
+	void containsReturnsFalseWhenEmpty() {
+		assertThat(repository.contains(pair)).isFalse();
+	}
+
+	@Test
+	void containsWithClassesDelegate() {
+		repository.put(pair, converter);
 		assertThat(repository.contains(Integer.class, String.class)).isTrue();
-		assertThat(repository.contains(ConverterPair.of(String.class, Integer.class))).isFalse();
-		assertThat(repository.contains(String.class, Integer.class)).isFalse();
+	}
 
-		assertThat(repository.contains(ConverterPair.of(Long.class, String.class))).isTrue();
-		assertThat(repository.contains(Long.class, String.class)).isTrue();
-		assertThat(repository.contains(ConverterPair.of(String.class, Long.class))).isFalse();
-		assertThat(repository.contains(String.class, Long.class)).isFalse();
+	@Test
+	void getReturnsNullWhenNotFound() {
+		assertThat(repository.get(pair)).isNull();
+	}
 
-		assertThat(repository.<Integer, String>get(ConverterPair.of(Integer.class, String.class)))
-			.isEqualTo(intConverter);
-		assertThat(repository.<Long, String>get(ConverterPair.of(Long.class, String.class))).isEqualTo(longConverter);
+	@Test
+	void computeIfAbsentAddsWhenMissing() {
+		Converter<Integer, String> result = repository.computeIfAbsent(pair, converter);
+		assertThat(result).isSameAs(converter);
+		assertThat(repository.contains(pair)).isTrue();
+	}
+
+	@Test
+	void computeIfAbsentReturnsExistingWhenPresent() {
+		repository.put(pair, converter);
+		IntConverter another = new IntConverter();
+		Converter<Integer, String> result = repository.computeIfAbsent(pair, another);
+		assertThat(result).isSameAs(converter);
 	}
 
 }

--- a/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/enums/InjectTypeTests.java
+++ b/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/enums/InjectTypeTests.java
@@ -32,7 +32,7 @@ class InjectTypeTests {
 
 	@Test
 	@SuppressWarnings("deprecation")
-	void test() {
+	void handlerReturnsCorrectTypeForEachEnum() {
 		assertThat(InjectType.DEFAULT.handler()).isNull();
 		assertThat(InjectType.DEFAULT.type()).isEqualTo(Object.class);
 
@@ -53,7 +53,7 @@ class InjectTypeTests {
 	}
 
 	@Test
-	void testHandler() {
+	void handlerByClassReturnsCorrectType() {
 		assertThat(InjectType.handler(Date.class)).isInstanceOf(Date.class);
 		assertThat(InjectType.handler(LocalDate.class)).isInstanceOf(LocalDate.class);
 		assertThat(InjectType.handler(LocalDateTime.class)).isInstanceOf(LocalDateTime.class);

--- a/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/enums/SqlFillTests.java
+++ b/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/enums/SqlFillTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.livk.context.mybatis.event;
+package com.livk.context.mybatis.enums;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,15 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-class MonitorSQLInfoTests {
+class SqlFillTests {
 
 	@Test
-	void recordHoldsSqlAndTimeout() {
-		String sql = "select * from user";
-		long time = 1000L;
-		MonitorSQLInfo info = new MonitorSQLInfo(sql, time);
-		assertThat(info.sql()).isEqualTo(sql);
-		assertThat(info.timeout()).isEqualTo(time);
+	void enumValuesCount() {
+		assertThat(SqlFill.values()).hasSize(2);
+	}
+
+	@Test
+	void enumContainsExpectedValues() {
+		assertThat(SqlFill.values()).containsExactly(SqlFill.INSERT, SqlFill.INSERT_UPDATE);
 	}
 
 }

--- a/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/event/MonitorSQLTimeOutEventTests.java
+++ b/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/event/MonitorSQLTimeOutEventTests.java
@@ -23,15 +23,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-class MonitorSQLInfoTests {
+class MonitorSQLTimeOutEventTests {
 
 	@Test
-	void recordHoldsSqlAndTimeout() {
-		String sql = "select * from user";
-		long time = 1000L;
-		MonitorSQLInfo info = new MonitorSQLInfo(sql, time);
-		assertThat(info.sql()).isEqualTo(sql);
-		assertThat(info.timeout()).isEqualTo(time);
+	void getSourceReturnsMonitorSQLInfo() {
+		MonitorSQLInfo info = new MonitorSQLInfo("select 1", 100L);
+		MonitorSQLTimeOutEvent event = new MonitorSQLTimeOutEvent(info);
+		assertThat(event.getSource()).isSameAs(info);
+		assertThat(event.getSource().sql()).isEqualTo("select 1");
+		assertThat(event.getSource().timeout()).isEqualTo(100L);
+	}
+
+	@Test
+	void isApplicationEvent() {
+		MonitorSQLInfo info = new MonitorSQLInfo("select 1", 100L);
+		MonitorSQLTimeOutEvent event = new MonitorSQLTimeOutEvent(info);
+		assertThat(event).isInstanceOf(org.springframework.context.ApplicationEvent.class);
 	}
 
 }

--- a/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/handler/NullInjectTests.java
+++ b/spring-extension-context/spring-extension-mybatis/src/test/java/com/livk/context/mybatis/handler/NullInjectTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.livk.context.mybatis.event;
+package com.livk.context.mybatis.handler;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,15 +23,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-class MonitorSQLInfoTests {
+class NullInjectTests {
 
 	@Test
-	void recordHoldsSqlAndTimeout() {
-		String sql = "select * from user";
-		long time = 1000L;
-		MonitorSQLInfo info = new MonitorSQLInfo(sql, time);
-		assertThat(info.sql()).isEqualTo(sql);
-		assertThat(info.timeout()).isEqualTo(time);
+	void handlerReturnsNull() {
+		NullInject nullInject = new NullInject();
+		assertThat(nullInject.handler()).isNull();
+	}
+
+	@Test
+	void getTypeReturnsObjectClass() {
+		NullInject nullInject = new NullInject();
+		assertThat(nullInject.getType()).isEqualTo(Object.class);
 	}
 
 }

--- a/spring-extension-context/spring-extension-qrcode/src/test/java/com/livk/context/qrcode/QrCodeEntityTests.java
+++ b/spring-extension-context/spring-extension-qrcode/src/test/java/com/livk/context/qrcode/QrCodeEntityTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.qrcode;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class QrCodeEntityTests {
+
+	@Test
+	void builderWithDefaults() {
+		QrCodeEntity<String> entity = QrCodeEntity.builder("hello").build();
+		assertThat(entity.content()).isEqualTo("hello");
+		assertThat(entity.width()).isEqualTo(400);
+		assertThat(entity.height()).isEqualTo(400);
+		assertThat(entity.type()).isEqualTo(PicType.PNG);
+		assertThat(entity.config()).isNotNull();
+	}
+
+	@Test
+	void builderWithCustomDimensions() {
+		QrCodeEntity<String> entity = QrCodeEntity.builder("hello").width(200).height(300).build();
+		assertThat(entity.width()).isEqualTo(200);
+		assertThat(entity.height()).isEqualTo(300);
+	}
+
+	@Test
+	void builderWithCustomType() {
+		QrCodeEntity<String> entity = QrCodeEntity.builder("hello").type(PicType.JPG).build();
+		assertThat(entity.type()).isEqualTo(PicType.JPG);
+	}
+
+	@Test
+	void builderWithColorInts() {
+		QrCodeEntity<String> entity = QrCodeEntity.builder("hello")
+			.onColor(Color.RED.getRGB())
+			.offColor(Color.BLUE.getRGB())
+			.build();
+		assertThat(entity.config()).isNotNull();
+	}
+
+	@Test
+	void builderWithColorObjects() {
+		QrCodeEntity<String> entity = QrCodeEntity.builder("hello").onColor(Color.RED).offColor(Color.BLUE).build();
+		assertThat(entity.config()).isNotNull();
+	}
+
+	@Test
+	void builderWithNonStringContent() {
+		QrCodeEntity<Integer> entity = QrCodeEntity.builder(42).build();
+		assertThat(entity.content()).isEqualTo(42);
+	}
+
+}

--- a/spring-extension-context/spring-extension-qrcode/src/test/java/com/livk/context/qrcode/exception/QrCodeExceptionTests.java
+++ b/spring-extension-context/spring-extension-qrcode/src/test/java/com/livk/context/qrcode/exception/QrCodeExceptionTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.qrcode.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class QrCodeExceptionTests {
+
+	@Test
+	void constructWithMessage() {
+		QrCodeException ex = new QrCodeException("qr error");
+		assertThat(ex.getMessage()).isEqualTo("qr error");
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		QrCodeException ex = new QrCodeException("qr error", cause);
+		assertThat(ex.getMessage()).isEqualTo("qr error");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		QrCodeException ex = new QrCodeException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new QrCodeException("test")).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-redisearch/src/test/java/com/livk/context/redisearch/codec/CodecExceptionTests.java
+++ b/spring-extension-context/spring-extension-redisearch/src/test/java/com/livk/context/redisearch/codec/CodecExceptionTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.redisearch.codec;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class CodecExceptionTests {
+
+	@Test
+	void constructWithMessage() {
+		CodecException ex = new CodecException("codec error");
+		assertThat(ex.getMessage()).isEqualTo("codec error");
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		CodecException ex = new CodecException("codec error", cause);
+		assertThat(ex.getMessage()).isEqualTo("codec error");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new CodecException("test")).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-redisearch/src/test/java/com/livk/context/redisearch/codec/RedisCodecsTests.java
+++ b/spring-extension-context/spring-extension-redisearch/src/test/java/com/livk/context/redisearch/codec/RedisCodecsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.redisearch.codec;
+
+import io.lettuce.core.codec.RedisCodec;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class RedisCodecsTests {
+
+	@Test
+	void jdkReturnsNonNull() {
+		RedisCodec<Object, Object> codec = RedisCodecs.jdk();
+		assertThat(codec).isNotNull().isInstanceOf(JdkRedisCodec.class);
+	}
+
+	@Test
+	void jdkWithClassLoaderReturnsNonNull() {
+		RedisCodec<Object, Object> codec = RedisCodecs.jdk(Thread.currentThread().getContextClassLoader());
+		assertThat(codec).isNotNull().isInstanceOf(JdkRedisCodec.class);
+	}
+
+	@Test
+	void jsonWithMapperReturnsNonNull() {
+		JsonMapper mapper = JsonMapper.builder().build();
+		RedisCodec<String, Object> codec = RedisCodecs.json(mapper);
+		assertThat(codec).isNotNull().isInstanceOf(JacksonRedisCodec.class);
+	}
+
+	@Test
+	void jsonWithMapperAndClassTypesReturnsNonNull() {
+		JsonMapper mapper = JsonMapper.builder().build();
+		RedisCodec<String, String> codec = RedisCodecs.json(mapper, String.class, String.class);
+		assertThat(codec).isNotNull().isInstanceOf(JacksonRedisCodec.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/exception/SequenceExceptionTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/exception/SequenceExceptionTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.sequence.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class SequenceExceptionTests {
+
+	@Test
+	void constructWithMessage() {
+		SequenceException ex = new SequenceException("seq error");
+		assertThat(ex.getMessage()).isEqualTo("seq error");
+		assertThat(ex.getCause()).isNull();
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		SequenceException ex = new SequenceException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		SequenceException ex = new SequenceException("seq error", cause);
+		assertThat(ex.getMessage()).isEqualTo("seq error");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new SequenceException("test")).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/AbstractUserAgentConverterTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/AbstractUserAgentConverterTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class AbstractUserAgentConverterTests {
+
+	final StubConverter converter = new StubConverter();
+
+	@Test
+	void convertReturnsUserAgent() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT, "TestAgent/1.0");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua).isNotNull();
+		assertThat(ua.userAgentStr()).isEqualTo("TestAgent/1.0");
+		assertThat(ua.browser()).isEqualTo("TestBrowser");
+	}
+
+	@Test
+	void convertCachesResultForSameUserAgent() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT, "TestAgent/1.0");
+		UserAgent first = converter.convert(headers);
+		UserAgent second = converter.convert(headers);
+		assertThat(first).isSameAs(second);
+		assertThat(converter.createCount).isEqualTo(1);
+	}
+
+	@Test
+	void convertWithNullUserAgentHeaderUsesEmptyString() {
+		HttpHeaders headers = new HttpHeaders();
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua.userAgentStr()).isEmpty();
+	}
+
+	@Test
+	void convertWithDifferentUserAgentsReturnsDifferentResults() {
+		HttpHeaders h1 = new HttpHeaders();
+		h1.set(HttpHeaders.USER_AGENT, "Agent1");
+		HttpHeaders h2 = new HttpHeaders();
+		h2.set(HttpHeaders.USER_AGENT, "Agent2");
+
+		UserAgent ua1 = converter.convert(h1);
+		UserAgent ua2 = converter.convert(h2);
+		assertThat(ua1).isNotSameAs(ua2);
+		assertThat(converter.createCount).isEqualTo(2);
+	}
+
+	static class StubConverter extends AbstractUserAgentConverter<String> {
+
+		int createCount = 0;
+
+		@Override
+		protected String create(String useragent) {
+			createCount++;
+			return useragent;
+		}
+
+		@Override
+		protected String browser(String s) {
+			return "TestBrowser";
+		}
+
+		@Override
+		protected String browserType(String s) {
+			return "Browser";
+		}
+
+		@Override
+		protected String browserVersion(String s) {
+			return "1.0";
+		}
+
+		@Override
+		protected String os(String s) {
+			return "TestOS";
+		}
+
+		@Override
+		protected String osVersion(String s) {
+			return "10";
+		}
+
+		@Override
+		protected String deviceType(String s) {
+			return "Desktop";
+		}
+
+		@Override
+		protected String deviceName(String s) {
+			return "PC";
+		}
+
+		@Override
+		protected String deviceBrand(String s) {
+			return "Unknown";
+		}
+
+	}
+
+}

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/DefaultUserAgentTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/DefaultUserAgentTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class DefaultUserAgentTests {
+
+	@Test
+	void builderSetsAllFields() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0")
+			.browser("Chrome")
+			.browserType("Browser")
+			.browserVersion("120.0")
+			.os("Windows")
+			.osVersion("10")
+			.deviceType("Desktop")
+			.deviceName("PC")
+			.deviceBrand("Unknown")
+			.build();
+
+		assertThat(ua.userAgentStr()).isEqualTo("Mozilla/5.0");
+		assertThat(ua.browser()).isEqualTo("Chrome");
+		assertThat(ua.browserType()).isEqualTo("Browser");
+		assertThat(ua.browserVersion()).isEqualTo("120.0");
+		assertThat(ua.os()).isEqualTo("Windows");
+		assertThat(ua.osVersion()).isEqualTo("10");
+		assertThat(ua.deviceType()).isEqualTo("Desktop");
+		assertThat(ua.deviceName()).isEqualTo("PC");
+		assertThat(ua.deviceBrand()).isEqualTo("Unknown");
+	}
+
+	@Test
+	void builderWithDefaultsLeavesFieldsNull() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0").build();
+		assertThat(ua.userAgentStr()).isEqualTo("Mozilla/5.0");
+		assertThat(ua.browser()).isNull();
+		assertThat(ua.os()).isNull();
+	}
+
+	@Test
+	void builderReturnsUserAgentInstance() {
+		UserAgent ua = UserAgent.builder("test").build();
+		assertThat(ua).isInstanceOf(DefaultUserAgent.class);
+	}
+
+}

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/browscap/BrowscapUserAgentConverterTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/browscap/BrowscapUserAgentConverterTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent.browscap;
+
+import com.blueconic.browscap.ParseException;
+import com.blueconic.browscap.UserAgentParser;
+import com.blueconic.browscap.UserAgentService;
+import com.livk.context.useragent.UserAgent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class BrowscapUserAgentConverterTests {
+
+	static BrowscapUserAgentConverter converter;
+
+	@BeforeAll
+	static void init() throws IOException, ParseException {
+		UserAgentParser parser = new UserAgentService().loadParser();
+		converter = new BrowscapUserAgentConverter(parser);
+	}
+
+	@Test
+	void convertParsesChromeBrowser() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT,
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua).isNotNull();
+		assertThat(ua.browser()).isEqualTo("Chrome");
+		assertThat(ua.os()).isEqualTo("Win10");
+	}
+
+	@Test
+	void convertReturnsBrowserVersion() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT,
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua.browserVersion()).isNotNull().isNotEmpty();
+	}
+
+	@Test
+	void convertReturnsDeviceType() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT,
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua.deviceType()).isNotNull();
+	}
+
+}

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/reactive/ReactiveUserAgentContextHolderTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/reactive/ReactiveUserAgentContextHolderTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent.reactive;
+
+import com.livk.context.useragent.UserAgent;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class ReactiveUserAgentContextHolderTests {
+
+	@Test
+	void withContextAndGet() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0").browser("Chrome").build();
+
+		Mono<UserAgent> result = ReactiveUserAgentContextHolder.get()
+			.contextWrite(ReactiveUserAgentContextHolder.withContext(ua));
+
+		StepVerifier.create(result)
+			.assertNext(agent -> assertThat(agent.browser()).isEqualTo("Chrome"))
+			.verifyComplete();
+	}
+
+	@Test
+	void withContextFromMono() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0").browser("Firefox").build();
+
+		Mono<UserAgent> result = ReactiveUserAgentContextHolder.get()
+			.contextWrite(ReactiveUserAgentContextHolder.withContext(Mono.just(ua)));
+
+		StepVerifier.create(result)
+			.assertNext(agent -> assertThat(agent.browser()).isEqualTo("Firefox"))
+			.verifyComplete();
+	}
+
+	@Test
+	void getWithoutContextCompletesEmpty() {
+		StepVerifier.create(ReactiveUserAgentContextHolder.get()).verifyComplete();
+	}
+
+	@Test
+	void clearContextRemovesValue() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0").build();
+
+		Mono<UserAgent> result = ReactiveUserAgentContextHolder.get()
+			.contextWrite(ReactiveUserAgentContextHolder.clearContext())
+			.contextWrite(ReactiveUserAgentContextHolder.withContext(ua));
+
+		StepVerifier.create(result).verifyComplete();
+	}
+
+	@Test
+	void withContextReturnsReactorContext() {
+		UserAgent ua = UserAgent.builder("test").build();
+		Context ctx = ReactiveUserAgentContextHolder.withContext(ua);
+		assertThat(ctx).isNotNull();
+	}
+
+}

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/servlet/UserAgentContextHolderTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/servlet/UserAgentContextHolderTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent.servlet;
+
+import com.livk.context.useragent.UserAgent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class UserAgentContextHolderTests {
+
+	@AfterEach
+	void tearDown() {
+		UserAgentContextHolder.cleanUserAgentContext();
+	}
+
+	@Test
+	void withAndGetUserAgentContext() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0").browser("Chrome").build();
+		UserAgentContextHolder.withUserAgentContext(ua);
+		assertThat(UserAgentContextHolder.getUserAgentContext()).isSameAs(ua);
+	}
+
+	@Test
+	void getUserAgentContextReturnsNullWhenNotSet() {
+		assertThat(UserAgentContextHolder.getUserAgentContext()).isNull();
+	}
+
+	@Test
+	void cleanUserAgentContextRemovesValue() {
+		UserAgent ua = UserAgent.builder("Mozilla/5.0").build();
+		UserAgentContextHolder.withUserAgentContext(ua);
+		UserAgentContextHolder.cleanUserAgentContext();
+		assertThat(UserAgentContextHolder.getUserAgentContext()).isNull();
+	}
+
+}

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/yauaa/YauaaUserAgentConverterTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/yauaa/YauaaUserAgentConverterTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent.yauaa;
+
+import com.livk.context.useragent.UserAgent;
+import nl.basjes.parse.useragent.UserAgentAnalyzer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class YauaaUserAgentConverterTests {
+
+	static YauaaUserAgentConverter converter;
+
+	@BeforeAll
+	static void init() {
+		UserAgentAnalyzer analyzer = UserAgentAnalyzer.newBuilder().hideMatcherLoadStats().withCache(100).build();
+		converter = new YauaaUserAgentConverter(analyzer);
+	}
+
+	@Test
+	void convertParsesChromeBrowser() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT,
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua).isNotNull();
+		assertThat(ua.browser()).isEqualTo("Chrome");
+		assertThat(ua.os()).isEqualTo("Windows NT");
+	}
+
+	@Test
+	void convertReturnsBrowserVersion() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT,
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua.browserVersion()).isNotNull().contains("120");
+	}
+
+	@Test
+	void convertReturnsDeviceInfo() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.USER_AGENT,
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+		UserAgent ua = converter.convert(headers);
+		assertThat(ua.deviceType()).isNotNull();
+		assertThat(ua.deviceName()).isNotNull();
+	}
+
+}


### PR DESCRIPTION
## Summary by Sourcery

在多个上下文模块中扩展并重构测试覆盖范围，以更好地验证行为和错误处理，同时移除基于执行顺序的假设并改进测试隔离性。

Tests:
- 将现有的 Curator、动态数据源、MapStruct、Disruptor、MyBatis、Fesod、Redisearch、QR code、sequence、limit、lock 和 user-agent 相关测试重构为更小、更聚焦的用例，并提供更清晰的命名以及 setup/teardown 流程。
- 为拦截器、执行器、异常类型、锁与限流策略、user-agent 转换器/上下文、Redis 编解码器以及各类工具类/枚举类新增大量单元测试。
- 通过移除有顺序依赖的测试、收紧断言条件以及验证缺失节点或未知转换器等失败场景，改进 Curator 和动态数据源的测试。
- 新增基于请求上下文和响应式上下文的测试，用于验证 user-agent 处理以及可重入的 Web 请求限流。
- 为 limit 模块的测试支持新增对 Spring Web 的构建时测试依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand and restructure test coverage across multiple context modules to better validate behaviors and error handling, while removing order-based assumptions and improving test isolation.

Tests:
- Refactor existing Curator, dynamic data source, MapStruct, Disruptor, MyBatis, Fesod, Redisearch, QR code, sequence, limit, lock, and user-agent tests into smaller, focused cases with clearer naming and setup/teardown.
- Add extensive new unit tests for interceptors, executors, exception types, lock and rate-limit strategies, user-agent converters/contexts, Redis codecs, and various utility/enumeration classes.
- Improve Curator and dynamic data source tests by removing ordered test dependencies, tightening assertions, and verifying failure scenarios such as missing nodes or unknown converters.
- Introduce request- and reactive-context based tests for user-agent handling and reentrant web request limiting.
- Add build test dependency on Spring Web for the limit module test support.

</details>