### PR TITLE
Rename processor test methods for clearer intent

### DIFF
--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/AotFactoriesProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/AotFactoriesProcessorTests.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AotFactoriesProcessorTests {
 
 	@Test
-	void test() {
+	void aotFactoriesFileContainsRegistrar() {
 		compile(AotRuntimeHintsRegistrar.class, RuntimeHintsRegistrar.class);
 	}
 

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringFactoriesProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringFactoriesProcessorTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SpringFactoriesProcessorTests {
 
 	@Test
-	void test() {
+	void springFactoriesFileContainsServiceImpl() {
 		compile(SpringFactoryServiceImpl.class, SpringFactoryService.class);
 	}
 


### PR DESCRIPTION
- Rename SpringFactoriesProcessorTests.test() to springFactoriesFileContainsServiceImpl()
- Rename AotFactoriesProcessorTests.test() to aotFactoriesFileContainsRegistrar()

## Summary by Sourcery

增强项：
- 改进 `AotFactoriesProcessorTests` 和 `SpringFactoriesProcessorTests` 中的测试方法名称，以提升可读性并更清晰地表达其意图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Improve test method names in AotFactoriesProcessorTests and SpringFactoriesProcessorTests for better readability and intent clarity.

</details>