### PR TITLE
Refine autoconfigure tests for curator, dynamic and Redisearch

### DIFF
--- a/spring-boot-extension-autoconfigure/spring-boot-extension-curator/src/test/java/com/livk/autoconfigure/curator/CuratorPropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-curator/src/test/java/com/livk/autoconfigure/curator/CuratorPropertiesTests.java
@@ -29,19 +29,45 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class CuratorPropertiesTests {
 
-	@Test
-	void curatorProperties() {
-		CuratorProperties properties = new CuratorProperties();
-		assertThat(properties).isNotNull();
+	final CuratorProperties properties = new CuratorProperties();
 
+	@Test
+	void defaultConnectString() {
 		assertThat(properties.getConnectString()).isEqualTo("localhost:2181");
+	}
+
+	@Test
+	void defaultRetryPolicy() {
 		assertThat(properties.getBaseSleepTimeMs()).isEqualTo(50);
 		assertThat(properties.getMaxRetries()).isEqualTo(10);
 		assertThat(properties.getMaxSleepMs()).isEqualTo(500);
+	}
+
+	@Test
+	void defaultBlockUntilConnected() {
 		assertThat(properties.getBlockUntilConnectedWait()).isEqualTo(10);
 		assertThat(properties.getBlockUntilConnectedUnit()).isEqualTo(TimeUnit.SECONDS);
+	}
+
+	@Test
+	void defaultSessionTimeout() {
 		assertThat(properties.getSessionTimeout()).isEqualTo(Duration.of(60 * 1000, ChronoUnit.MILLIS));
+	}
+
+	@Test
+	void defaultConnectionTimeout() {
 		assertThat(properties.getConnectionTimeout()).isEqualTo(Duration.of(15 * 1000, ChronoUnit.MILLIS));
+	}
+
+	@Test
+	void setAndGetConnectString() {
+		properties.setConnectString("zk1:2181,zk2:2181");
+		assertThat(properties.getConnectString()).isEqualTo("zk1:2181,zk2:2181");
+	}
+
+	@Test
+	void prefixIsCorrect() {
+		assertThat(CuratorProperties.PREFIX).isEqualTo("spring.zookeeper.curator");
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-disruptor/src/test/java/com/livk/autoconfigure/disruptor/DisruptorAutoConfigurationTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-disruptor/src/test/java/com/livk/autoconfigure/disruptor/DisruptorAutoConfigurationTests.java
@@ -35,7 +35,7 @@ class DisruptorAutoConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(DisruptorAutoConfiguration.class));
 
 	@Test
-	void test() {
+	void autoConfigurationRegistersDisruptorBean() {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(SpringDisruptor.class);
 			assertThat(context).hasBean("disruptorEntity");

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-disruptor/src/test/java/com/livk/autoconfigure/disruptor/DisruptorRegistrarFailureAnalyzerTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-disruptor/src/test/java/com/livk/autoconfigure/disruptor/DisruptorRegistrarFailureAnalyzerTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.autoconfigure.disruptor;
+
+import com.livk.context.disruptor.exception.DisruptorRegistrarException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class DisruptorRegistrarFailureAnalyzerTests {
+
+	final DisruptorRegistrarFailureAnalyzer analyzer = new DisruptorRegistrarFailureAnalyzer();
+
+	@Test
+	void analyzeReturnsFailureAnalysis() {
+		DisruptorRegistrarException cause = new DisruptorRegistrarException("missing packages");
+		FailureAnalysis analysis = analyzer.analyze(cause, cause);
+		assertThat(analysis).isNotNull();
+		assertThat(analysis.getDescription()).isEqualTo("missing packages");
+		assertThat(analysis.getAction()).contains("basePackages");
+	}
+
+}

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/DynamicDatasourcePropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/DynamicDatasourcePropertiesTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.autoconfigure.dynamic;
+
+import com.livk.autoconfigure.dynamic.exception.PrimaryNotFountException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author livk
+ */
+class DynamicDatasourcePropertiesTests {
+
+	@Test
+	void prefixIsCorrect() {
+		assertThat(DynamicDatasourceProperties.PREFIX).isEqualTo("spring.dynamic");
+	}
+
+	@Test
+	void afterPropertiesSetWithValidPrimary() {
+		DynamicDatasourceProperties properties = new DynamicDatasourceProperties();
+		properties.setPrimary("master");
+		properties.setDatasource(Map.of("master", new DataSourceProperties()));
+		properties.afterPropertiesSet();
+	}
+
+	@Test
+	void afterPropertiesSetWithMissingPrimaryThrows() {
+		DynamicDatasourceProperties properties = new DynamicDatasourceProperties();
+		properties.setPrimary("master");
+		properties.setDatasource(Map.of("slave", new DataSourceProperties()));
+		assertThatThrownBy(properties::afterPropertiesSet).isInstanceOf(PrimaryNotFountException.class);
+	}
+
+	@Test
+	void afterPropertiesSetWithNullPrimaryThrows() {
+		DynamicDatasourceProperties properties = new DynamicDatasourceProperties();
+		properties.setDatasource(Map.of("master", new DataSourceProperties()));
+		assertThatThrownBy(properties::afterPropertiesSet).isInstanceOf(PrimaryNotFountException.class);
+	}
+
+}

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/exception/PrimaryAbstractFailureAnalyzerTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/exception/PrimaryAbstractFailureAnalyzerTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.autoconfigure.dynamic.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class PrimaryAbstractFailureAnalyzerTests {
+
+	final PrimaryAbstractFailureAnalyzer analyzer = new PrimaryAbstractFailureAnalyzer();
+
+	@Test
+	void analyzeReturnsFailureAnalysis() {
+		PrimaryNotFountException cause = new PrimaryNotFountException("missing primary datasource");
+		FailureAnalysis analysis = analyzer.analyze(cause, cause);
+		assertThat(analysis).isNotNull();
+		assertThat(analysis.getDescription()).isEqualTo("missing primary datasource");
+		assertThat(analysis.getAction()).contains("spring.dynamic.primary");
+	}
+
+}

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/exception/PrimaryNotFountExceptionTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/exception/PrimaryNotFountExceptionTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.autoconfigure.dynamic.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class PrimaryNotFountExceptionTests {
+
+	@Test
+	void constructDefault() {
+		PrimaryNotFountException ex = new PrimaryNotFountException();
+		assertThat(ex.getMessage()).isNull();
+	}
+
+	@Test
+	void constructWithMessage() {
+		PrimaryNotFountException ex = new PrimaryNotFountException("missing primary");
+		assertThat(ex.getMessage()).isEqualTo("missing primary");
+	}
+
+	@Test
+	void constructWithMessageAndCause() {
+		RuntimeException cause = new RuntimeException("root");
+		PrimaryNotFountException ex = new PrimaryNotFountException("missing primary", cause);
+		assertThat(ex.getMessage()).isEqualTo("missing primary");
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void constructWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		PrimaryNotFountException ex = new PrimaryNotFountException(cause);
+		assertThat(ex.getCause()).isSameAs(cause);
+	}
+
+	@Test
+	void isRuntimeException() {
+		assertThat(new PrimaryNotFountException()).isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-mybatis/src/test/java/com/livk/autoconfigure/mybatis/MybatisLogMonitorPropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-mybatis/src/test/java/com/livk/autoconfigure/mybatis/MybatisLogMonitorPropertiesTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.autoconfigure.mybatis;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class MybatisLogMonitorPropertiesTests {
+
+	@Test
+	void prefixIsCorrect() {
+		assertThat(MybatisLogMonitorProperties.PREFIX).isEqualTo("mybatis.log.monitor");
+	}
+
+	@Test
+	void defaultTimeOut() {
+		MybatisLogMonitorProperties props = new MybatisLogMonitorProperties();
+		assertThat(props.getTimeOut()).isEqualTo(Duration.ofSeconds(1));
+	}
+
+	@Test
+	void propertiesContainsTimeOut() {
+		MybatisLogMonitorProperties props = new MybatisLogMonitorProperties();
+		Properties properties = props.properties();
+		assertThat(properties).containsKey("timeOut");
+		assertThat(properties.get("timeOut")).isEqualTo(Duration.ofSeconds(1));
+	}
+
+	@Test
+	void customTimeOutReflectedInProperties() {
+		MybatisLogMonitorProperties props = new MybatisLogMonitorProperties();
+		props.setTimeOut(Duration.ofMillis(500));
+		Properties properties = props.properties();
+		assertThat(properties.get("timeOut")).isEqualTo(Duration.ofMillis(500));
+	}
+
+}

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-redisearch/src/test/java/com/livk/autoconfigure/redisearch/RediSearchPropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-redisearch/src/test/java/com/livk/autoconfigure/redisearch/RediSearchPropertiesTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.autoconfigure.redisearch;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author livk
+ */
+class RediSearchPropertiesTests {
+
+	final RediSearchProperties properties = new RediSearchProperties();
+
+	@Test
+	void defaultHost() {
+		assertThat(properties.getHost()).isEqualTo("localhost");
+	}
+
+	@Test
+	void defaultPort() {
+		assertThat(properties.getPort()).isEqualTo(6379);
+	}
+
+	@Test
+	void defaultDatabase() {
+		assertThat(properties.getDatabase()).isZero();
+	}
+
+	@Test
+	void defaultSsl() {
+		assertThat(properties.getSsl()).isFalse();
+	}
+
+	@Test
+	void defaultPoolSettings() {
+		RediSearchProperties.Pool pool = properties.getPool();
+		assertThat(pool.getEnabled()).isTrue();
+		assertThat(pool.getMaxIdle()).isEqualTo(8);
+		assertThat(pool.getMinIdle()).isZero();
+		assertThat(pool.getMaxActive()).isEqualTo(8);
+		assertThat(pool.getMaxWait()).isEqualTo(Duration.ofMillis(-1));
+	}
+
+	@Test
+	void defaultUsernameAndPasswordAreNull() {
+		assertThat(properties.getUsername()).isNull();
+		assertThat(properties.getPassword()).isNull();
+	}
+
+	@Test
+	void defaultClusterIsNull() {
+		assertThat(properties.getCluster()).isNull();
+	}
+
+}


### PR DESCRIPTION
- Split CuratorPropertiesTests into 7 focused tests
- Rename DisruptorAutoConfigurationTests.test() to descriptive name
- Add DisruptorRegistrarFailureAnalyzerTests
- Add DynamicDatasourcePropertiesTests: valid/missing/null primary validation
- Add PrimaryNotFountExceptionTests and PrimaryAbstractFailureAnalyzerTests
- Add MybatisLogMonitorPropertiesTests: prefix, default timeout, properties method
- Add RediSearchPropertiesTests: all defaults including pool and cluster

## Summary by Sourcery

改进 curator、disruptor、dynamic datasource、mybatis log monitor 和 redisearch 模块中与自动配置相关测试的覆盖率和清晰度。

测试内容：
- 拆分 CuratorProperties 测试为更聚焦的用例，用于分别验证默认值、修改器以及配置前缀。
- 重命名 disruptor 自动配置测试，使其更清晰地描述所验证的已注册 Bean。
- 为 RediSearchProperties 添加测试，用于覆盖所有默认连接、连接池以及集群相关设置。
- 添加 DynamicDatasourceProperties 测试，用于验证配置前缀和主数据源校验行为，包括失败场景。
- 新增 PrimaryNotFountException 及其失败分析器的测试，以确保异常构造与诊断输出正确。
- 添加 MybatisLogMonitorProperties 测试，用于验证配置前缀、默认超时时间及其向属性中的传递。
- 添加 DisruptorRegistrarFailureAnalyzer 测试，用于验证生成的失败分析结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve coverage and clarity of autoconfiguration-related tests across curator, disruptor, dynamic datasource, mybatis log monitor, and redisearch modules.

Tests:
- Split CuratorProperties tests into focused cases validating defaults, mutators, and configuration prefix.
- Rename the disruptor autoconfiguration test to clearly describe the registered beans it verifies.
- Add tests for RediSearchProperties to cover all default connection, pool, and cluster-related settings.
- Add DynamicDatasourceProperties tests to validate prefix and primary datasource validation behavior, including failure scenarios.
- Introduce tests for PrimaryNotFountException and its failure analyzer to ensure proper exception construction and diagnostic output.
- Add MybatisLogMonitorProperties tests to verify configuration prefix, default timeout, and propagation into properties.
- Add DisruptorRegistrarFailureAnalyzer tests to verify produced failure analyses.

</details>