### PR TITLE
Improve web, dynamic, lock and sequence robustness and validation

### DIFF
--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/AotFactoriesProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/AotFactoriesProcessorTests.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AotFactoriesProcessorTests {
 
 	@Test
-	void aotFactoriesFileContainsRegistrar() {
+	void aotFactoriesFileContainsRegistrarInferredFromSingleInterface() {
 		compile(AotRuntimeHintsRegistrar.class, RuntimeHintsRegistrar.class);
 	}
 

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringFactoriesProcessorTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/SpringFactoriesProcessorTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SpringFactoriesProcessorTests {
 
 	@Test
-	void springFactoriesFileContainsServiceImpl() {
+	void springFactoriesFileContainsServiceImplInferredFromSingleInterface() {
 		compile(SpringFactoryServiceImpl.class, SpringFactoryService.class);
 	}
 

--- a/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTests.java
+++ b/spring-auto-service/src/test/java/com/livk/auto/service/processor/TypeElementsTests.java
@@ -85,7 +85,7 @@ class TypeElementsTests {
 	@Test
 	void getBinaryName() {
 		List<Class<?>> classes = List.of(String.class, SpringAutoContext.class, SpringContext.class,
-				SpringFactoryServiceImpl.class);
+				SpringFactoryServiceImpl.class, NestedSpringFactoryServiceImpl.class);
 
 		for (Class<?> type : classes) {
 			assertThat(TypeElements.getBinaryName(get(type))).isEqualTo(type.getName());
@@ -95,6 +95,10 @@ class TypeElementsTests {
 
 	static TypeElement get(Class<?> type) {
 		return elements.getTypeElement(type.getCanonicalName());
+	}
+
+	static class NestedSpringFactoryServiceImpl implements SpringFactoryService {
+
 	}
 
 }

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/main/java/com/livk/autoconfigure/dynamic/DynamicDatasourceProperties.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/main/java/com/livk/autoconfigure/dynamic/DynamicDatasourceProperties.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.util.Map;
@@ -45,6 +46,9 @@ public class DynamicDatasourceProperties implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() {
+		if (CollectionUtils.isEmpty(datasource)) {
+			throw new PrimaryNotFountException("The 'datasource' configuration is missing!");
+		}
 		if (StringUtils.hasText(primary)) {
 			if (!datasource.containsKey(primary)) {
 				throw new PrimaryNotFountException(

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/DynamicDatasourcePropertiesTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-dynamic/src/test/java/com/livk/autoconfigure/dynamic/DynamicDatasourcePropertiesTests.java
@@ -52,6 +52,14 @@ class DynamicDatasourcePropertiesTests {
 	}
 
 	@Test
+	void afterPropertiesSetWithMissingDatasourceThrows() {
+		DynamicDatasourceProperties properties = new DynamicDatasourceProperties();
+		properties.setPrimary("master");
+		assertThatThrownBy(properties::afterPropertiesSet).isInstanceOf(PrimaryNotFountException.class)
+			.hasMessage("The 'datasource' configuration is missing!");
+	}
+
+	@Test
 	void afterPropertiesSetWithNullPrimaryThrows() {
 		DynamicDatasourceProperties properties = new DynamicDatasourceProperties();
 		properties.setDatasource(Map.of("master", new DataSourceProperties()));

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-useragent/src/main/java/com/livk/autoconfigure/useragent/UserAgentConfiguration.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-useragent/src/main/java/com/livk/autoconfigure/useragent/UserAgentConfiguration.java
@@ -25,6 +25,7 @@ import com.livk.context.useragent.servlet.UserAgentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -47,6 +48,7 @@ public class UserAgentConfiguration {
 	 * @return the user agent helper
 	 */
 	@Bean
+	@ConditionalOnMissingBean
 	public UserAgentHelper userAgentHelper() {
 		return new UserAgentHelper();
 	}

--- a/spring-boot-extension-autoconfigure/spring-boot-extension-useragent/src/test/java/com/livk/autoconfigure/useragent/UserAgentAutoConfigurationTests.java
+++ b/spring-boot-extension-autoconfigure/spring-boot-extension-useragent/src/test/java/com/livk/autoconfigure/useragent/UserAgentAutoConfigurationTests.java
@@ -58,6 +58,13 @@ class UserAgentAutoConfigurationTests {
 	}
 
 	@Test
+	void customUserAgentHelperBacksOffAutoConfiguredHelper() {
+		UserAgentHelper helper = new UserAgentHelper();
+		this.contextRunner.withBean(UserAgentHelper.class, () -> helper)
+			.run((context) -> assertThat(context).getBean(UserAgentHelper.class).isSameAs(helper));
+	}
+
+	@Test
 	void testBrowscap() {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(UserAgentParser.class);

--- a/spring-extension-commons/src/main/java/com/livk/commons/io/DataBufferUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/io/DataBufferUtils.java
@@ -57,7 +57,7 @@ public class DataBufferUtils extends org.springframework.core.io.buffer.DataBuff
 	 * @return the mono
 	 */
 	public Mono<InputStream> transform(Flux<DataBuffer> dataBufferFlux) {
-		return join(dataBufferFlux).map(DataBuffer::asInputStream);
+		return join(dataBufferFlux).map(dataBuffer -> dataBuffer.asInputStream(true));
 	}
 
 	/**
@@ -79,7 +79,7 @@ public class DataBufferUtils extends org.springframework.core.io.buffer.DataBuff
 		return DataBufferUtils.transform(bufferFlux)
 			.publishOn(Schedulers.boundedElastic())
 			.handle((inputStream, sink) -> {
-				try {
+				try (inputStream) {
 					sink.next(inputStream.readAllBytes());
 				}
 				catch (IOException ex) {

--- a/spring-extension-commons/src/main/java/com/livk/commons/util/ReflectionUtils.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/util/ReflectionUtils.java
@@ -60,6 +60,7 @@ public class ReflectionUtils extends org.springframework.util.ReflectionUtils {
 	public Set<Method> getReadMethods(Class<?> targetClass) {
 		return Arrays.stream(BeanUtils.getPropertyDescriptors(targetClass))
 			.map(PropertyDescriptor::getReadMethod)
+			.filter(Objects::nonNull)
 			.filter(method -> !method.getName().equals("getClass"))
 			.collect(Collectors.toSet());
 	}

--- a/spring-extension-commons/src/main/java/com/livk/commons/web/RequestWrapper.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/web/RequestWrapper.java
@@ -160,7 +160,7 @@ public class RequestWrapper extends HttpServletRequestWrapper {
 		if (ObjectUtils.isEmpty(body)) {
 			body = StreamUtils.copyToByteArray(super.getInputStream());
 		}
-		return new BufferedReader(new ByteArrayReader(body));
+		return new BufferedReader(new ByteArrayReader(body, Charset.forName(getCharacterEncoding())));
 	}
 
 	@Override
@@ -209,7 +209,7 @@ public class RequestWrapper extends HttpServletRequestWrapper {
 
 	@Override
 	public Enumeration<String> getHeaderNames() {
-		Set<String> headerNames = headers.headerNames();
+		Set<String> headerNames = new HashSet<>(headers.headerNames());
 		if (bodyReviseStatus) {
 			headerNames.add(HttpHeaders.CONTENT_TYPE);
 		}
@@ -249,9 +249,10 @@ public class RequestWrapper extends HttpServletRequestWrapper {
 		/**
 		 * 创建ByteArrayReader
 		 * @param bytes the bytes
+		 * @param charset the charset
 		 */
-		ByteArrayReader(byte[] bytes) {
-			super(new ByteArrayInputStream(bytes));
+		ByteArrayReader(byte[] bytes, Charset charset) {
+			super(new ByteArrayInputStream(bytes), charset);
 		}
 
 	}

--- a/spring-extension-commons/src/main/java/com/livk/commons/web/RequestWrapper.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/web/RequestWrapper.java
@@ -271,7 +271,7 @@ public class RequestWrapper extends HttpServletRequestWrapper {
 
 		@Override
 		public boolean isFinished() {
-				return in.available() == 0;
+			return in.available() == 0;
 		}
 
 		@Override

--- a/spring-extension-commons/src/main/java/com/livk/commons/web/RequestWrapper.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/web/RequestWrapper.java
@@ -18,8 +18,8 @@ package com.livk.commons.web;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.livk.commons.util.ObjectUtils;
 import com.livk.commons.util.HttpServletUtils;
+import com.livk.commons.util.ObjectUtils;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +32,6 @@ import org.springframework.util.StreamUtils;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -259,7 +258,7 @@ public class RequestWrapper extends HttpServletRequestWrapper {
 
 	private static class ByteArrayServletInputStream extends ServletInputStream {
 
-		private final InputStream in;
+		private final ByteArrayInputStream in;
 
 		/**
 		 * 创建ByteArrayServletInputStream
@@ -271,12 +270,12 @@ public class RequestWrapper extends HttpServletRequestWrapper {
 
 		@Override
 		public boolean isFinished() {
-			return false;
+				return in.available() == 0;
 		}
 
 		@Override
 		public boolean isReady() {
-			return false;
+			return true;
 		}
 
 		@Override

--- a/spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/web/RequestWrapperTests.java
@@ -26,6 +26,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -89,6 +91,18 @@ class RequestWrapperTests {
 	}
 
 	@Test
+	void getReaderUsesRequestCharacterEncoding() throws IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCharacterEncoding("GBK");
+		RequestWrapper encodedWrapper = new RequestWrapper(request);
+		String text = "中文";
+
+		encodedWrapper.body(text.getBytes(Charset.forName("GBK")), MediaType.TEXT_PLAIN_VALUE);
+
+		assertThat(encodedWrapper.getReader().readLine()).isEqualTo(text);
+	}
+
+	@Test
 	void getContentLengthReflectsBodySize() throws IOException {
 		wrapper.body(BODY_BYTES);
 		assertThat(wrapper.getContentLength()).isEqualTo(BODY_BYTES.length);
@@ -115,6 +129,13 @@ class RequestWrapperTests {
 		wrapper.addHeader(HttpHeaders.ACCEPT, new String[] { "text/html", "application/json" });
 		HttpHeaders headers = HttpServletUtils.headers(wrapper);
 		assertThat(headers.get(HttpHeaders.ACCEPT)).contains("text/html", "application/json");
+	}
+
+	@Test
+	void getHeaderNamesIncludesContentTypeAfterBodyChanged() {
+		wrapper.body(BODY_BYTES);
+
+		assertThat(Collections.list(wrapper.getHeaderNames())).contains(HttpHeaders.CONTENT_TYPE);
 	}
 
 	// --- parameters ---

--- a/spring-extension-context/spring-extension-disruptor/src/main/java/com/livk/context/disruptor/factory/DisruptorFactoryBean.java
+++ b/spring-extension-context/spring-extension-disruptor/src/main/java/com/livk/context/disruptor/factory/DisruptorFactoryBean.java
@@ -106,6 +106,7 @@ public class DisruptorFactoryBean<T>
 		if (StringUtils.hasText(threadFactoryBeanName)) {
 			factory = beanFactory.getBean(threadFactoryBeanName, ThreadFactory.class);
 		}
+		Assert.notNull(factory, "threadFactory must not be null");
 		if (useVirtualThreads) {
 			factory = new VirtualThreadFactory(factory);
 		}

--- a/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTests.java
+++ b/spring-extension-context/spring-extension-disruptor/src/test/java/com/livk/context/disruptor/factory/DisruptorFactoryBeanTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author livk
@@ -62,6 +63,19 @@ class DisruptorFactoryBeanTests {
 		DisruptorFactoryBean<Entity> factoryBean = createFactoryBean();
 		factoryBean.afterPropertiesSet();
 		factoryBean.destroy();
+	}
+
+	@Test
+	void afterPropertiesSetFailsFastWhenVirtualThreadDelegateIsMissing() {
+		DisruptorFactoryBean<Entity> factoryBean = new DisruptorFactoryBean<>(Entity.class);
+		DisruptorEvent event = Entity.class.getAnnotation(DisruptorEvent.class);
+		factoryBean.setBeanFactory(beanFactory);
+		factoryBean.setProducerType(event.type());
+		factoryBean.setUseVirtualThreads(true);
+		factoryBean.setWaitStrategy(BeanUtils.instantiateClass(event.strategy()));
+
+		assertThatThrownBy(factoryBean::afterPropertiesSet).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("threadFactory must not be null");
 	}
 
 	private DisruptorFactoryBean<Entity> createFactoryBean() {

--- a/spring-extension-context/spring-extension-dynamic/src/main/java/com/livk/context/dynamic/intercept/DataSourceInterceptor.java
+++ b/spring-extension-context/spring-extension-dynamic/src/main/java/com/livk/context/dynamic/intercept/DataSourceInterceptor.java
@@ -31,9 +31,12 @@ public class DataSourceInterceptor extends AnnotationAbstractPointcutTypeAdvisor
 		if (dynamicSource != null) {
 			DataSourceContextHolder.switchDataSource(dynamicSource.value());
 		}
-		Object proceed = invocation.proceed();
-		DataSourceContextHolder.clear();
-		return proceed;
+		try {
+			return invocation.proceed();
+		}
+		finally {
+			DataSourceContextHolder.clear();
+		}
 	}
 
 }

--- a/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/intercept/DataSourceInterceptorTests.java
+++ b/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/intercept/DataSourceInterceptorTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -81,6 +82,18 @@ class DataSourceInterceptorTests {
 
 		interceptor.invoke(invocation, annotation);
 
+		assertThat(DataSourceContextHolder.getDataSource()).isNull();
+	}
+
+	@Test
+	void invokeClearsDataSourceWhenProceedThrows() throws Throwable {
+		DynamicSource annotation = mock(DynamicSource.class);
+		given(annotation.value()).willReturn("slave3");
+
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		given(invocation.proceed()).willThrow(new IllegalStateException("boom"));
+
+		assertThatThrownBy(() -> interceptor.invoke(invocation, annotation)).isInstanceOf(IllegalStateException.class);
 		assertThat(DataSourceContextHolder.getDataSource()).isNull();
 	}
 

--- a/spring-extension-context/spring-extension-fesod/src/main/java/com/livk/context/fesod/resolver/FesodSupport.java
+++ b/spring-extension-context/spring-extension-fesod/src/main/java/com/livk/context/fesod/resolver/FesodSupport.java
@@ -59,19 +59,19 @@ abstract class FesodSupport {
 		try (ExcelWriter writer = builder.build()) {
 			int index = 0;
 			for (Map.Entry<String, ? extends List<?>> entry : result.entrySet()) {
-				WriteSheet sheet = buildSheet(location, entry, index++);
+				WriteSheet sheet = buildSheet(location, entry.getKey(), index++);
 				writer.write(entry.getValue(), sheet);
 			}
 		}
 	}
 
-	protected WriteSheet buildSheet(String location, Map.Entry<String, ? extends List<?>> entry, int index) {
+	protected WriteSheet buildSheet(String location, String sheetName, int index) {
 		if (StringUtils.hasText(location)) {
-			return FesodSheet.writerSheet(index, entry.getKey())
-				.registerWriteHandler(new TemplateSheetWriteHandler(index, entry.getKey()))
+			return FesodSheet.writerSheet(index, sheetName)
+				.registerWriteHandler(new TemplateSheetWriteHandler(index, sheetName))
 				.build();
 		}
-		return FesodSheet.writerSheet(entry.getKey()).build();
+		return FesodSheet.writerSheet(sheetName).build();
 	}
 
 	<T> Object getExcelData(ExcelMapReadListener<T> listener, ExcelDataType type) {

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/interceptor/LimitInterceptorTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/interceptor/LimitInterceptorTests.java
@@ -23,6 +23,7 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 
+import java.time.Duration;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -60,6 +61,7 @@ class LimitInterceptorTests {
 
 		assertThat(result).isEqualTo("result");
 		verify(invocation).proceed();
+		verify(executor).tryAccess("testKey", 10, Duration.ofSeconds(60));
 	}
 
 	@Test

--- a/spring-extension-context/spring-extension-lock/src/main/java/com/livk/context/lock/support/AbstractLockSupport.java
+++ b/spring-extension-context/spring-extension-lock/src/main/java/com/livk/context/lock/support/AbstractLockSupport.java
@@ -30,14 +30,14 @@ public abstract class AbstractLockSupport<T> implements DistributedLock {
 	/**
 	 * The Thread local.
 	 */
-	protected final ThreadLocal<T> threadLocal = new InheritableThreadLocal<>();
+	protected final ThreadLocal<T> threadLocal = new ThreadLocal<>();
 
 	@Override
 	public final boolean tryLock(LockType type, String key, long leaseTime, long waitTime, boolean async) {
 		T lock = getLock(type, key);
 		try {
 			boolean isLocked = supportAsync() && async ? tryLockAsync(lock, leaseTime, waitTime)
-					: tryLock(lock, waitTime, leaseTime);
+					: tryLock(lock, leaseTime, waitTime);
 			if (isLocked) {
 				threadLocal.set(lock);
 			}

--- a/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/support/AbstractLockSupportTests.java
+++ b/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/support/AbstractLockSupportTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.lock.support;
+
+import com.livk.context.lock.LockType;
+import com.livk.context.lock.exception.LockException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractLockSupportTests {
+
+	@Test
+	void tryLockPassesLeaseTimeBeforeWaitTime() {
+		TestLockSupport support = new TestLockSupport();
+
+		assertThat(support.tryLock(LockType.LOCK, "key", 10, 20, false)).isTrue();
+
+		assertThat(support.leaseTime).isEqualTo(10);
+		assertThat(support.waitTime).isEqualTo(20);
+	}
+
+	private static final class TestLockSupport extends AbstractLockSupport<String> {
+
+		private long leaseTime;
+
+		private long waitTime;
+
+		@Override
+		protected String getLock(LockType type, String key) {
+			return key;
+		}
+
+		@Override
+		protected boolean unlock(String lock) {
+			return true;
+		}
+
+		@Override
+		protected boolean tryLock(String lock, long leaseTime, long waitTime) throws LockException {
+			this.leaseTime = leaseTime;
+			this.waitTime = waitTime;
+			return true;
+		}
+
+		@Override
+		protected void lock(String lock) throws LockException {
+		}
+
+		@Override
+		protected boolean isLocked(String lock) {
+			return true;
+		}
+
+	}
+
+}

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/DbRangeManager.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/DbRangeManager.java
@@ -20,6 +20,7 @@ import com.livk.context.sequence.SequenceRange;
 import com.livk.context.sequence.exception.SequenceException;
 import com.livk.context.sequence.support.db.SequenceDbHelper;
 import lombok.Setter;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -92,7 +93,12 @@ public class DbRangeManager extends AbstractRangeManager implements RangeManager
 				return value;
 			}
 			else {
-				insertRange(name, stepStart);
+				try {
+					insertRange(name, stepStart);
+				}
+				catch (DuplicateKeyException ex) {
+					return null;
+				}
 				return null;
 			}
 		});

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/support/DbRangeManagerTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/support/DbRangeManagerTests.java
@@ -23,6 +23,7 @@ import org.h2.Driver;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
@@ -85,6 +86,34 @@ class DbRangeManagerTests {
 		SequenceRange retriedRange = manager.nextRange(name);
 		assertThat(retriedRange).isNotNull();
 		assertThat(retriedRange.getMin()).isEqualTo(concurrentRange.getMax() + 1);
+	}
+
+	@Test
+	void testNextRangeRetriesWhenConcurrentInsertWins() {
+		class DuplicateKeyOnceDbRangeManager extends DbRangeManager {
+
+			private boolean duplicateKeyThrown;
+
+			DuplicateKeyOnceDbRangeManager(DataSource ds) {
+				super(ds);
+			}
+
+			@Override
+			protected void insertRange(String name, long stepStart) {
+				super.insertRange(name, stepStart);
+				if (!duplicateKeyThrown) {
+					duplicateKeyThrown = true;
+					throw new DuplicateKeyException("concurrent insert");
+				}
+			}
+
+		}
+		DuplicateKeyOnceDbRangeManager manager = new DuplicateKeyOnceDbRangeManager(dataSource);
+
+		SequenceRange range = manager.nextRange("duplicate-key-retry-seq");
+
+		assertThat(range.getMin()).isEqualTo(1);
+		assertThat(range.getMax()).isEqualTo(1000);
 	}
 
 	@Test

--- a/spring-extension-context/spring-extension-useragent/src/main/java/com/livk/context/useragent/servlet/UserAgentFilter.java
+++ b/spring-extension-context/spring-extension-useragent/src/main/java/com/livk/context/useragent/servlet/UserAgentFilter.java
@@ -44,8 +44,12 @@ public class UserAgentFilter extends OncePerRequestFilter {
 		HttpHeaders headers = HttpServletUtils.headers(request);
 		UserAgent userAgent = helper.convert(headers);
 		UserAgentContextHolder.withUserAgentContext(userAgent);
-		filterChain.doFilter(request, response);
-		UserAgentContextHolder.cleanUserAgentContext();
+		try {
+			filterChain.doFilter(request, response);
+		}
+		finally {
+			UserAgentContextHolder.cleanUserAgentContext();
+		}
 	}
 
 }

--- a/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/servlet/UserAgentFilterTests.java
+++ b/spring-extension-context/spring-extension-useragent/src/test/java/com/livk/context/useragent/servlet/UserAgentFilterTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.livk.context.useragent.servlet;
+
+import com.livk.context.useragent.UserAgent;
+import com.livk.context.useragent.UserAgentHelper;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class UserAgentFilterTests {
+
+	@AfterEach
+	void tearDown() {
+		UserAgentContextHolder.cleanUserAgentContext();
+	}
+
+	@Test
+	void doFilterClearsContextWhenChainThrows() throws ServletException, IOException {
+		UserAgentHelper helper = mock(UserAgentHelper.class);
+		UserAgent userAgent = UserAgent.builder("Mozilla/5.0").browser("Chrome").build();
+		given(helper.convert(any(HttpHeaders.class))).willReturn(userAgent);
+		UserAgentFilter filter = new UserAgentFilter(helper);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThatThrownBy(() -> filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+			assertThat(UserAgentContextHolder.getUserAgentContext()).isSameAs(userAgent);
+			throw new ServletException("boom");
+		})).isInstanceOf(ServletException.class);
+
+		assertThat(UserAgentContextHolder.getUserAgentContext()).isNull();
+	}
+
+}


### PR DESCRIPTION
## Summary by Sourcery

在 Web、数据源、用户代理、锁以及序列组件中提升健壮性与正确性，并强化校验与生命周期管理。

Bug 修复：
- 确保 `RequestWrapper` 的 reader 遵循请求的字符编码，并在请求体被修改后准确报告 `Content-Type`。
- 通过使用 `finally` 块保证 `DataSourceContextHolder` 和 `UserAgentContextHolder` 必定被清理，即使下游处理抛出异常。
- 在 `DbRangeManager` 中通过在重复键插入竞争时安全重试，正确处理并发序列区间初始化。
- 修复 `DataBufferUtils`，通过使用带所有权转移的 `asInputStream` 并在使用后关闭流来释放缓冲区。
- 修正 `AbstractLockSupport` 的 `tryLock` 参数顺序，并避免可继承线程本地变量在线程之间泄漏锁状态。
- 当在 `DisruptorFactoryBean` 中启用虚拟线程时，断言 `ThreadFactory` 非空，以防止错误配置。
- 在 `ReflectionUtils.getReadMethods` 中通过过滤掉为 `null` 的读取方法，避免出现 `NullPointerException`。
- 基于底层流的可用性改进 `ByteArrayServletInputStream` 的就绪状态与完成状态报告。
- 校验 `DynamicDatasourceProperties`，当设置了 primary 但缺少对应数据源配置时快速失败。

增强：
- 优化 `FesodSupport` 的构表 API，使其基于 sheet 名称而不是完整的映射条目进行操作，从而简化使用方式。
- 明确 auto-service 处理器测试与二进制名称处理逻辑，包括对嵌套实现类的覆盖。

测试：
- 新增单元测试覆盖 `RequestWrapper` 的字符编码行为以及在请求体变更后的头信息暴露情况。
- 扩展 `DbRangeManager` 测试，以验证在并发插入导致重复键时的重试行为。
- 新增 `DisruptorFactoryBean` 测试，以验证在配置使用虚拟线程但未提供 `ThreadFactory` 时会失败。
- 扩展 `DataSourceInterceptor` 测试，以确认在被拦截的调用抛出异常时上下文会被清理。
- 新增 `DynamicDatasourceProperties` 测试，用于验证缺失数据源配置时的处理。
- 引入 `AbstractLockSupport` 测试，以验证 `tryLock` 中租约时间和等待时间的参数顺序。
- 新增 `UserAgentFilter` 测试，断言在过滤器链抛出异常时上下文被清理，并增加自定义 helper 回退（backoff）的自动配置测试。
- 收紧 `LimitInterceptor` 测试，以验证执行器使用预期参数进行调用。
- 拓宽 auto-service 处理器测试，以覆盖接口推断场景和嵌套服务实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and correctness across web, data source, user agent, locking, and sequence components while tightening validation and lifecycle handling.

Bug Fixes:
- Ensure RequestWrapper reader respects the request character encoding and accurately reports Content-Type after body changes.
- Guarantee DataSourceContextHolder and UserAgentContextHolder are always cleared using finally blocks, even when downstream processing throws exceptions.
- Handle concurrent sequence range initialization in DbRangeManager by safely retrying on duplicate key insert races.
- Fix DataBufferUtils to release buffers by using asInputStream with ownership transfer and closing the stream after use.
- Correct AbstractLockSupport tryLock parameter ordering and avoid inheritable thread-local lock leakage across threads.
- Assert a non-null ThreadFactory when virtual threads are enabled in DisruptorFactoryBean to prevent misconfiguration errors.
- Prevent NullPointerExceptions in ReflectionUtils.getReadMethods by filtering out null read methods.
- Improve ByteArrayServletInputStream readiness and completion reporting based on underlying stream availability.
- Validate DynamicDatasourceProperties to fail fast when primary is set but datasource configuration is missing.

Enhancements:
- Refine FesodSupport sheet-building API to operate on sheet names instead of full map entries, simplifying usage.
- Clarify auto-service processor tests and binary name handling, including coverage for nested implementation classes.

Tests:
- Add unit tests covering RequestWrapper character encoding behavior and header exposure after body mutation.
- Extend DbRangeManager tests to verify retry behavior when concurrent inserts cause duplicate keys.
- Add DisruptorFactoryBean tests to validate failure when virtual thread usage is configured without a backing ThreadFactory.
- Extend DataSourceInterceptor tests to confirm context clearing when intercepted invocation throws.
- Add DynamicDatasourceProperties tests for missing datasource configuration handling.
- Introduce AbstractLockSupport tests to verify lease and wait time ordering in tryLock.
- Add UserAgentFilter tests to assert context cleanup when the filter chain throws and auto-configuration tests for custom helper backoff.
- Tighten LimitInterceptor tests to verify executor usage with expected arguments.
- Broaden auto-service processor tests to cover interface inference scenarios and nested service implementations.

</details>