### PR TITLE
Refactor sequence range for dynamic step/start and fix H2 SQL key

### DIFF
--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/SequenceRange.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/SequenceRange.java
@@ -17,7 +17,6 @@
 package com.livk.context.sequence;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author livk
  */
 @ToString
-public class SequenceRange {
+public final class SequenceRange {
 
 	/**
 	 * 区间的序列号开始值
@@ -45,13 +44,6 @@ public class SequenceRange {
 	 */
 	private final AtomicLong value;
 
-	/**
-	 * 区间的序列号是否分配完毕，每次分配完毕就会去重新获取一个新的区间
-	 */
-	@Setter
-	@Getter
-	private volatile boolean over = false;
-
 	public SequenceRange(long min, long max) {
 		this.min = min;
 		this.max = max;
@@ -62,14 +54,17 @@ public class SequenceRange {
 	 * 返回并递增下一个序列号
 	 * @return 下一个序列号，如果返回-1表示序列号分配完毕
 	 */
-	public long getAndIncrement() {
-		long currentValue = value.getAndIncrement();
-		if (currentValue > max) {
-			over = true;
-			return -1;
-		}
+	public long next() {
+		long current = value.getAndIncrement();
+		return current <= max ? current : -1;
+	}
 
-		return currentValue;
+	/**
+	 * 区间的序列号是否分配完毕，每次分配完毕就会去重新获取一个新的区间
+	 * @return true表示区间已分配完毕
+	 */
+	public boolean isOver() {
+		return value.get() > max;
 	}
 
 }

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/builder/DefaultRangeSequence.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/builder/DefaultRangeSequence.java
@@ -50,10 +50,22 @@ class DefaultRangeSequence implements Sequence {
 	 */
 	private final String name;
 
-	DefaultRangeSequence(RangeManager manager, String name) {
+	/**
+	 * 获取区间的步长
+	 */
+	private final int step;
+
+	/**
+	 * 序列号分配起始值
+	 */
+	private final long stepStart;
+
+	DefaultRangeSequence(RangeManager manager, String name, int step, long stepStart) {
 		Assert.notNull(name, "name is required");
 		this.manager = manager;
 		this.name = name;
+		this.step = step;
+		this.stepStart = stepStart;
 	}
 
 	@Override
@@ -65,11 +77,11 @@ class DefaultRangeSequence implements Sequence {
 				refreshRange();
 				continue;
 			}
-			long id = range.getAndIncrement();
+			long id = range.next();
 			if (id >= 0) {
 				return id;
 			}
-			// 如果 getAndIncrement() 返回 <0，说明已用尽 → 循环刷新
+			// 如果 next() 返回 <0，说明已用尽 → 循环刷新
 		}
 	}
 
@@ -77,7 +89,7 @@ class DefaultRangeSequence implements Sequence {
 		lock.lock();
 		try {
 			if (currentRange == null || currentRange.isOver()) {
-				currentRange = manager.nextRange(name);
+				currentRange = manager.nextRange(name, step, stepStart);
 			}
 		}
 		catch (Exception ex) {

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/builder/DefaultSequenceBuilder.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/builder/DefaultSequenceBuilder.java
@@ -45,7 +45,10 @@ class DefaultSequenceBuilder implements SequenceBuilder {
 
 	@Override
 	public final SequenceBuilder step(int step) {
-		this.step = step;
+		// 非法步长忽略，保留默认值
+		if (step > 0) {
+			this.step = step;
+		}
 		return this;
 	}
 
@@ -57,15 +60,16 @@ class DefaultSequenceBuilder implements SequenceBuilder {
 
 	@Override
 	public final SequenceBuilder stepStart(long stepStart) {
-		this.stepStart = stepStart;
+		// 非法起始值忽略，保留默认值
+		if (stepStart >= 0) {
+			this.stepStart = stepStart;
+		}
 		return this;
 	}
 
 	@Override
 	public final Sequence build() {
-		manager.step(this.step);
-		manager.stepStart(stepStart);
-		return new DefaultRangeSequence(manager, bizName);
+		return new DefaultRangeSequence(manager, bizName, step, stepStart);
 	}
 
 }

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/AbstractRangeManager.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/AbstractRangeManager.java
@@ -25,37 +25,13 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractRangeManager implements RangeManager {
 
-	/**
-	 * 区间步长
-	 */
-	protected int step = 1000;
-
-	/**
-	 * 区间起始位置，真实从stepStart+1开始
-	 */
-	protected long stepStart = 0;
-
 	@Override
-	public void step(int step) {
-		if (step > 0) {
-			this.step = step;
-		}
-	}
-
-	@Override
-	public void stepStart(long stepStart) {
-		if (stepStart >= 0) {
-			this.stepStart = stepStart;
-		}
-	}
-
-	@Override
-	public final SequenceRange nextRange(String name) {
+	public final SequenceRange nextRange(String name, int step, long stepStart) {
 		if (!StringUtils.hasText(name)) {
 			throw new SequenceException("[RangeManager-nextRange] name is empty.");
 		}
 		try {
-			return buildNextRange(name);
+			return buildNextRange(name, step, stepStart);
 		}
 		catch (SequenceException ex) {
 			throw ex;
@@ -65,6 +41,6 @@ public abstract class AbstractRangeManager implements RangeManager {
 		}
 	}
 
-	protected abstract SequenceRange buildNextRange(String name);
+	protected abstract SequenceRange buildNextRange(String name, int step, long stepStart);
 
 }

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/DbRangeManager.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/DbRangeManager.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 /**
  * @author livk
  */
-public class DbRangeManager extends AbstractRangeManager implements RangeManager {
+public class DbRangeManager extends AbstractRangeManager {
 
 	/**
 	 * 表名前缀，为防止数据库表名冲突，默认带上这个前缀
@@ -62,7 +62,7 @@ public class DbRangeManager extends AbstractRangeManager implements RangeManager
 	}
 
 	@Override
-	public SequenceRange buildNextRange(String name) {
+	public SequenceRange buildNextRange(String name, int step, long stepStart) {
 		for (int i = 0; i < retryTimes; i++) {
 			Long oldValue = this.selectRange(name, stepStart);
 			if (null == oldValue) {

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/RangeManager.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/RangeManager.java
@@ -19,14 +19,21 @@ package com.livk.context.sequence.support;
 import com.livk.context.sequence.SequenceRange;
 
 /**
+ * 序列号区间管理器。
+ * <p>
+ * 实现应当是无状态的，区间步长与起始值由调用方在获取区间时传入，从而支持同一个管理器被多个不同配置的序列安全共享。
+ *
  * @author livk
  */
 public interface RangeManager {
 
-	SequenceRange nextRange(String name);
-
-	void step(int step);
-
-	void stepStart(long stepStart);
+	/**
+	 * 获取指定业务名称的下一个序列号区间。
+	 * @param name 业务名称
+	 * @param step 区间步长
+	 * @param stepStart 区间起始位置
+	 * @return 序列号区间
+	 */
+	SequenceRange nextRange(String name, int step, long stepStart);
 
 }

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/RedisRangeManager.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/RedisRangeManager.java
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets;
  * @author livk
  */
 @RequiredArgsConstructor
-public class RedisRangeManager extends AbstractRangeManager implements RangeManager {
+public class RedisRangeManager extends AbstractRangeManager {
 
 	/**
 	 * 前缀防止key重复
@@ -40,7 +40,7 @@ public class RedisRangeManager extends AbstractRangeManager implements RangeMana
 	private final SequenceRedisHelper helper;
 
 	@Override
-	public SequenceRange buildNextRange(String name) {
+	public SequenceRange buildNextRange(String name, int step, long stepStart) {
 		byte[] realKey = getRealKey(name);
 		helper.setNx(realKey, stepStart);
 		Long max = helper.incrBy(realKey, step);

--- a/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/db/H2SequenceDbHelper.java
+++ b/spring-extension-context/spring-extension-sequence/src/main/java/com/livk/context/sequence/support/db/H2SequenceDbHelper.java
@@ -50,7 +50,7 @@ public class H2SequenceDbHelper implements SequenceDbHelper {
 	public String insertRangeSql(String tableName) {
 		return String.format("""
 				MERGE INTO %s (name, val, create_time, update_time)
-				KEY(val)
+				KEY(name)
 				VALUES (:name, :val, :create_time, :update_time)
 				""", tableName);
 	}

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/SequenceRangeTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/SequenceRangeTests.java
@@ -30,10 +30,10 @@ class SequenceRangeTests {
 		SequenceRange range = new SequenceRange(1L, 10L);
 		for (int i = 1; i <= 10; i++) {
 			assertThat(range.isOver()).isFalse();
-			assertThat(range.getAndIncrement()).isEqualTo(i);
+			assertThat(range.next()).isEqualTo(i);
 		}
 
-		assertThat(range.getAndIncrement()).isEqualTo(-1);
+		assertThat(range.next()).isEqualTo(-1);
 		assertThat(range.isOver()).isTrue();
 	}
 

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/builder/DefaultRangeSequenceTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/builder/DefaultRangeSequenceTests.java
@@ -31,7 +31,7 @@ class DefaultRangeSequenceTests {
 
 	@Test
 	void nextValue() {
-		DefaultRangeSequence sequence = new DefaultRangeSequence(rangeManager, "test");
+		DefaultRangeSequence sequence = new DefaultRangeSequence(rangeManager, "test", 10, 0);
 		for (int i = 0; i < 10; i++) {
 			assertThat(sequence.nextValue()).isEqualTo(i + 1);
 		}
@@ -40,18 +40,8 @@ class DefaultRangeSequenceTests {
 	static class TestRangeManager implements RangeManager {
 
 		@Override
-		public SequenceRange nextRange(String name) {
+		public SequenceRange nextRange(String name, int step, long stepStart) {
 			return new SequenceRange(1L, 10L);
-		}
-
-		@Override
-		public void step(int step) {
-
-		}
-
-		@Override
-		public void stepStart(long stepStart) {
-
 		}
 
 	}

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/builder/DefaultSequenceBuilderTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/builder/DefaultSequenceBuilderTests.java
@@ -101,14 +101,7 @@ class DefaultSequenceBuilderTests {
 		Sequence sequence = builder.build();
 		assertThat(sequence).isNotNull();
 
-		// Use reflection to access the step value in DbRangeManager
-		Field managerField = sequence.getClass().getDeclaredField("manager");
-		managerField.setAccessible(true);
-		Object manager = managerField.get(sequence);
-		Field stepField = DbRangeManager.class.getSuperclass().getDeclaredField("step");
-		stepField.setAccessible(true);
-		int actualStep = (int) stepField.get(manager);
-		assertThat(actualStep).isEqualTo(customStep);
+		assertThat(readStep(sequence)).isEqualTo(customStep);
 	}
 
 	@Test
@@ -120,14 +113,7 @@ class DefaultSequenceBuilderTests {
 		Sequence sequence = builder.build();
 		assertThat(sequence).isNotNull();
 
-		// Use reflection to access the stepStart value in DbRangeManager
-		Field managerField = sequence.getClass().getDeclaredField("manager");
-		managerField.setAccessible(true);
-		Object manager = managerField.get(sequence);
-		Field stepStartField = DbRangeManager.class.getSuperclass().getDeclaredField("stepStart");
-		stepStartField.setAccessible(true);
-		long actualStepStart = (long) stepStartField.get(manager);
-		assertThat(actualStepStart).isEqualTo(customStepStart);
+		assertThat(readStepStart(sequence)).isEqualTo(customStepStart);
 	}
 
 	@Test
@@ -145,13 +131,7 @@ class DefaultSequenceBuilderTests {
 		assertThat(sequence).isNotNull();
 
 		// Should still use default step (1000)
-		Field managerField = sequence.getClass().getDeclaredField("manager");
-		managerField.setAccessible(true);
-		Object manager = managerField.get(sequence);
-		Field stepField = DbRangeManager.class.getSuperclass().getDeclaredField("step");
-		stepField.setAccessible(true);
-		int actualStep = (int) stepField.get(manager);
-		assertThat(actualStep).isEqualTo(10);
+		assertThat(readStep(sequence)).isEqualTo(1000);
 	}
 
 	@Test
@@ -161,13 +141,19 @@ class DefaultSequenceBuilderTests {
 		assertThat(sequence).isNotNull();
 
 		// Should still use default stepStart (0)
-		Field managerField = sequence.getClass().getDeclaredField("manager");
-		managerField.setAccessible(true);
-		Object manager = managerField.get(sequence);
-		Field stepStartField = DbRangeManager.class.getSuperclass().getDeclaredField("stepStart");
+		assertThat(readStepStart(sequence)).isEqualTo(0);
+	}
+
+	private static int readStep(Sequence sequence) throws Exception {
+		Field stepField = sequence.getClass().getDeclaredField("step");
+		stepField.setAccessible(true);
+		return stepField.getInt(sequence);
+	}
+
+	private static long readStepStart(Sequence sequence) throws Exception {
+		Field stepStartField = sequence.getClass().getDeclaredField("stepStart");
 		stepStartField.setAccessible(true);
-		long actualStepStart = (long) stepStartField.get(manager);
-		assertThat(actualStepStart).isEqualTo(0);
+		return stepStartField.getLong(sequence);
 	}
 
 	@Test

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/support/DbRangeManagerTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/support/DbRangeManagerTests.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DuplicateKeyException;
 
 import javax.sql.DataSource;
-import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -54,20 +53,20 @@ class DbRangeManagerTests {
 	void testNextRangeReturnsValidSequenceRange() {
 		DbRangeManager manager = new DbRangeManager(dataSource);
 		String name = "test-seq";
-		SequenceRange range = manager.nextRange(name);
+		SequenceRange range = manager.nextRange(name, 1000, 0);
 		assertThat(range).isNotNull();
 		assertThat(range.getMin()).isEqualTo(1);
 		assertThat(range.getMax()).isEqualTo(1000);
 		assertThat(range.isOver()).isFalse();
-		assertThat(range.getAndIncrement()).isEqualTo(1);
-		assertThat(range.getAndIncrement()).isEqualTo(2);
+		assertThat(range.next()).isEqualTo(1);
+		assertThat(range.next()).isEqualTo(2);
 	}
 
 	@Test
 	void testInitCreatesTableSuccessfully() {
 		assertThatCode(() -> new DbRangeManager(dataSource)).doesNotThrowAnyException();
 
-		SequenceRange range = new DbRangeManager(dataSource).nextRange("init-table-seq");
+		SequenceRange range = new DbRangeManager(dataSource).nextRange("init-table-seq", 1000, 0);
 		assertThat(range).isNotNull();
 	}
 
@@ -76,14 +75,14 @@ class DbRangeManagerTests {
 		DbRangeManager manager = new DbRangeManager(dataSource);
 		String name = "retry-seq";
 
-		SequenceRange firstRange = manager.nextRange(name);
+		SequenceRange firstRange = manager.nextRange(name, 1000, 0);
 		assertThat(firstRange).isNotNull();
 
 		DbRangeManager concurrentManager = new DbRangeManager(dataSource);
-		SequenceRange concurrentRange = concurrentManager.nextRange(name);
+		SequenceRange concurrentRange = concurrentManager.nextRange(name, 1000, 0);
 		assertThat(concurrentRange).isNotNull();
 
-		SequenceRange retriedRange = manager.nextRange(name);
+		SequenceRange retriedRange = manager.nextRange(name, 1000, 0);
 		assertThat(retriedRange).isNotNull();
 		assertThat(retriedRange.getMin()).isEqualTo(concurrentRange.getMax() + 1);
 	}
@@ -110,7 +109,7 @@ class DbRangeManagerTests {
 		}
 		DuplicateKeyOnceDbRangeManager manager = new DuplicateKeyOnceDbRangeManager(dataSource);
 
-		SequenceRange range = manager.nextRange("duplicate-key-retry-seq");
+		SequenceRange range = manager.nextRange("duplicate-key-retry-seq", 1000, 0);
 
 		assertThat(range.getMin()).isEqualTo(1);
 		assertThat(range.getMax()).isEqualTo(1000);
@@ -120,9 +119,9 @@ class DbRangeManagerTests {
 	void testNextRangeThrowsOnEmptyName() {
 		DbRangeManager manager = new DbRangeManager(dataSource);
 
-		assertThatThrownBy(() -> manager.nextRange("")).isInstanceOf(SequenceException.class);
+		assertThatThrownBy(() -> manager.nextRange("", 1000, 0)).isInstanceOf(SequenceException.class);
 
-		assertThatThrownBy(() -> manager.nextRange(null)).isInstanceOf(SequenceException.class);
+		assertThatThrownBy(() -> manager.nextRange(null, 1000, 0)).isInstanceOf(SequenceException.class);
 
 	}
 
@@ -134,19 +133,6 @@ class DbRangeManagerTests {
 
 			FailingDbRangeManager(DataSource ds) {
 				super(ds);
-			}
-
-			@Override
-			public SequenceRange buildNextRange(String name) {
-				// Use reflection to set step to 1 for faster test
-				try {
-					Field stepField = AbstractRangeManager.class.getDeclaredField("step");
-					stepField.setAccessible(true);
-					stepField.setInt(this, 1);
-				}
-				catch (Exception ignored) {
-				}
-				return super.buildNextRange(name);
 			}
 
 			@Override
@@ -162,7 +148,7 @@ class DbRangeManagerTests {
 		}
 		FailingDbRangeManager manager = new FailingDbRangeManager(dataSource);
 
-		assertThatThrownBy(() -> manager.nextRange("fail-retry-seq")).isInstanceOf(SequenceException.class);
+		assertThatThrownBy(() -> manager.nextRange("fail-retry-seq", 1, 0)).isInstanceOf(SequenceException.class);
 	}
 
 	@Test
@@ -183,7 +169,7 @@ class DbRangeManagerTests {
 		}
 		NullReturningDbRangeManager manager = new NullReturningDbRangeManager(dataSource);
 
-		assertThatThrownBy(() -> manager.nextRange("null-helper-seq")).isInstanceOf(SequenceException.class);
+		assertThatThrownBy(() -> manager.nextRange("null-helper-seq", 1000, 0)).isInstanceOf(SequenceException.class);
 	}
 
 }

--- a/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/support/RedisRangeManagerTests.java
+++ b/spring-extension-context/spring-extension-sequence/src/test/java/com/livk/context/sequence/support/RedisRangeManagerTests.java
@@ -69,10 +69,8 @@ class RedisRangeManagerTests {
 	@Test
 	void testNextRangeReturnsValidSequenceRangeForNewKey() {
 		RedisRangeManager manager = new RedisRangeManager(helper);
-		manager.step(10);
-		manager.stepStart(100);
 		String key = "test-sequence";
-		SequenceRange range = manager.nextRange(key);
+		SequenceRange range = manager.nextRange(key, 10, 100);
 
 		assertThat(range).isNotNull();
 		assertThat(range.getMin()).isEqualTo(101);
@@ -93,21 +91,20 @@ class RedisRangeManagerTests {
 	@Test
 	void testNextRangeDoesNotReinitializeExistingKey() {
 		RedisRangeManager manager = new RedisRangeManager(helper);
-		manager.step(5);
-		manager.stepStart(0);
+		int step = 5;
 		String key = "repeat-key";
 
-		SequenceRange firstRange = manager.nextRange(key);
+		SequenceRange firstRange = manager.nextRange(key, step, 0);
 		assertThat(firstRange).isNotNull();
 		long max1 = firstRange.getMax();
 
-		SequenceRange secondRange = manager.nextRange(key);
+		SequenceRange secondRange = manager.nextRange(key, step, 0);
 		assertThat(secondRange).isNotNull();
 		long min2 = secondRange.getMin();
 		long max2 = secondRange.getMax();
 
 		assertThat(min2).isEqualTo(max1 + 1);
-		assertThat(max2).isEqualTo(max1 + manager.step);
+		assertThat(max2).isEqualTo(max1 + step);
 	}
 
 }


### PR DESCRIPTION
- 将 RangeManager 接口的 nextRange 方法签名修改为接受业务名称、步长和起始位置参数
- 从 AbstractRangeManager 移除状态字段 step 和 stepStart，改为通过方法参数传递
- 修改各 RangeManager 实现类（DbRangeManager、RedisRangeManager）方法签名及实现，支持动态步长和起始位置
- 调整 DefaultRangeSequence 构造与使用，支持传递步长和起始位置参数
- 更新 DefaultSequenceBuilder，增加步长和起始位置的有效性校验，并传递给 DefaultRangeSequence
- 修改 SequenceRange 类，移除 Setter 与过时方法，优化序列号递增和区间结束判断逻辑
- 修正 H2SequenceDbHelper 的 SQL 中键字段错误，由原来的 val 改为 name
- 更新相关单元测试，适配新接口，去除反射访问旧字段，改用直接传参方式测试逻辑
- RedisRangeManager 测试中移除旧的 step 设置，改用传参调用 nextRange 方法
- 整体消除共享状态，确保区间管理逻辑更加无状态且线程安全
- 统一使用 next() 替代 getAndIncrement()，提升命名语义清晰度

## Summary by Sourcery

重构序列区间管理，使其在每次调用时都能接受动态的步长和起始参数，移除管理器中的共享可变状态，并改进序列区间处理语义。

新特性：
- 允许 RangeManager 实现通过 `nextRange(name, step, stepStart)` 动态接收步长和起始位置。

缺陷修复：
- 修复 H2SequenceDbHelper 的 MERGE 语句，使其使用 `name` 作为主键列而不是 `val`。

增强改进：
- 使 SequenceRange 在结构上不可变，用 `next()` 替代 `getAndIncrement()`，并基于当前值而不是可变标志来判断是否结束。
- 更新 DefaultRangeSequence 和 DefaultSequenceBuilder，显式携带并校验步长和起始配置，确保更安全、更清晰的区间分配。
- 简化 RangeManager、AbstractRangeManager、DbRangeManager 和 RedisRangeManager 的 API，通过移除与步长相关的字段和 setter，使其无状态且线程安全。
- 调整测试以使用新的无状态配置和 `next()` API，去除对反射和内部状态的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the sequence range management to accept dynamic step and start parameters per call, remove shared mutable state from managers, and improve sequence range handling semantics.

New Features:
- Allow RangeManager implementations to accept step size and start position dynamically via nextRange(name, step, stepStart).

Bug Fixes:
- Fix H2SequenceDbHelper MERGE statement to use name as the key column instead of val.

Enhancements:
- Make SequenceRange immutable in structure, replace getAndIncrement() with next(), and base the over state on current value rather than a mutable flag.
- Update DefaultRangeSequence and DefaultSequenceBuilder to carry and validate step and start configuration explicitly, ensuring safer, clearer range allocation.
- Simplify RangeManager, AbstractRangeManager, DbRangeManager, and RedisRangeManager APIs to be stateless and thread-safe by removing step-related fields and setters.
- Adjust tests to use the new stateless configuration and next() API, removing reliance on reflection and internal state.

</details>