### PR TITLE
Refactor AOP annotation advisors to use pointcut factories

### DIFF
--- a/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/main/java/com/livk/redisson/lock/ShopController.java
+++ b/spring-boot-extension-tests/distributed-lock-boot-test/redisson-lock-boot-test/src/main/java/com/livk/redisson/lock/ShopController.java
@@ -27,6 +27,7 @@ import org.redisson.client.codec.StringCodec;
 import org.redisson.codec.CompositeCodec;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.ResourceUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -65,8 +66,7 @@ public class ShopController {
 	@PostMapping("/buy/distributed")
 	@DistLock(key = "shop:lock")
 	public HttpEntity<Map<String, Object>> buy(@RequestParam(defaultValue = "2") Integer count) throws IOException {
-		String luaScript = ResourceScanner
-			.getResource(org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX + "script/buy.lua")
+		String luaScript = ResourceScanner.getResource(ResourceUtils.CLASSPATH_URL_PREFIX + "script/buy.lua")
 			.getContentAsString(StandardCharsets.UTF_8);
 		List<Object> keys = List.of("shop", "num", "buySucCount", "buyCount");
 		RScript script = redissonClient.getScript();

--- a/spring-extension-commons/src/main/java/com/livk/commons/aop/AbstractAnnotationAdvisor.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/aop/AbstractAnnotationAdvisor.java
@@ -34,18 +34,18 @@ import java.lang.reflect.Method;
  * @param <A> 注解
  * @author livk
  */
-public abstract class AnnotationAbstractPointcutAdvisor<A extends Annotation> extends AbstractPointcutAdvisor
+public abstract class AbstractAnnotationAdvisor<A extends Annotation> extends AbstractPointcutAdvisor
 		implements IntroductionInterceptor {
 
 	/**
 	 * 切点注解类型
 	 */
 	protected final Class<A> annotationType = TypeUtils.resolveTypeArgument(this.getClass(),
-			AnnotationAbstractPointcutAdvisor.class);
+			AbstractAnnotationAdvisor.class);
 
 	@NonNull
 	@Override
-	public Object invoke(@NonNull MethodInvocation invocation) throws Throwable {
+	public final Object invoke(@NonNull MethodInvocation invocation) throws Throwable {
 		Assert.notNull(annotationType, "annotationType must not be null");
 		Method method = invocation.getMethod();
 		AnnotationTarget<A> target = AnnotationTarget.of(annotationType);
@@ -53,7 +53,7 @@ public abstract class AnnotationAbstractPointcutAdvisor<A extends Annotation> ex
 		if (annotation == null && invocation.getThis() != null) {
 			annotation = target.getAnnotation(invocation.getThis().getClass());
 		}
-		return invoke(invocation, annotation);
+		return doInvoke(invocation, annotation);
 	}
 
 	@Override
@@ -69,7 +69,7 @@ public abstract class AnnotationAbstractPointcutAdvisor<A extends Annotation> ex
 	 * @return 方法返回结果 object
 	 * @throws Throwable the throwable
 	 */
-	protected abstract Object invoke(MethodInvocation invocation, A annotation) throws Throwable;
+	protected abstract Object doInvoke(MethodInvocation invocation, A annotation) throws Throwable;
 
 	@Override
 	public boolean implementsInterface(@NonNull Class<?> intf) {

--- a/spring-extension-commons/src/main/java/com/livk/commons/aop/AbstractAnnotationPointcutStrategyAdvisor.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/aop/AbstractAnnotationPointcutStrategyAdvisor.java
@@ -26,25 +26,23 @@ import java.lang.annotation.Annotation;
  *
  * @param <A> the type parameter
  * @author livk
- * @see AnnotationAbstractPointcutAdvisor
+ * @see AbstractAnnotationAdvisor
  */
-public abstract class AnnotationAbstractPointcutTypeAdvisor<A extends Annotation>
-		extends AnnotationAbstractPointcutAdvisor<A> {
+public abstract class AbstractAnnotationPointcutStrategyAdvisor<A extends Annotation>
+		extends AbstractAnnotationAdvisor<A> {
 
 	@NonNull
 	@Override
-	public Pointcut getPointcut() {
-		return annotationPointcut().getPointcut(annotationType);
+	public final Pointcut getPointcut() {
+		return pointcutStrategy().create(annotationType);
 	}
 
 	/**
-	 * <p>
-	 * 用于指定不同的切点类型，默认为{@link AnnotationPointcut#forTarget()}
-	 * </p>
-	 * @return the annotation pointcut type
+	 * Returns the strategy used to create the {@link Pointcut} for the configured
+	 * annotation.
 	 */
-	protected AnnotationPointcut annotationPointcut() {
-		return AnnotationPointcut.forTarget();
+	protected AnnotationPointcutFactory pointcutStrategy() {
+		return AnnotationPointcutFactory.forTarget();
 	}
 
 }

--- a/spring-extension-commons/src/main/java/com/livk/commons/aop/AnnotationPointcutFactory.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/aop/AnnotationPointcutFactory.java
@@ -28,36 +28,38 @@ import java.lang.annotation.Annotation;
  * @author livk
  */
 @FunctionalInterface
-public interface AnnotationPointcut {
+public interface AnnotationPointcutFactory {
 
 	/**
-	 * 根据注解获取到切点
+	 * 根据指定注解类型创建 Pointcut。
 	 * @param annotationType 注解类信息
 	 * @return 切点
+	 * @deprecated since 2.1.1, use {@link #create(Class)} instead.
 	 */
-	Pointcut getPointcut(Class<? extends Annotation> annotationType);
+	@Deprecated(since = "2.1.1")
+	default Pointcut getPointcut(Class<? extends Annotation> annotationType) {
+		return create(annotationType);
+	}
 
-	static AnnotationPointcut forType() {
+	Pointcut create(Class<? extends Annotation> annotationType);
+
+	static AnnotationPointcutFactory forType() {
 		return AnnotationMatchingPointcut::forClassAnnotation;
 	}
 
-	static AnnotationPointcut forType(boolean checkInherited) {
+	static AnnotationPointcutFactory forType(boolean checkInherited) {
 		return annotationType -> new AnnotationMatchingPointcut(annotationType, checkInherited);
 	}
 
-	static AnnotationPointcut forMethod() {
+	static AnnotationPointcutFactory forMethod() {
 		return AnnotationMatchingPointcut::forMethodAnnotation;
 	}
 
-	static AnnotationPointcut forTypeOrMethod() {
-		return annotationType -> {
-			AnnotationMatchingPointcut cpc = AnnotationMatchingPointcut.forClassAnnotation(annotationType);
-			AnnotationMatchingPointcut mpc = AnnotationMatchingPointcut.forMethodAnnotation(annotationType);
-			return new ComposablePointcut(cpc).union(mpc);
-		};
+	static AnnotationPointcutFactory forTypeOrMethod() {
+		return forTypeOrMethod(false);
 	}
 
-	static AnnotationPointcut forTypeOrMethod(boolean checkInherited) {
+	static AnnotationPointcutFactory forTypeOrMethod(boolean checkInherited) {
 		return annotationType -> {
 			AnnotationMatchingPointcut cpc = new AnnotationMatchingPointcut(annotationType, checkInherited);
 			AnnotationMatchingPointcut mpc = AnnotationMatchingPointcut.forMethodAnnotation(annotationType);
@@ -65,7 +67,7 @@ public interface AnnotationPointcut {
 		};
 	}
 
-	static AnnotationPointcut forTarget() {
+	static AnnotationPointcutFactory forTarget() {
 		return AnnotationTarget.TARGET_POINTCUT;
 	}
 

--- a/spring-extension-commons/src/main/java/com/livk/commons/aop/AnnotationTarget.java
+++ b/spring-extension-commons/src/main/java/com/livk/commons/aop/AnnotationTarget.java
@@ -16,17 +16,17 @@
 
 package com.livk.commons.aop;
 
-import com.google.common.collect.Sets;
-import org.springframework.core.annotation.AnnotationUtils;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.aop.Pointcut;
+import org.springframework.core.annotation.AnnotationUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 final class AnnotationTarget<A extends Annotation> {
 
-	public static final AnnotationPointcut TARGET_POINTCUT = new AnnotationTargetPointcut();
+	public static final AnnotationPointcutFactory TARGET_POINTCUT = new AnnotationTargetPointcut();
 
 	private static final ConcurrentMap<Class<? extends Annotation>, AnnotationTarget<?>> CACHE = new ConcurrentHashMap<>();
 
@@ -46,49 +46,51 @@ final class AnnotationTarget<A extends Annotation> {
 
 	private final Class<A> annotationType;
 
-	private final Set<ElementType> elementTypes;
+	private final EnumSet<ElementType> elementTypes;
 
 	private AnnotationTarget(Class<A> annotationType) {
 		this.annotationType = annotationType;
 		Target target = annotationType.getAnnotation(Target.class);
-		this.elementTypes = Sets.newHashSet(target.value());
+		this.elementTypes = (target == null) ? EnumSet.allOf(ElementType.class)
+				: EnumSet.copyOf(Arrays.asList(target.value()));
 	}
 
 	public A getAnnotation(Method method) {
-		return supportMethod() ? AnnotationUtils.getAnnotation(method, annotationType) : null;
+		return supports(ElementType.METHOD) ? AnnotationUtils.getAnnotation(method, annotationType) : null;
 	}
 
 	public A getAnnotation(Class<?> clazz) {
-		return supportType() ? AnnotationUtils.getAnnotation(clazz, annotationType) : null;
+		return supports(ElementType.TYPE) ? AnnotationUtils.getAnnotation(clazz, annotationType) : null;
 	}
 
-	private boolean supportMethod() {
-		return elementTypes.contains(ElementType.METHOD);
-	}
-
-	private boolean supportType() {
-		return elementTypes.contains(ElementType.TYPE);
+	/**
+	 * 是否支持指定的 ElementType。
+	 */
+	boolean supports(ElementType elementType) {
+		return elementTypes.contains(elementType);
 	}
 
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	static final class AnnotationTargetPointcut implements AnnotationPointcut {
+	static final class AnnotationTargetPointcut implements AnnotationPointcutFactory {
 
 		@Override
-		public Pointcut getPointcut(Class<? extends Annotation> annotationType) {
+		public Pointcut create(Class<? extends Annotation> annotationType) {
 			AnnotationTarget<?> target = AnnotationTarget.of(annotationType);
-			if (target.supportType() && target.supportMethod()) {
-				return AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType);
+
+			if (target.supports(ElementType.TYPE) && target.supports(ElementType.METHOD)) {
+				return AnnotationPointcutFactory.forTypeOrMethod().create(annotationType);
 			}
-			else if (target.supportType()) {
-				return AnnotationPointcut.forType().getPointcut(annotationType);
+
+			if (target.supports(ElementType.TYPE)) {
+				return AnnotationPointcutFactory.forType().create(annotationType);
 			}
-			else if (target.supportMethod()) {
-				return AnnotationPointcut.forMethod().getPointcut(annotationType);
+
+			if (target.supports(ElementType.METHOD)) {
+				return AnnotationPointcutFactory.forMethod().create(annotationType);
 			}
-			else {
-				throw new IllegalArgumentException(
-						"annotation:" + annotationType + " Missing " + Target.class + " TYPE or METHOD information");
-			}
+
+			throw new IllegalArgumentException("Annotation '" + annotationType.getName()
+					+ "' must support ElementType.TYPE and/or ElementType.METHOD.");
 		}
 
 	}

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AbstractAnnotationAdvisorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AbstractAnnotationAdvisorTests.java
@@ -33,9 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-class AnnotationAbstractPointcutAdvisorTests {
+class AbstractAnnotationAdvisorTests {
 
-	final MyAnnotationAbstractPointcutAdvisor advisor = new MyAnnotationAbstractPointcutAdvisor();
+	final MyAbstractAnnotationAdvisor advisor = new MyAbstractAnnotationAdvisor();
 
 	@Test
 	void resolvesAnnotationTypeFromGenericArgument() {
@@ -93,17 +93,17 @@ class AnnotationAbstractPointcutAdvisorTests {
 
 	}
 
-	static class MyAnnotationAbstractPointcutAdvisor extends AnnotationAbstractPointcutAdvisor<MyAnnotation> {
+	static class MyAbstractAnnotationAdvisor extends AbstractAnnotationAdvisor<MyAnnotation> {
 
 		@Override
-		protected Object invoke(MethodInvocation invocation, MyAnnotation annotation) throws Throwable {
+		protected Object doInvoke(MethodInvocation invocation, MyAnnotation annotation) throws Throwable {
 			return invocation.proceed();
 		}
 
 		@NonNull
 		@Override
 		public Pointcut getPointcut() {
-			return AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType);
+			return AnnotationPointcutFactory.forTypeOrMethod().create(annotationType);
 		}
 
 	}

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AbstractAnnotationPointcutStrategyAdvisorTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AbstractAnnotationPointcutStrategyAdvisorTests.java
@@ -30,9 +30,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-class AnnotationAbstractPointcutTypeAdvisorTests {
+class AbstractAnnotationPointcutStrategyAdvisorTests {
 
-	final MyAnnotationAbstractPointcutTypeAdvisor advisor = new MyAnnotationAbstractPointcutTypeAdvisor();
+	final MyAbstractAnnotationTypeAdvisor advisor = new MyAbstractAnnotationTypeAdvisor();
 
 	@Test
 	void pointcutIsAnnotationMatchingPointcut() {
@@ -51,9 +51,8 @@ class AnnotationAbstractPointcutTypeAdvisorTests {
 
 	@Test
 	void classFilterDoesNotMatchDifferentAnnotatedClass() {
-		assertThat(advisor.getPointcut()
-			.getClassFilter()
-			.matches(AnnotationAbstractPointcutAdvisorTests.AopProxyClass.class)).isFalse();
+		assertThat(advisor.getPointcut().getClassFilter().matches(AbstractAnnotationAdvisorTests.AopProxyClass.class))
+			.isFalse();
 	}
 
 	@Test
@@ -80,16 +79,16 @@ class AnnotationAbstractPointcutTypeAdvisorTests {
 
 	}
 
-	static class MyAnnotationAbstractPointcutTypeAdvisor extends AnnotationAbstractPointcutTypeAdvisor<MyAnnotation> {
+	static class MyAbstractAnnotationTypeAdvisor extends AbstractAnnotationPointcutStrategyAdvisor<MyAnnotation> {
 
 		@Override
-		protected Object invoke(MethodInvocation invocation, MyAnnotation annotation) throws Throwable {
+		protected Object doInvoke(MethodInvocation invocation, MyAnnotation annotation) throws Throwable {
 			return invocation.proceed();
 		}
 
 		@Override
-		protected AnnotationPointcut annotationPointcut() {
-			return AnnotationPointcut.forType();
+		protected AnnotationPointcutFactory pointcutStrategy() {
+			return AnnotationPointcutFactory.forType();
 		}
 
 	}

--- a/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationPointcutFactoryTests.java
+++ b/spring-extension-commons/src/test/java/com/livk/commons/aop/AnnotationPointcutFactoryTests.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author livk
  */
-class AnnotationPointcutTests {
+class AnnotationPointcutFactoryTests {
 
 	static final Class<? extends Annotation> annotationType = MyAnnotation.class;
 	static final Class<?> type = AopProxyClass.class;
@@ -45,50 +45,50 @@ class AnnotationPointcutTests {
 
 	@Test
 	void testAnnotationPointcutForTarget() {
-		AnnotationPointcut pointcut = AnnotationPointcut.forTarget();
+		AnnotationPointcutFactory pointcut = AnnotationPointcutFactory.forTarget();
 
-		assertThat(pointcut.getPointcut(annotationType))
-			.isEqualTo(AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType));
+		assertThat(pointcut.create(annotationType))
+			.isEqualTo(AnnotationPointcutFactory.forTypeOrMethod().create(annotationType));
 
-		assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+		assertThat(pointcut.create(annotationType).getClassFilter().matches(type)).isTrue();
 
-		assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
+		assertThat(pointcut.create(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 	}
 
 	@Test
 	void testAnnotationPointcutForType() {
-		AnnotationPointcut pointcut = AnnotationPointcut.forType();
+		AnnotationPointcutFactory pointcut = AnnotationPointcutFactory.forType();
 
-		assertThat(pointcut.getPointcut(annotationType))
+		assertThat(pointcut.create(annotationType))
 			.isEqualTo(AnnotationMatchingPointcut.forClassAnnotation(annotationType));
 
-		assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+		assertThat(pointcut.create(annotationType).getClassFilter().matches(type)).isTrue();
 
-		assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
+		assertThat(pointcut.create(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 	}
 
 	@Test
 	void testAnnotationPointcutForMethod() {
-		AnnotationPointcut pointcut = AnnotationPointcut.forMethod();
+		AnnotationPointcutFactory pointcut = AnnotationPointcutFactory.forMethod();
 
-		assertThat(pointcut.getPointcut(annotationType))
+		assertThat(pointcut.create(annotationType))
 			.isEqualTo(AnnotationMatchingPointcut.forMethodAnnotation(annotationType));
 
-		assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+		assertThat(pointcut.create(annotationType).getClassFilter().matches(type)).isTrue();
 
-		assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
+		assertThat(pointcut.create(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 	}
 
 	@Test
 	void testAnnotationPointcutForTypeOrMethod() {
-		AnnotationPointcut pointcut = AnnotationPointcut.forTypeOrMethod();
+		AnnotationPointcutFactory pointcut = AnnotationPointcutFactory.forTypeOrMethod();
 
-		assertThat(pointcut.getPointcut(annotationType))
-			.isEqualTo(AnnotationPointcut.forTypeOrMethod().getPointcut(annotationType));
+		assertThat(pointcut.create(annotationType))
+			.isEqualTo(AnnotationPointcutFactory.forTypeOrMethod().create(annotationType));
 
-		assertThat(pointcut.getPointcut(annotationType).getClassFilter().matches(type)).isTrue();
+		assertThat(pointcut.create(annotationType).getClassFilter().matches(type)).isTrue();
 
-		assertThat(pointcut.getPointcut(annotationType).getMethodMatcher().matches(method, type)).isTrue();
+		assertThat(pointcut.create(annotationType).getMethodMatcher().matches(method, type)).isTrue();
 	}
 
 	@MyAnnotation

--- a/spring-extension-context/spring-extension-dynamic/src/main/java/com/livk/context/dynamic/intercept/DataSourceInterceptor.java
+++ b/spring-extension-context/spring-extension-dynamic/src/main/java/com/livk/context/dynamic/intercept/DataSourceInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.livk.context.dynamic.intercept;
 
-import com.livk.commons.aop.AnnotationAbstractPointcutTypeAdvisor;
+import com.livk.commons.aop.AbstractAnnotationPointcutStrategyAdvisor;
 import com.livk.context.dynamic.DataSourceContextHolder;
 import com.livk.context.dynamic.annotation.DynamicSource;
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,10 +24,10 @@ import org.aopalliance.intercept.MethodInvocation;
 /**
  * @author livk
  */
-public class DataSourceInterceptor extends AnnotationAbstractPointcutTypeAdvisor<DynamicSource> {
+public class DataSourceInterceptor extends AbstractAnnotationPointcutStrategyAdvisor<DynamicSource> {
 
 	@Override
-	protected Object invoke(MethodInvocation invocation, DynamicSource dynamicSource) throws Throwable {
+	protected Object doInvoke(MethodInvocation invocation, DynamicSource dynamicSource) throws Throwable {
 		if (dynamicSource != null) {
 			DataSourceContextHolder.switchDataSource(dynamicSource.value());
 		}

--- a/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/intercept/DataSourceInterceptorTests.java
+++ b/spring-extension-context/spring-extension-dynamic/src/test/java/com/livk/context/dynamic/intercept/DataSourceInterceptorTests.java
@@ -41,7 +41,7 @@ class DataSourceInterceptorTests {
 	}
 
 	@Test
-	void invokeSwitchesDataSourceAndClearsAfter() throws Throwable {
+	void doInvokeSwitchesDataSourceAndClearsAfter() throws Throwable {
 		DynamicSource annotation = mock(DynamicSource.class);
 		given(annotation.value()).willReturn("slave1");
 
@@ -52,7 +52,7 @@ class DataSourceInterceptorTests {
 			return "result";
 		});
 
-		Object result = interceptor.invoke(invocation, annotation);
+		Object result = interceptor.doInvoke(invocation, annotation);
 
 		assertThat(result).isEqualTo("result");
 		assertThat(DataSourceContextHolder.getDataSource()).isNull();
@@ -60,18 +60,18 @@ class DataSourceInterceptorTests {
 	}
 
 	@Test
-	void invokeWithNullAnnotationDoesNotSwitchDataSource() throws Throwable {
+	void doInvokeWithNullAnnotationDoesNotSwitchDataSource() throws Throwable {
 		MethodInvocation invocation = mock(MethodInvocation.class);
 		given(invocation.proceed()).willReturn("result");
 
-		Object result = interceptor.invoke(invocation, null);
+		Object result = interceptor.doInvoke(invocation, null);
 
 		assertThat(result).isEqualTo("result");
 		assertThat(DataSourceContextHolder.getDataSource()).isNull();
 	}
 
 	@Test
-	void invokeClearsDataSourceEvenWhenAnnotationPresent() throws Throwable {
+	void doInvokeClearsDataSourceEvenWhenAnnotationPresent() throws Throwable {
 		DataSourceContextHolder.switchDataSource("existing");
 
 		DynamicSource annotation = mock(DynamicSource.class);
@@ -80,20 +80,21 @@ class DataSourceInterceptorTests {
 		MethodInvocation invocation = mock(MethodInvocation.class);
 		given(invocation.proceed()).willReturn(null);
 
-		interceptor.invoke(invocation, annotation);
+		interceptor.doInvoke(invocation, annotation);
 
 		assertThat(DataSourceContextHolder.getDataSource()).isNull();
 	}
 
 	@Test
-	void invokeClearsDataSourceWhenProceedThrows() throws Throwable {
+	void doInvokeClearsDataSourceWhenProceedThrows() throws Throwable {
 		DynamicSource annotation = mock(DynamicSource.class);
 		given(annotation.value()).willReturn("slave3");
 
 		MethodInvocation invocation = mock(MethodInvocation.class);
 		given(invocation.proceed()).willThrow(new IllegalStateException("boom"));
 
-		assertThatThrownBy(() -> interceptor.invoke(invocation, annotation)).isInstanceOf(IllegalStateException.class);
+		assertThatThrownBy(() -> interceptor.doInvoke(invocation, annotation))
+			.isInstanceOf(IllegalStateException.class);
 		assertThat(DataSourceContextHolder.getDataSource()).isNull();
 	}
 

--- a/spring-extension-context/spring-extension-limit/src/main/java/com/livk/context/limit/interceptor/LimitInterceptor.java
+++ b/spring-extension-context/spring-extension-limit/src/main/java/com/livk/context/limit/interceptor/LimitInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.livk.context.limit.interceptor;
 
-import com.livk.commons.aop.AnnotationAbstractPointcutTypeAdvisor;
+import com.livk.commons.aop.AbstractAnnotationPointcutStrategyAdvisor;
 import com.livk.commons.expression.ExpressionResolver;
 import com.livk.commons.expression.spring.SpringExpressionResolver;
 import org.springframework.beans.BeanUtils;
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class LimitInterceptor extends AnnotationAbstractPointcutTypeAdvisor<Limit> {
+public class LimitInterceptor extends AbstractAnnotationPointcutStrategyAdvisor<Limit> {
 
 	/**
 	 * 执行器
@@ -50,7 +50,7 @@ public class LimitInterceptor extends AnnotationAbstractPointcutTypeAdvisor<Limi
 	private final ExpressionResolver resolver = new SpringExpressionResolver();
 
 	@Override
-	protected Object invoke(MethodInvocation invocation, Limit limit) throws Throwable {
+	protected Object doInvoke(MethodInvocation invocation, Limit limit) throws Throwable {
 		String key = limit.key();
 		int rate = limit.rate();
 		int rateInterval = limit.rateInterval();

--- a/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/interceptor/LimitInterceptorTests.java
+++ b/spring-extension-context/spring-extension-limit/src/test/java/com/livk/context/limit/interceptor/LimitInterceptorTests.java
@@ -48,7 +48,7 @@ class LimitInterceptorTests {
 	LimitInterceptor interceptor = new LimitInterceptor(providers);
 
 	@Test
-	void invokeAllowsAccessWhenExecutorReturnsTrue() throws Throwable {
+	void doInvokeAllowsAccessWhenExecutorReturnsTrue() throws Throwable {
 		LimitExecutor executor = mock(LimitExecutor.class);
 		given(executor.tryAccess(anyString(), anyInt(), any())).willReturn(true);
 		given(providers.orderedStream()).willReturn(Stream.of(executor));
@@ -57,7 +57,7 @@ class LimitInterceptorTests {
 		MethodInvocation invocation = mockInvocation();
 		given(invocation.proceed()).willReturn("result");
 
-		Object result = interceptor.invoke(invocation, limit);
+		Object result = interceptor.doInvoke(invocation, limit);
 
 		assertThat(result).isEqualTo("result");
 		verify(invocation).proceed();
@@ -65,7 +65,7 @@ class LimitInterceptorTests {
 	}
 
 	@Test
-	void invokeThrowsLimitExceptionWhenExecutorReturnsFalse() throws Throwable {
+	void doInvokeThrowsLimitExceptionWhenExecutorReturnsFalse() throws Throwable {
 		LimitExecutor executor = mock(LimitExecutor.class);
 		given(executor.tryAccess(anyString(), anyInt(), any())).willReturn(false);
 		given(providers.orderedStream()).willReturn(Stream.of(executor));
@@ -73,7 +73,7 @@ class LimitInterceptorTests {
 		Limit limit = createLimit("testKey", 10, 60);
 		MethodInvocation invocation = mockInvocation();
 
-		assertThatThrownBy(() -> interceptor.invoke(invocation, limit)).isInstanceOf(LimitException.class);
+		assertThatThrownBy(() -> interceptor.doInvoke(invocation, limit)).isInstanceOf(LimitException.class);
 	}
 
 	private Limit createLimit(String key, int rate, int rateInterval) {

--- a/spring-extension-context/spring-extension-lock/src/main/java/com/livk/context/lock/intercept/DistributedLockInterceptor.java
+++ b/spring-extension-context/spring-extension-lock/src/main/java/com/livk/context/lock/intercept/DistributedLockInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.livk.context.lock.intercept;
 
-import com.livk.commons.aop.AnnotationAbstractPointcutTypeAdvisor;
+import com.livk.commons.aop.AbstractAnnotationPointcutStrategyAdvisor;
 import com.livk.commons.expression.ExpressionResolver;
 import com.livk.commons.expression.spring.SpringExpressionResolver;
 import com.livk.context.lock.DistributedLock;
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  * @author livk
  */
 @RequiredArgsConstructor
-public class DistributedLockInterceptor extends AnnotationAbstractPointcutTypeAdvisor<DistLock> {
+public class DistributedLockInterceptor extends AbstractAnnotationPointcutStrategyAdvisor<DistLock> {
 
 	/**
 	 * lock的实现类集合
@@ -45,7 +45,7 @@ public class DistributedLockInterceptor extends AnnotationAbstractPointcutTypeAd
 	private final ExpressionResolver resolver = new SpringExpressionResolver();
 
 	@Override
-	protected Object invoke(MethodInvocation invocation, DistLock lock) throws Throwable {
+	protected Object doInvoke(MethodInvocation invocation, DistLock lock) throws Throwable {
 		Assert.notNull(lock, "lock is null");
 		DistributedLock distributedLock = distributedLockProvider.orderedStream()
 			.findFirst()

--- a/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/intercept/DistributedLockInterceptorTests.java
+++ b/spring-extension-context/spring-extension-lock/src/test/java/com/livk/context/lock/intercept/DistributedLockInterceptorTests.java
@@ -48,7 +48,7 @@ class DistributedLockInterceptorTests {
 	DistributedLockInterceptor interceptor = new DistributedLockInterceptor(provider);
 
 	@Test
-	void invokeAllowsAccessWhenLockAcquired() throws Throwable {
+	void doInvokeAllowsAccessWhenLockAcquired() throws Throwable {
 		DistributedLock distributedLock = mock(DistributedLock.class);
 		given(distributedLock.tryLock(any(), anyString(), anyLong(), anyLong(), anyBoolean())).willReturn(true);
 		given(provider.orderedStream()).willReturn(Stream.of(distributedLock));
@@ -57,7 +57,7 @@ class DistributedLockInterceptorTests {
 		MethodInvocation invocation = mockInvocation();
 		given(invocation.proceed()).willReturn("result");
 
-		Object result = interceptor.invoke(invocation, distLock);
+		Object result = interceptor.doInvoke(invocation, distLock);
 
 		assertThat(result).isEqualTo("result");
 		verify(invocation).proceed();
@@ -65,7 +65,7 @@ class DistributedLockInterceptorTests {
 	}
 
 	@Test
-	void invokeThrowsLockExceptionWhenLockNotAcquired() throws Throwable {
+	void doInvokeThrowsLockExceptionWhenLockNotAcquired() throws Throwable {
 		DistributedLock distributedLock = mock(DistributedLock.class);
 		given(distributedLock.tryLock(any(), anyString(), anyLong(), anyLong(), anyBoolean())).willReturn(false);
 		given(provider.orderedStream()).willReturn(Stream.of(distributedLock));
@@ -73,12 +73,12 @@ class DistributedLockInterceptorTests {
 		DistLock distLock = createDistLock();
 		MethodInvocation invocation = mockInvocation();
 
-		assertThatThrownBy(() -> interceptor.invoke(invocation, distLock)).isInstanceOf(LockException.class)
+		assertThatThrownBy(() -> interceptor.doInvoke(invocation, distLock)).isInstanceOf(LockException.class)
 			.hasMessage("Failed to acquire locks!");
 	}
 
 	@Test
-	void invokeUnlocksEvenWhenProceedThrows() throws Throwable {
+	void doInvokeUnlocksEvenWhenProceedThrows() throws Throwable {
 		DistributedLock distributedLock = mock(DistributedLock.class);
 		given(distributedLock.tryLock(any(), anyString(), anyLong(), anyLong(), anyBoolean())).willReturn(true);
 		given(provider.orderedStream()).willReturn(Stream.of(distributedLock));
@@ -87,7 +87,7 @@ class DistributedLockInterceptorTests {
 		MethodInvocation invocation = mockInvocation();
 		given(invocation.proceed()).willThrow(new RuntimeException("business error"));
 
-		assertThatThrownBy(() -> interceptor.invoke(invocation, distLock)).isInstanceOf(RuntimeException.class)
+		assertThatThrownBy(() -> interceptor.doInvoke(invocation, distLock)).isInstanceOf(RuntimeException.class)
 			.hasMessage("business error");
 		verify(distributedLock).unlock();
 	}


### PR DESCRIPTION
- 重命名 AnnotationAbstractPointcutAdvisor 为 AbstractAnnotationAdvisor，调整相关方法命名及访问权限
- 重命名 AnnotationAbstractPointcutTypeAdvisor 为 AbstractAnnotationPointcutStrategyAdvisor，修改切点策略方法实现
- 将 AnnotationPointcut 接口重命名为 AnnotationPointcutFactory，统一切点创建方法命名
- 优化 AnnotationTarget 中 ElementType 相关判断逻辑，使用 EnumSet 代替 Set
- 更新相关测试类名称及测试方法，匹配类重构后的命名
- 统一所有切面实现类 invoke 方法更名为 doInvoke，体现抽象层设计
- 调整多个拦截器（如 DataSourceInterceptor、DistributedLockInterceptor、LimitInterceptor）继承自新基类
- ShopController 修正 lua 脚本加载逻辑，优化资源路径使用 ResourceUtils
- 优化代码结构，增强接口设计的扩展性和可读性

## Summary by Sourcery

重构 AOP 注解 advisor 和 pointcut 基础设施，采用更清晰的命名和基于工厂的 pointcut 策略，同时收紧注解目标处理，并更新相关的拦截器和测试。

Enhancements:
- 将核心 AOP advisor 类重命名并整合为 `AbstractAnnotationAdvisor` 和 `AbstractAnnotationPointcutStrategyAdvisor`，并通过 `AnnotationPointcutFactory` 引入更清晰的 pointcut 工厂抽象，以策略化方式创建 pointcut。
- 改进 `AnnotationTarget` 对 `@Target` 中 `ElementType` 值的处理，通过 `EnumSet` 统一管理 `ElementType` 检查，并针对不支持的组合优化错误信息。
- 使 `DataSourceInterceptor`、`DistributedLockInterceptor` 和 `LimitInterceptor` 与新的抽象 AOP advisor 基类以及标准化的 `doInvoke` 模板方法保持一致，用于实现拦截逻辑。
- 调整 `ShopController` 的 Lua 脚本加载逻辑，依赖 Spring 的 `ResourceUtils` classpath 前缀，以实现更健壮的资源解析。

Tests:
- 重命名并更新 AOP、动态数据源、分布式锁和限流相关测试，使其与新的 advisor 和 pointcut 工厂 API 以及 `doInvoke` 方法命名保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the AOP annotation advisor and pointcut infrastructure to use clearer naming and a factory-based pointcut strategy while tightening annotation target handling and updating dependent interceptors and tests.

Enhancements:
- Rename and consolidate core AOP advisor classes into AbstractAnnotationAdvisor and AbstractAnnotationPointcutStrategyAdvisor, and introduce a clearer pointcut factory abstraction via AnnotationPointcutFactory with strategy-based pointcut creation.
- Improve AnnotationTarget handling of @Target ElementType values using EnumSet, centralizing ElementType checks and refining error messages for unsupported combinations.
- Align DataSourceInterceptor, DistributedLockInterceptor, and LimitInterceptor with the new abstract AOP advisor base classes and standardized doInvoke template method for interception logic.
- Adjust ShopController Lua script loading to rely on Spring's ResourceUtils classpath prefix for more robust resource resolution.

Tests:
- Rename and update AOP, dynamic data source, distributed lock, and rate limiting tests to reflect the new advisor and pointcut factory APIs and the doInvoke method naming.

</details>