### PR TITLE
Bump CircleCI machine image to Ubuntu 26.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ executors:
       JVM_OPTS: -Xmx3200m
       TERM: dumb
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2604:2026.07.1
       docker_layer_caching: true
-    resource_class: arm.large
+    resource_class: large.gen2
 
 commands:
   install-jdk:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     machine:
       image: ubuntu-2604:2026.07.1
       docker_layer_caching: true
-    resource_class: large.gen2
+    resource_class: arm.large.gen2
 
 commands:
   install-jdk:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     machine:
       image: ubuntu-2604:2026.07.1
       docker_layer_caching: true
-    resource_class: arm.large.gen2
+    resource_class: arm.large
 
 commands:
   install-jdk:


### PR DESCRIPTION
## Summary by Sourcery

将 CircleCI 的 machine 执行器更新为使用更新的 Ubuntu 镜像和资源类别。

CI：
- 将 CircleCI machine 镜像从 Ubuntu 24.04 升级到 Ubuntu 26.04。
- 将 CircleCI 执行器的资源类别从 arm.large 修改为 large.gen2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CircleCI machine executor to use a newer Ubuntu image and resource class.

CI:
- Bump CircleCI machine image from Ubuntu 24.04 to Ubuntu 26.04.
- Change CircleCI executor resource class from arm.large to large.gen2.

</details>